### PR TITLE
feat: feature flag system with per-tenant/per-user overrides and admin UI

### DIFF
--- a/frontend/src/api/feature-flags.functions.ts
+++ b/frontend/src/api/feature-flags.functions.ts
@@ -1,0 +1,56 @@
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '@/server/middleware'
+import { apiDelete, apiGet, apiPost } from '@/server/api'
+import {
+  adminFeatureFlagSchema,
+  featureFlagOverrideSchema,
+  featuresResponseSchema,
+  upsertFeatureFlagOverrideSchema,
+} from './feature-flags.schemas'
+import { z } from 'zod'
+
+export const fetchFeatureFlags = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    const data = await apiGet('/features', context)
+    return featuresResponseSchema.parse(data)
+  })
+
+export const fetchAdminFeatureFlags = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    const data = await apiGet('/admin/feature-flags', context)
+    return z.array(adminFeatureFlagSchema).parse(data)
+  })
+
+export const fetchFeatureFlagOverrides = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      tenantId: z.string().uuid().optional(),
+      userId: z.string().uuid().optional(),
+    }),
+  )
+  .handler(async ({ context, data }) => {
+    const params = new URLSearchParams()
+    if (data.tenantId) params.set('tenantId', data.tenantId)
+    if (data.userId) params.set('userId', data.userId)
+    const qs = params.size > 0 ? `?${params.toString()}` : ''
+    const response = await apiGet(`/admin/feature-flags/overrides${qs}`, context)
+    return z.array(featureFlagOverrideSchema).parse(response)
+  })
+
+export const upsertFeatureFlagOverride = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(upsertFeatureFlagOverrideSchema)
+  .handler(async ({ context, data }) => {
+    const response = await apiPost('/admin/feature-flags/overrides', context, data)
+    return featureFlagOverrideSchema.parse(response)
+  })
+
+export const deleteFeatureFlagOverride = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    await apiDelete(`/admin/feature-flags/overrides/${id}`, context)
+  })

--- a/frontend/src/api/feature-flags.schemas.ts
+++ b/frontend/src/api/feature-flags.schemas.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+export const featureFlagSchema = z.object({
+  displayName: z.string(),
+  stage: z.string(),
+  isEnabled: z.boolean(),
+})
+
+export const featuresResponseSchema = z.record(z.string(), featureFlagSchema)
+
+export const featureFlagOverrideSchema = z.object({
+  id: z.string().uuid(),
+  flagName: z.string(),
+  tenantId: z.string().uuid().nullable(),
+  userId: z.string().uuid().nullable(),
+  isEnabled: z.boolean(),
+  createdAt: z.string().datetime({ offset: true }),
+  expiresAt: z.string().datetime({ offset: true }).nullable(),
+})
+
+export const adminFeatureFlagSchema = z.object({
+  flagName: z.string(),
+  displayName: z.string(),
+  stage: z.string(),
+  isEnabled: z.boolean(),
+})
+
+export const upsertFeatureFlagOverrideSchema = z.object({
+  flagName: z.string(),
+  tenantId: z.string().uuid().nullable().optional(),
+  userId: z.string().uuid().nullable().optional(),
+  isEnabled: z.boolean(),
+  expiresAt: z.string().datetime({ offset: true }).nullable().optional(),
+})
+
+export type FeatureFlag = z.infer<typeof featureFlagSchema>
+export type FeaturesResponse = z.infer<typeof featuresResponseSchema>
+export type FeatureFlagOverride = z.infer<typeof featureFlagOverrideSchema>
+export type AdminFeatureFlag = z.infer<typeof adminFeatureFlagSchema>
+export type UpsertFeatureFlagOverrideInput = z.infer<typeof upsertFeatureFlagOverrideSchema>

--- a/frontend/src/components/features/roles/__tests__/RoleActivationDialog.test.tsx
+++ b/frontend/src/components/features/roles/__tests__/RoleActivationDialog.test.tsx
@@ -38,6 +38,7 @@ function makeUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
     tenantIds: ['tenant-1'],
     requiresSetup: false,
     systemStatus: null,
+    featureFlags: {},
     ...overrides,
   }
 }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -57,6 +57,7 @@ import { Route as AuthedAdminWorkflowsIdRouteImport } from './routes/_authed/adm
 import { Route as AuthedAdminTenantsIdRouteImport } from './routes/_authed/admin/tenants/$id'
 import { Route as AuthedAdminTeamsIdRouteImport } from './routes/_authed/admin/teams/$id'
 import { Route as AuthedAdminPlatformNotificationsRouteImport } from './routes/_authed/admin/platform/notifications'
+import { Route as AuthedAdminPlatformFeatureFlagsRouteImport } from './routes/_authed/admin/platform/feature-flags'
 import { Route as AuthedAdminPlatformAiRouteImport } from './routes/_authed/admin/platform/ai'
 import { Route as AuthedAdminDeviceRulesNewRouteImport } from './routes/_authed/admin/device-rules/new'
 import { Route as AuthedAdminDeviceRulesIdRouteImport } from './routes/_authed/admin/device-rules/$id'
@@ -315,6 +316,12 @@ const AuthedAdminPlatformNotificationsRoute =
     path: '/admin/platform/notifications',
     getParentRoute: () => AuthedRoute,
   } as any)
+const AuthedAdminPlatformFeatureFlagsRoute =
+  AuthedAdminPlatformFeatureFlagsRouteImport.update({
+    id: '/admin/platform/feature-flags',
+    path: '/admin/platform/feature-flags',
+    getParentRoute: () => AuthedRoute,
+  } as any)
 const AuthedAdminPlatformAiRoute = AuthedAdminPlatformAiRouteImport.update({
   id: '/admin/platform/ai',
   path: '/admin/platform/ai',
@@ -371,6 +378,7 @@ export interface FileRoutesByFullPath {
   '/admin/device-rules/$id': typeof AuthedAdminDeviceRulesIdRoute
   '/admin/device-rules/new': typeof AuthedAdminDeviceRulesNewRoute
   '/admin/platform/ai': typeof AuthedAdminPlatformAiRoute
+  '/admin/platform/feature-flags': typeof AuthedAdminPlatformFeatureFlagsRoute
   '/admin/platform/notifications': typeof AuthedAdminPlatformNotificationsRoute
   '/admin/teams/$id': typeof AuthedAdminTeamsIdRoute
   '/admin/tenants/$id': typeof AuthedAdminTenantsIdRoute
@@ -423,6 +431,7 @@ export interface FileRoutesByTo {
   '/admin/device-rules/$id': typeof AuthedAdminDeviceRulesIdRoute
   '/admin/device-rules/new': typeof AuthedAdminDeviceRulesNewRoute
   '/admin/platform/ai': typeof AuthedAdminPlatformAiRoute
+  '/admin/platform/feature-flags': typeof AuthedAdminPlatformFeatureFlagsRoute
   '/admin/platform/notifications': typeof AuthedAdminPlatformNotificationsRoute
   '/admin/teams/$id': typeof AuthedAdminTeamsIdRoute
   '/admin/tenants/$id': typeof AuthedAdminTenantsIdRoute
@@ -477,6 +486,7 @@ export interface FileRoutesById {
   '/_authed/admin/device-rules/$id': typeof AuthedAdminDeviceRulesIdRoute
   '/_authed/admin/device-rules/new': typeof AuthedAdminDeviceRulesNewRoute
   '/_authed/admin/platform/ai': typeof AuthedAdminPlatformAiRoute
+  '/_authed/admin/platform/feature-flags': typeof AuthedAdminPlatformFeatureFlagsRoute
   '/_authed/admin/platform/notifications': typeof AuthedAdminPlatformNotificationsRoute
   '/_authed/admin/teams/$id': typeof AuthedAdminTeamsIdRoute
   '/_authed/admin/tenants/$id': typeof AuthedAdminTenantsIdRoute
@@ -531,6 +541,7 @@ export interface FileRouteTypes {
     | '/admin/device-rules/$id'
     | '/admin/device-rules/new'
     | '/admin/platform/ai'
+    | '/admin/platform/feature-flags'
     | '/admin/platform/notifications'
     | '/admin/teams/$id'
     | '/admin/tenants/$id'
@@ -583,6 +594,7 @@ export interface FileRouteTypes {
     | '/admin/device-rules/$id'
     | '/admin/device-rules/new'
     | '/admin/platform/ai'
+    | '/admin/platform/feature-flags'
     | '/admin/platform/notifications'
     | '/admin/teams/$id'
     | '/admin/tenants/$id'
@@ -636,6 +648,7 @@ export interface FileRouteTypes {
     | '/_authed/admin/device-rules/$id'
     | '/_authed/admin/device-rules/new'
     | '/_authed/admin/platform/ai'
+    | '/_authed/admin/platform/feature-flags'
     | '/_authed/admin/platform/notifications'
     | '/_authed/admin/teams/$id'
     | '/_authed/admin/tenants/$id'
@@ -1001,6 +1014,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminPlatformNotificationsRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/admin/platform/feature-flags': {
+      id: '/_authed/admin/platform/feature-flags'
+      path: '/admin/platform/feature-flags'
+      fullPath: '/admin/platform/feature-flags'
+      preLoaderRoute: typeof AuthedAdminPlatformFeatureFlagsRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/admin/platform/ai': {
       id: '/_authed/admin/platform/ai'
       path: '/admin/platform/ai'
@@ -1070,6 +1090,7 @@ interface AuthedRouteChildren {
   AuthedAdminDeviceRulesIdRoute: typeof AuthedAdminDeviceRulesIdRoute
   AuthedAdminDeviceRulesNewRoute: typeof AuthedAdminDeviceRulesNewRoute
   AuthedAdminPlatformAiRoute: typeof AuthedAdminPlatformAiRoute
+  AuthedAdminPlatformFeatureFlagsRoute: typeof AuthedAdminPlatformFeatureFlagsRoute
   AuthedAdminPlatformNotificationsRoute: typeof AuthedAdminPlatformNotificationsRoute
   AuthedAdminTeamsIdRoute: typeof AuthedAdminTeamsIdRoute
   AuthedAdminTenantsIdRoute: typeof AuthedAdminTenantsIdRoute
@@ -1114,6 +1135,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAdminDeviceRulesIdRoute: AuthedAdminDeviceRulesIdRoute,
   AuthedAdminDeviceRulesNewRoute: AuthedAdminDeviceRulesNewRoute,
   AuthedAdminPlatformAiRoute: AuthedAdminPlatformAiRoute,
+  AuthedAdminPlatformFeatureFlagsRoute: AuthedAdminPlatformFeatureFlagsRoute,
   AuthedAdminPlatformNotificationsRoute: AuthedAdminPlatformNotificationsRoute,
   AuthedAdminTeamsIdRoute: AuthedAdminTeamsIdRoute,
   AuthedAdminTenantsIdRoute: AuthedAdminTenantsIdRoute,
@@ -1145,3 +1167,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/frontend/src/routes/_authed/admin/index.tsx
+++ b/frontend/src/routes/_authed/admin/index.tsx
@@ -1,5 +1,5 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
-import { Bell, Bot, Braces, Building2, ChevronRight, DatabaseZap, GitBranchPlus, Plug, ScanSearch, ShieldCheck, ShieldEllipsis, Tags, Users, Workflow, Wrench } from 'lucide-react'
+import { Bell, Bot, Braces, Building2, ChevronRight, DatabaseZap, Flag, GitBranchPlus, Plug, ScanSearch, ShieldCheck, ShieldEllipsis, Tags, Users, Workflow, Wrench } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export const Route = createFileRoute('/_authed/admin/')({
@@ -36,8 +36,10 @@ type AdminArea = {
     | '/admin/authenticated-scans'
     | '/admin/platform/ai'
     | '/admin/platform/notifications'
+    | '/admin/platform/feature-flags'
   roles: AdminRole[]
   icon: typeof Users
+  featureFlag?: string
 }
 
 type AdminSection = {
@@ -111,6 +113,7 @@ const adminSections: AdminSection[] = [
         to: '/admin/workflows',
         roles: ['GlobalAdmin', 'SecurityManager'],
         icon: Workflow,
+        featureFlag: 'Workflows',
       },
       {
         title: 'Security profiles',
@@ -173,6 +176,13 @@ const adminSections: AdminSection[] = [
         roles: ['GlobalAdmin'],
         icon: Bell,
       },
+      {
+        title: 'Feature flags',
+        description: 'Manage per-tenant and per-user feature flag overrides across the platform.',
+        to: '/admin/platform/feature-flags',
+        roles: ['GlobalAdmin'],
+        icon: Flag,
+      },
     ],
   },
 ]
@@ -184,10 +194,15 @@ function canAccess(roles: AdminRole[], activeRoles: string[]) {
 function AdminLandingPage() {
   const { user } = Route.useRouteContext()
   const activeRoles = user.activeRoles ?? []
+  const featureFlags = user.featureFlags ?? {}
   const accessibleSections = adminSections
     .map((section) => ({
       ...section,
-      areas: section.areas.filter((area) => canAccess(area.roles, activeRoles)),
+      areas: section.areas.filter((area) => {
+        if (!canAccess(area.roles, activeRoles)) return false
+        if (area.featureFlag && !featureFlags[area.featureFlag]?.isEnabled) return false
+        return true
+      }),
     }))
     .filter((section) => section.areas.length > 0)
 

--- a/frontend/src/routes/_authed/admin/platform/feature-flags.tsx
+++ b/frontend/src/routes/_authed/admin/platform/feature-flags.tsx
@@ -1,0 +1,316 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { Flag, Plus, Trash2 } from 'lucide-react'
+import {
+  deleteFeatureFlagOverride,
+  fetchAdminFeatureFlags,
+  fetchFeatureFlagOverrides,
+  upsertFeatureFlagOverride,
+} from '@/api/feature-flags.functions'
+import type { AdminFeatureFlag, FeatureFlagOverride } from '@/api/feature-flags.schemas'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { getApiErrorMessage } from '@/lib/api-errors'
+
+export const Route = createFileRoute('/_authed/admin/platform/feature-flags')({
+  beforeLoad: ({ context }) => {
+    if (!(context.user?.activeRoles ?? []).includes('GlobalAdmin')) {
+      throw redirect({ to: '/admin' })
+    }
+  },
+  component: FeatureFlagsPage,
+})
+
+function stageBadgeVariant(stage: string): 'default' | 'secondary' | 'outline' | 'destructive' {
+  switch (stage) {
+    case 'Experimental': return 'outline'
+    case 'Preview': return 'secondary'
+    case 'GenerallyAvailable': return 'default'
+    case 'Deprecated': return 'destructive'
+    default: return 'outline'
+  }
+}
+
+function stageLabel(stage: string): string {
+  switch (stage) {
+    case 'GenerallyAvailable': return 'GA'
+    default: return stage
+  }
+}
+
+type NewOverrideForm = {
+  flagName: string
+  targetType: 'tenant' | 'user'
+  targetId: string
+  isEnabled: boolean
+  expiresAt: string
+}
+
+function FeatureFlagsPage() {
+  const flagsQuery = useQuery({
+    queryKey: ['admin-feature-flags'],
+    queryFn: () => fetchAdminFeatureFlags(),
+    staleTime: 30_000,
+  })
+
+  const overridesQuery = useQuery({
+    queryKey: ['feature-flag-overrides'],
+    queryFn: () => fetchFeatureFlagOverrides({ data: {} }),
+    staleTime: 30_000,
+  })
+
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<NewOverrideForm>({
+    flagName: '',
+    targetType: 'tenant',
+    targetId: '',
+    isEnabled: true,
+    expiresAt: '',
+  })
+
+  const upsertMutation = useMutation({
+    mutationFn: async () => {
+      await upsertFeatureFlagOverride({
+        data: {
+          flagName: form.flagName,
+          tenantId: form.targetType === 'tenant' ? form.targetId : undefined,
+          userId: form.targetType === 'user' ? form.targetId : undefined,
+          isEnabled: form.isEnabled,
+          expiresAt: form.expiresAt ? form.expiresAt : undefined,
+        },
+      })
+    },
+    onSuccess: async () => {
+      toast.success('Override saved')
+      setShowForm(false)
+      setForm({ flagName: '', targetType: 'tenant', targetId: '', isEnabled: true, expiresAt: '' })
+      await Promise.all([flagsQuery.refetch(), overridesQuery.refetch()])
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, 'Failed to save override'))
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteFeatureFlagOverride({ data: { id } }),
+    onSuccess: async () => {
+      toast.success('Override removed')
+      await Promise.all([flagsQuery.refetch(), overridesQuery.refetch()])
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, 'Failed to remove override'))
+    },
+  })
+
+  const flags: AdminFeatureFlag[] = flagsQuery.data ?? []
+  const overrides: FeatureFlagOverride[] = overridesQuery.data ?? []
+
+  return (
+    <section className="space-y-5 pb-4">
+      <div className="rounded-[32px] border border-border/70 bg-[linear-gradient(135deg,color-mix(in_oklab,var(--primary)_10%,transparent),transparent_55%),var(--color-card)] p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Platform configuration</p>
+            <h1 className="text-3xl font-semibold tracking-[-0.04em]">Feature Flags</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              View the global state of all feature flags and manage per-tenant or per-user overrides.
+              Overrides take precedence over the global configuration default.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Card className="rounded-2xl border-border/70 bg-card/85">
+        <CardHeader>
+          <CardTitle>Registered flags</CardTitle>
+          <CardDescription>
+            Global resolved state for each flag — before any per-tenant or per-user overrides.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {flags.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {flagsQuery.isLoading ? 'Loading…' : 'No flags registered.'}
+            </p>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {flags.map((flag) => (
+                <div key={flag.flagName} className="flex items-center justify-between gap-3 py-3">
+                  <div className="space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <Flag className="size-4 text-primary" />
+                      <span className="font-medium">{flag.displayName}</span>
+                      <Badge variant={stageBadgeVariant(flag.stage)} className="rounded-full text-xs">
+                        {stageLabel(flag.stage)}
+                      </Badge>
+                    </div>
+                    <p className="pl-6 text-xs text-muted-foreground">{flag.flagName}</p>
+                  </div>
+                  <Badge
+                    variant={flag.isEnabled ? 'default' : 'outline'}
+                    className="rounded-full"
+                  >
+                    {flag.isEnabled ? 'Enabled' : 'Disabled'}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border-border/70 bg-card/85">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <CardTitle>Overrides</CardTitle>
+              <CardDescription>
+                Per-tenant and per-user overrides. Highest-precedence override wins at evaluation time.
+              </CardDescription>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() => setShowForm((v) => !v)}
+            >
+              <Plus className="size-4" />
+              Add override
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {showForm && (
+            <div className="rounded-2xl border border-border/70 bg-background/30 p-4 space-y-4">
+              <p className="text-sm font-medium">New override</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="space-y-1.5">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Flag</span>
+                  <select
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    value={form.flagName}
+                    onChange={(e) => setForm((f) => ({ ...f, flagName: e.target.value }))}
+                  >
+                    <option value="">Select a flag…</option>
+                    {flags.map((flag) => (
+                      <option key={flag.flagName} value={flag.flagName}>
+                        {flag.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Target type</span>
+                  <select
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    value={form.targetType}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, targetType: e.target.value as 'tenant' | 'user' }))
+                    }
+                  >
+                    <option value="tenant">Tenant</option>
+                    <option value="user">User</option>
+                  </select>
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                    {form.targetType === 'tenant' ? 'Tenant ID' : 'User ID'}
+                  </span>
+                  <input
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    type="text"
+                    placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                    value={form.targetId}
+                    onChange={(e) => setForm((f) => ({ ...f, targetId: e.target.value }))}
+                  />
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Expires at (optional)</span>
+                  <input
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    type="datetime-local"
+                    value={form.expiresAt}
+                    onChange={(e) => setForm((f) => ({ ...f, expiresAt: e.target.value }))}
+                  />
+                </label>
+              </div>
+              <label className="flex items-center gap-3 rounded-2xl border border-border/70 bg-background/20 px-4 py-3">
+                <input
+                  type="checkbox"
+                  checked={form.isEnabled}
+                  onChange={(e) => setForm((f) => ({ ...f, isEnabled: e.target.checked }))}
+                />
+                <div>
+                  <p className="text-sm font-medium">Enabled for this target</p>
+                  <p className="text-xs text-muted-foreground">
+                    Uncheck to explicitly disable the flag for this tenant or user.
+                  </p>
+                </div>
+              </label>
+              <div className="flex gap-3">
+                <Button
+                  size="sm"
+                  onClick={() => upsertMutation.mutate()}
+                  disabled={upsertMutation.isPending || !form.flagName || !form.targetId}
+                >
+                  {upsertMutation.isPending ? 'Saving…' : 'Save override'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setShowForm(false)
+                    setForm({ flagName: '', targetType: 'tenant', targetId: '', isEnabled: true, expiresAt: '' })
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {overrides.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {overridesQuery.isLoading ? 'Loading…' : 'No overrides configured.'}
+            </p>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {overrides.map((override) => (
+                <div
+                  key={override.id}
+                  className="flex items-center justify-between gap-3 py-3"
+                >
+                  <div className="space-y-0.5 text-sm">
+                    <p className="font-medium">{override.flagName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {override.tenantId ? `Tenant: ${override.tenantId}` : `User: ${override.userId}`}
+                      {override.expiresAt && ` · Expires ${new Date(override.expiresAt).toLocaleDateString()}`}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={override.isEnabled ? 'default' : 'outline'} className="rounded-full">
+                      {override.isEnabled ? 'Enabled' : 'Disabled'}
+                    </Badge>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8 text-muted-foreground hover:text-destructive"
+                      onClick={() => deleteMutation.mutate(override.id)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      <Trash2 className="size-4" />
+                      <span className="sr-only">Remove override</span>
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/frontend/src/server/auth.functions.ts
+++ b/frontend/src/server/auth.functions.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { apiGet } from '@/server/api'
 import { getSession, isTokenExpired } from '@/server/session'
 import { refreshAccessTokenSilent } from '@/server/auth'
+import type { FeaturesResponse } from '@/api/feature-flags.schemas'
 
 type SystemStatus = {
   openBaoAvailable: boolean
@@ -49,6 +50,7 @@ export const getCurrentUser = createServerFn({ method: 'GET' })
     let setupStatus: SetupStatus | null = null
     let roles = session.roles ?? []
     let tenantIds = session.tenantIds ?? (session.tenantId ? [session.tenantId] : [])
+    let featureFlags: FeaturesResponse = {}
     try {
       systemStatus = await apiGet<SystemStatus>('/system/status', {
         token: session.accessToken,
@@ -96,6 +98,15 @@ export const getCurrentUser = createServerFn({ method: 'GET' })
       tenantIds = session.tenantIds ?? (session.tenantId ? [session.tenantId] : [])
     }
 
+    try {
+      featureFlags = await apiGet<FeaturesResponse>('/features', {
+        token: session.accessToken,
+        tenantId: session.tenantId,
+      })
+    } catch {
+      featureFlags = {}
+    }
+
     return {
       id: session.userId,
       email: session.email ?? '',
@@ -106,6 +117,7 @@ export const getCurrentUser = createServerFn({ method: 'GET' })
       tenantIds,
       requiresSetup: setupStatus?.requiresSetup ?? false,
       systemStatus,
+      featureFlags,
     }
   })
 

--- a/src/PatchHound.Api/Controllers/AdminFeatureFlagsController.cs
+++ b/src/PatchHound.Api/Controllers/AdminFeatureFlagsController.cs
@@ -1,0 +1,170 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
+using PatchHound.Api.Auth;
+using PatchHound.Core.Common;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/admin/feature-flags")]
+[Authorize(Policy = Policies.ManageGlobalSettings)]
+public class AdminFeatureFlagsController : ControllerBase
+{
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly IFeatureManager _featureManager;
+
+    public AdminFeatureFlagsController(
+        PatchHoundDbContext dbContext,
+        IFeatureManager featureManager
+    )
+    {
+        _dbContext = dbContext;
+        _featureManager = featureManager;
+    }
+
+    /// <summary>GET /api/admin/feature-flags — all flags with global state + metadata.</summary>
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<AdminFeatureFlagDto>>> GetFlags(CancellationToken ct)
+    {
+        var result = new List<AdminFeatureFlagDto>();
+
+        foreach (var (key, meta) in FeatureFlags.Metadata)
+        {
+            var isEnabled = await _featureManager.IsEnabledAsync(key);
+            result.Add(new AdminFeatureFlagDto(key, meta.DisplayName, meta.Stage.ToString(), isEnabled));
+        }
+
+        return Ok(result);
+    }
+
+    /// <summary>GET /api/admin/feature-flags/overrides — all overrides, optional ?tenantId= and ?userId= filters.</summary>
+    [HttpGet("overrides")]
+    public async Task<ActionResult<IReadOnlyList<FeatureFlagOverrideDto>>> GetOverrides(
+        [FromQuery] Guid? tenantId,
+        [FromQuery] Guid? userId,
+        CancellationToken ct
+    )
+    {
+        var query = _dbContext.FeatureFlagOverrides
+            .IgnoreQueryFilters()
+            .AsNoTracking();
+
+        if (tenantId.HasValue)
+            query = query.Where(o => o.TenantId == tenantId.Value);
+
+        if (userId.HasValue)
+            query = query.Where(o => o.UserId == userId.Value);
+
+        var overrides = await query
+            .OrderBy(o => o.FlagName)
+            .ThenBy(o => o.CreatedAt)
+            .Select(o => new FeatureFlagOverrideDto(
+                o.Id,
+                o.FlagName,
+                o.TenantId,
+                o.UserId,
+                o.IsEnabled,
+                o.CreatedAt,
+                o.ExpiresAt
+            ))
+            .ToListAsync(ct);
+
+        return Ok(overrides);
+    }
+
+    /// <summary>POST /api/admin/feature-flags/overrides — create or upsert an override.</summary>
+    [HttpPost("overrides")]
+    public async Task<ActionResult<FeatureFlagOverrideDto>> CreateOrUpdateOverride(
+        [FromBody] UpsertFeatureFlagOverrideRequest request,
+        CancellationToken ct
+    )
+    {
+        if (!FeatureFlags.Metadata.ContainsKey(request.FlagName))
+            return BadRequest(new ProblemDetails { Title = $"Unknown feature flag: {request.FlagName}" });
+
+        if (request.TenantId.HasValue == request.UserId.HasValue)
+            return BadRequest(new ProblemDetails { Title = "Exactly one of TenantId or UserId must be provided." });
+
+        var now = DateTimeOffset.UtcNow;
+
+        // Check for existing override to upsert
+        FeatureFlagOverride? existing = null;
+        if (request.TenantId.HasValue)
+        {
+            existing = await _dbContext.FeatureFlagOverrides
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(o => o.FlagName == request.FlagName && o.TenantId == request.TenantId.Value, ct);
+        }
+        else if (request.UserId.HasValue)
+        {
+            existing = await _dbContext.FeatureFlagOverrides
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(o => o.FlagName == request.FlagName && o.UserId == request.UserId.Value, ct);
+        }
+
+        if (existing is not null)
+        {
+            existing.Update(request.IsEnabled, request.ExpiresAt);
+        }
+        else
+        {
+            existing = request.TenantId.HasValue
+                ? FeatureFlagOverride.CreateTenantOverride(request.FlagName, request.TenantId.Value, request.IsEnabled, request.ExpiresAt)
+                : FeatureFlagOverride.CreateUserOverride(request.FlagName, request.UserId!.Value, request.IsEnabled, request.ExpiresAt);
+
+            await _dbContext.FeatureFlagOverrides.AddAsync(existing, ct);
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        return Ok(new FeatureFlagOverrideDto(
+            existing.Id,
+            existing.FlagName,
+            existing.TenantId,
+            existing.UserId,
+            existing.IsEnabled,
+            existing.CreatedAt,
+            existing.ExpiresAt
+        ));
+    }
+
+    /// <summary>DELETE /api/admin/feature-flags/overrides/{id} — delete an override.</summary>
+    [HttpDelete("overrides/{id:guid}")]
+    public async Task<IActionResult> DeleteOverride(Guid id, CancellationToken ct)
+    {
+        var existing = await _dbContext.FeatureFlagOverrides
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(o => o.Id == id, ct);
+
+        if (existing is null)
+            return NotFound(new ProblemDetails { Title = "Override not found." });
+
+        _dbContext.FeatureFlagOverrides.Remove(existing);
+        await _dbContext.SaveChangesAsync(ct);
+        return NoContent();
+    }
+}
+
+public record AdminFeatureFlagDto(string FlagName, string DisplayName, string Stage, bool IsEnabled);
+
+public record FeatureFlagOverrideDto(
+    Guid Id,
+    string FlagName,
+    Guid? TenantId,
+    Guid? UserId,
+    bool IsEnabled,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ExpiresAt
+);
+
+public record UpsertFeatureFlagOverrideRequest(
+    string FlagName,
+    Guid? TenantId,
+    Guid? UserId,
+    bool IsEnabled,
+    DateTimeOffset? ExpiresAt
+);

--- a/src/PatchHound.Api/Controllers/FeaturesController.cs
+++ b/src/PatchHound.Api/Controllers/FeaturesController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement;
+using PatchHound.Core.Common;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/features")]
+[Authorize]
+public class FeaturesController : ControllerBase
+{
+    private readonly IFeatureManager _featureManager;
+
+    public FeaturesController(IFeatureManager featureManager)
+    {
+        _featureManager = featureManager;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<Dictionary<string, FeatureFlagResponseDto>>> GetFeatures(
+        CancellationToken ct
+    )
+    {
+        var result = new Dictionary<string, FeatureFlagResponseDto>();
+
+        foreach (var (key, meta) in FeatureFlags.Metadata)
+        {
+            var isEnabled = await _featureManager.IsEnabledAsync(key);
+            result[key] = new FeatureFlagResponseDto(meta.DisplayName, meta.Stage.ToString(), isEnabled);
+        }
+
+        return Ok(result);
+    }
+}
+
+public record FeatureFlagResponseDto(string DisplayName, string Stage, bool IsEnabled);

--- a/src/PatchHound.Api/PatchHound.Api.csproj
+++ b/src/PatchHound.Api/PatchHound.Api.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>

--- a/src/PatchHound.Api/Program.cs
+++ b/src/PatchHound.Api/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 using Microsoft.Identity.Web;
 using Microsoft.IdentityModel.Logging;
 using Npgsql;
@@ -467,6 +468,12 @@ if (!string.IsNullOrWhiteSpace(frontendOrigin))
 // OpenAPI
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
+
+// Feature management (database-backed overrides + config defaults)
+// Register the custom provider as IFeatureDefinitionProvider — FeatureManager resolves it via DI.
+builder.Services.AddScoped<Microsoft.FeatureManagement.IFeatureDefinitionProvider,
+    PatchHound.Infrastructure.FeatureFlags.DatabaseFeatureDefinitionProvider>();
+builder.Services.AddFeatureManagement(builder.Configuration.GetSection("FeatureManagement"));
 
 var app = builder.Build();
 

--- a/src/PatchHound.Api/appsettings.json
+++ b/src/PatchHound.Api/appsettings.json
@@ -24,5 +24,9 @@
   },
   "Frontend": {
     "Origin": "http://localhost:5173"
+  },
+  "FeatureManagement": {
+    "Workflows": true,
+    "AuthenticatedScans": true
   }
 }

--- a/src/PatchHound.Core/Common/FeatureFlags.cs
+++ b/src/PatchHound.Core/Common/FeatureFlags.cs
@@ -1,0 +1,18 @@
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Common;
+
+public record FeatureFlagMeta(string DisplayName, FeatureFlagStage Stage);
+
+public static class FeatureFlags
+{
+    public const string Workflows = "Workflows";
+    public const string AuthenticatedScans = "AuthenticatedScans";
+
+    public static readonly IReadOnlyDictionary<string, FeatureFlagMeta> Metadata =
+        new Dictionary<string, FeatureFlagMeta>
+        {
+            [Workflows] = new("Workflow engine", FeatureFlagStage.GenerallyAvailable),
+            [AuthenticatedScans] = new("Authenticated scanning", FeatureFlagStage.GenerallyAvailable),
+        };
+}

--- a/src/PatchHound.Core/Entities/FeatureFlagOverride.cs
+++ b/src/PatchHound.Core/Entities/FeatureFlagOverride.cs
@@ -1,0 +1,62 @@
+namespace PatchHound.Core.Entities;
+
+public class FeatureFlagOverride
+{
+    public Guid Id { get; private set; }
+    public string FlagName { get; private set; } = null!;
+    public Guid? TenantId { get; private set; }
+    public Guid? UserId { get; private set; }
+    public bool IsEnabled { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset? ExpiresAt { get; private set; }
+
+    // Navigation properties
+    public Tenant? Tenant { get; private set; }
+    public User? User { get; private set; }
+
+    private FeatureFlagOverride() { }
+
+    public static FeatureFlagOverride CreateTenantOverride(
+        string flagName,
+        Guid tenantId,
+        bool isEnabled,
+        DateTimeOffset? expiresAt = null
+    )
+    {
+        return new FeatureFlagOverride
+        {
+            Id = Guid.NewGuid(),
+            FlagName = flagName,
+            TenantId = tenantId,
+            UserId = null,
+            IsEnabled = isEnabled,
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = expiresAt,
+        };
+    }
+
+    public static FeatureFlagOverride CreateUserOverride(
+        string flagName,
+        Guid userId,
+        bool isEnabled,
+        DateTimeOffset? expiresAt = null
+    )
+    {
+        return new FeatureFlagOverride
+        {
+            Id = Guid.NewGuid(),
+            FlagName = flagName,
+            TenantId = null,
+            UserId = userId,
+            IsEnabled = isEnabled,
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = expiresAt,
+        };
+    }
+
+    public void Update(bool isEnabled, DateTimeOffset? expiresAt)
+    {
+        IsEnabled = isEnabled;
+        ExpiresAt = expiresAt;
+    }
+}

--- a/src/PatchHound.Core/Enums/FeatureFlagStage.cs
+++ b/src/PatchHound.Core/Enums/FeatureFlagStage.cs
@@ -1,0 +1,9 @@
+namespace PatchHound.Core.Enums;
+
+public enum FeatureFlagStage
+{
+    Experimental,
+    Preview,
+    GenerallyAvailable,
+    Deprecated,
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/FeatureFlagOverrideConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/FeatureFlagOverrideConfiguration.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class FeatureFlagOverrideConfiguration : IEntityTypeConfiguration<FeatureFlagOverride>
+{
+    public void Configure(EntityTypeBuilder<FeatureFlagOverride> builder)
+    {
+        builder.HasKey(f => f.Id);
+
+        builder.Property(f => f.FlagName).HasMaxLength(256).IsRequired();
+        builder.Property(f => f.TenantId).IsRequired(false);
+        builder.Property(f => f.UserId).IsRequired(false);
+        builder.Property(f => f.IsEnabled).IsRequired();
+        builder.Property(f => f.CreatedAt).IsRequired();
+        builder.Property(f => f.ExpiresAt).IsRequired(false);
+
+        builder.HasIndex(f => new { f.FlagName, f.TenantId });
+        builder.HasIndex(f => new { f.FlagName, f.UserId });
+
+        // Exactly one of TenantId/UserId must be non-null
+        builder.ToTable(
+            "FeatureFlagOverrides",
+            t => t.HasCheckConstraint(
+                "CK_FeatureFlagOverrides_OneTarget",
+                "(\"TenantId\" IS NOT NULL AND \"UserId\" IS NULL) OR (\"TenantId\" IS NULL AND \"UserId\" IS NOT NULL)"
+            )
+        );
+
+        builder
+            .HasOne(f => f.Tenant)
+            .WithMany()
+            .HasForeignKey(f => f.TenantId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder
+            .HasOne(f => f.User)
+            .WithMany()
+            .HasForeignKey(f => f.UserId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Migrations/20260414035605_AddFeatureFlagOverrides.Designer.cs
+++ b/src/PatchHound.Infrastructure/Data/Migrations/20260414035605_AddFeatureFlagOverrides.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414035605_AddFeatureFlagOverrides")]
+    partial class AddFeatureFlagOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Data/Migrations/20260414035605_AddFeatureFlagOverrides.cs
+++ b/src/PatchHound.Infrastructure/Data/Migrations/20260414035605_AddFeatureFlagOverrides.cs
@@ -1,0 +1,1523 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeatureFlagOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AIReports_TenantVulnerabilities_TenantVulnerabilityId",
+                table: "AIReports");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrganizationalSeverities_TenantVulnerabilities_TenantVulner~",
+                table: "OrganizationalSeverities");
+
+            migrationBuilder.DropTable(
+                name: "AssetScanProfileAssignments");
+
+            migrationBuilder.DropTable(
+                name: "NormalizedSoftwareVulnerabilityProjections");
+
+            migrationBuilder.DropTable(
+                name: "SoftwareVulnerabilityMatches");
+
+            migrationBuilder.DropTable(
+                name: "StagedAuthenticatedScanSoftware");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityAssetAssessments");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityAssets");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityDefinitionAffectedSoftware");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityDefinitionReferences");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityEpisodeRiskAssessments");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityThreatAssessments");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityAssetEpisodes");
+
+            migrationBuilder.DropTable(
+                name: "TenantVulnerabilities");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityDefinitions");
+
+            migrationBuilder.RenameColumn(
+                name: "AssetId",
+                table: "ScanJobs",
+                newName: "DeviceId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantVulnerabilityId",
+                table: "OrganizationalSeverities",
+                newName: "VulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_OrganizationalSeverities_TenantVulnerabilityId",
+                table: "OrganizationalSeverities",
+                newName: "IX_OrganizationalSeverities_VulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_OrganizationalSeverities_TenantId_TenantVulnerabilityId",
+                table: "OrganizationalSeverities",
+                newName: "IX_OrganizationalSeverities_TenantId_VulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantVulnerabilityId",
+                table: "AIReports",
+                newName: "VulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_AIReports_TenantVulnerabilityId",
+                table: "AIReports",
+                newName: "IX_AIReports_VulnerabilityId");
+
+            migrationBuilder.CreateTable(
+                name: "DeviceRules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    Priority = table.Column<int>(type: "integer", nullable: false),
+                    Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    FilterDefinition = table.Column<string>(type: "text", nullable: false),
+                    Operations = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastExecutedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastMatchCount = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceRules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DeviceScanProfileAssignments",
+                columns: table => new
+                {
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScanProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssignedByRuleId = table.Column<Guid>(type: "uuid", nullable: true),
+                    AssignedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceScanProfileAssignments", x => new { x.DeviceId, x.ScanProfileId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FeatureFlagOverrides",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FlagName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FeatureFlagOverrides", x => x.Id);
+                    table.CheckConstraint("CK_FeatureFlagOverrides_OneTarget", "(\"TenantId\" IS NOT NULL AND \"UserId\" IS NULL) OR (\"TenantId\" IS NULL AND \"UserId\" IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "FK_FeatureFlagOverrides_Tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "Tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_FeatureFlagOverrides_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SecurityProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    EnvironmentClass = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    InternetReachability = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ConfidentialityRequirement = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    IntegrityRequirement = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    AvailabilityRequirement = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedAttackVector = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedAttackComplexity = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedPrivilegesRequired = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedUserInteraction = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedScope = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedConfidentialityImpact = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedIntegrityImpact = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ModifiedAvailabilityImpact = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SecurityProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SoftwareProducts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CanonicalProductKey = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Vendor = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Name = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    PrimaryCpe23Uri = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    EndOfLifeAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SoftwareProducts", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SourceSystems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SourceSystems", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StagedDetectedSoftware",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScanJobId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScanProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CanonicalName = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    CanonicalProductKey = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    CanonicalVendor = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Category = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    PrimaryCpe23Uri = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    DetectedVersion = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    StagedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StagedDetectedSoftware", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Vulnerabilities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Source = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ExternalId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Title = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    VendorSeverity = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CvssScore = table.Column<decimal>(type: "numeric(4,2)", nullable: true),
+                    CvssVector = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    PublishedDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Vulnerabilities", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TenantSoftwareProductInsights",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Description = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: true),
+                    SupplyChainEvidenceJson = table.Column<string>(type: "text", nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenantSoftwareProductInsights", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TenantSoftwareProductInsights_SoftwareProducts_SoftwareProd~",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Devices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceSystemId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ExternalId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    BaselineCriticality = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Criticality = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CriticalitySource = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    CriticalityReason = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    CriticalityRuleId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CriticalityUpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    OwnerType = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    OwnerUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OwnerTeamId = table.Column<Guid>(type: "uuid", nullable: true),
+                    FallbackTeamId = table.Column<Guid>(type: "uuid", nullable: true),
+                    FallbackTeamRuleId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SecurityProfileId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SecurityProfileRuleId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ComputerDnsName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    HealthStatus = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    OsPlatform = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    OsVersion = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    ExternalRiskLabel = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastIpAddress = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    AadDeviceId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    GroupId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    GroupName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ExposureLevel = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    IsAadJoined = table.Column<bool>(type: "boolean", nullable: true),
+                    OnboardingStatus = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    DeviceValue = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ExposureImpactScore = table.Column<decimal>(type: "numeric", nullable: true),
+                    ActiveInTenant = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    Metadata = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Devices", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Devices_SourceSystems_SourceSystemId",
+                        column: x => x.SourceSystemId,
+                        principalTable: "SourceSystems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SoftwareAliases",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceSystemId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ExternalId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ObservedVendor = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ObservedName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SoftwareAliases", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SoftwareAliases_SoftwareProducts_SoftwareProductId",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SoftwareAliases_SourceSystems_SourceSystemId",
+                        column: x => x.SourceSystemId,
+                        principalTable: "SourceSystems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ThreatAssessments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ThreatScore = table.Column<decimal>(type: "numeric(4,2)", nullable: false),
+                    TechnicalScore = table.Column<decimal>(type: "numeric(4,2)", nullable: false),
+                    ExploitLikelihoodScore = table.Column<decimal>(type: "numeric(4,3)", nullable: false),
+                    ThreatActivityScore = table.Column<decimal>(type: "numeric(4,2)", nullable: false),
+                    EpssScore = table.Column<decimal>(type: "numeric(5,4)", nullable: true),
+                    KnownExploited = table.Column<bool>(type: "boolean", nullable: false),
+                    PublicExploit = table.Column<bool>(type: "boolean", nullable: false),
+                    ActiveAlert = table.Column<bool>(type: "boolean", nullable: false),
+                    HasRansomwareAssociation = table.Column<bool>(type: "boolean", nullable: false),
+                    HasMalwareAssociation = table.Column<bool>(type: "boolean", nullable: false),
+                    DefenderLastRefreshedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    FactorsJson = table.Column<string>(type: "text", nullable: false),
+                    CalculationVersion = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ThreatAssessments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ThreatAssessments_Vulnerabilities_VulnerabilityId",
+                        column: x => x.VulnerabilityId,
+                        principalTable: "Vulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityApplicabilities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CpeCriteria = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Vulnerable = table.Column<bool>(type: "boolean", nullable: false),
+                    VersionStartIncluding = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    VersionStartExcluding = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    VersionEndIncluding = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    VersionEndExcluding = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityApplicabilities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityApplicabilities_SoftwareProducts_SoftwareProdu~",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityApplicabilities_Vulnerabilities_VulnerabilityId",
+                        column: x => x.VulnerabilityId,
+                        principalTable: "Vulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityReferences",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Url = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    Source = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Tags = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityReferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityReferences_Vulnerabilities_VulnerabilityId",
+                        column: x => x.VulnerabilityId,
+                        principalTable: "Vulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DeviceBusinessLabels",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    BusinessLabelId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceType = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    SourceKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    AssignedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    AssignedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    AssignedByRuleId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceBusinessLabels", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DeviceBusinessLabels_BusinessLabels_BusinessLabelId",
+                        column: x => x.BusinessLabelId,
+                        principalTable: "BusinessLabels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_DeviceBusinessLabels_Devices_DeviceId",
+                        column: x => x.DeviceId,
+                        principalTable: "Devices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DeviceRiskScores",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OverallScore = table.Column<decimal>(type: "numeric(7,2)", precision: 7, scale: 2, nullable: false),
+                    MaxEpisodeRiskScore = table.Column<decimal>(type: "numeric(7,2)", precision: 7, scale: 2, nullable: false),
+                    CriticalCount = table.Column<int>(type: "integer", nullable: false),
+                    HighCount = table.Column<int>(type: "integer", nullable: false),
+                    MediumCount = table.Column<int>(type: "integer", nullable: false),
+                    LowCount = table.Column<int>(type: "integer", nullable: false),
+                    OpenEpisodeCount = table.Column<int>(type: "integer", nullable: false),
+                    FactorsJson = table.Column<string>(type: "text", nullable: false),
+                    CalculationVersion = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceRiskScores", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DeviceRiskScores_Devices_DeviceId",
+                        column: x => x.DeviceId,
+                        principalTable: "Devices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DeviceTags",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Value = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceTags", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DeviceTags_Devices_DeviceId",
+                        column: x => x.DeviceId,
+                        principalTable: "Devices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InstalledSoftware",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceSystemId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Version = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    FirstSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InstalledSoftware", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InstalledSoftware_Devices_DeviceId",
+                        column: x => x.DeviceId,
+                        principalTable: "Devices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_InstalledSoftware_SoftwareProducts_SoftwareProductId",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_InstalledSoftware_SourceSystems_SourceSystemId",
+                        column: x => x.SourceSystemId,
+                        principalTable: "SourceSystems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceBusinessLabels_AssignedByRuleId",
+                table: "DeviceBusinessLabels",
+                column: "AssignedByRuleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceBusinessLabels_BusinessLabelId",
+                table: "DeviceBusinessLabels",
+                column: "BusinessLabelId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceBusinessLabels_DeviceId_BusinessLabelId_SourceKey",
+                table: "DeviceBusinessLabels",
+                columns: new[] { "DeviceId", "BusinessLabelId", "SourceKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceBusinessLabels_TenantId",
+                table: "DeviceBusinessLabels",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceRiskScores_DeviceId",
+                table: "DeviceRiskScores",
+                column: "DeviceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceRiskScores_TenantId",
+                table: "DeviceRiskScores",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceRiskScores_TenantId_DeviceId",
+                table: "DeviceRiskScores",
+                columns: new[] { "TenantId", "DeviceId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceRules_TenantId",
+                table: "DeviceRules",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceRules_TenantId_Priority",
+                table: "DeviceRules",
+                columns: new[] { "TenantId", "Priority" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_SecurityProfileId",
+                table: "Devices",
+                column: "SecurityProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_SourceSystemId",
+                table: "Devices",
+                column: "SourceSystemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_TenantId",
+                table: "Devices",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_TenantId_ActiveInTenant",
+                table: "Devices",
+                columns: new[] { "TenantId", "ActiveInTenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_TenantId_SourceSystemId_ExternalId",
+                table: "Devices",
+                columns: new[] { "TenantId", "SourceSystemId", "ExternalId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceScanProfileAssignments_TenantId_ScanProfileId",
+                table: "DeviceScanProfileAssignments",
+                columns: new[] { "TenantId", "ScanProfileId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceTags_DeviceId_Key",
+                table: "DeviceTags",
+                columns: new[] { "DeviceId", "Key" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceTags_TenantId",
+                table: "DeviceTags",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceTags_TenantId_Key",
+                table: "DeviceTags",
+                columns: new[] { "TenantId", "Key" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FeatureFlagOverrides_FlagName_TenantId",
+                table: "FeatureFlagOverrides",
+                columns: new[] { "FlagName", "TenantId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FeatureFlagOverrides_FlagName_UserId",
+                table: "FeatureFlagOverrides",
+                columns: new[] { "FlagName", "UserId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FeatureFlagOverrides_TenantId",
+                table: "FeatureFlagOverrides",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FeatureFlagOverrides_UserId",
+                table: "FeatureFlagOverrides",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstalledSoftware_DeviceId",
+                table: "InstalledSoftware",
+                column: "DeviceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstalledSoftware_SoftwareProductId",
+                table: "InstalledSoftware",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstalledSoftware_SourceSystemId",
+                table: "InstalledSoftware",
+                column: "SourceSystemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstalledSoftware_TenantId",
+                table: "InstalledSoftware",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstalledSoftware_TenantId_DeviceId_SoftwareProductId_Sourc~",
+                table: "InstalledSoftware",
+                columns: new[] { "TenantId", "DeviceId", "SoftwareProductId", "SourceSystemId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstalledSoftware_TenantId_SoftwareProductId",
+                table: "InstalledSoftware",
+                columns: new[] { "TenantId", "SoftwareProductId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecurityProfiles_TenantId",
+                table: "SecurityProfiles",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecurityProfiles_TenantId_Name",
+                table: "SecurityProfiles",
+                columns: new[] { "TenantId", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareAliases_SoftwareProductId",
+                table: "SoftwareAliases",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareAliases_SourceSystemId_ExternalId",
+                table: "SoftwareAliases",
+                columns: new[] { "SourceSystemId", "ExternalId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareProducts_CanonicalProductKey",
+                table: "SoftwareProducts",
+                column: "CanonicalProductKey",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SourceSystems_Key",
+                table: "SourceSystems",
+                column: "Key",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StagedDetectedSoftware_ScanJobId",
+                table: "StagedDetectedSoftware",
+                column: "ScanJobId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantSoftwareProductInsights_SoftwareProductId",
+                table: "TenantSoftwareProductInsights",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantSoftwareProductInsights_TenantId_SoftwareProductId",
+                table: "TenantSoftwareProductInsights",
+                columns: new[] { "TenantId", "SoftwareProductId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ThreatAssessments_VulnerabilityId",
+                table: "ThreatAssessments",
+                column: "VulnerabilityId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Vulnerabilities_ExternalId",
+                table: "Vulnerabilities",
+                column: "ExternalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Vulnerabilities_Source_ExternalId",
+                table: "Vulnerabilities",
+                columns: new[] { "Source", "ExternalId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityApplicabilities_SoftwareProductId",
+                table: "VulnerabilityApplicabilities",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityApplicabilities_VulnerabilityId_CpeCriteria",
+                table: "VulnerabilityApplicabilities",
+                columns: new[] { "VulnerabilityId", "CpeCriteria" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityApplicabilities_VulnerabilityId_SoftwareProduc~",
+                table: "VulnerabilityApplicabilities",
+                columns: new[] { "VulnerabilityId", "SoftwareProductId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityReferences_VulnerabilityId_Url",
+                table: "VulnerabilityReferences",
+                columns: new[] { "VulnerabilityId", "Url" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AIReports_Vulnerabilities_VulnerabilityId",
+                table: "AIReports",
+                column: "VulnerabilityId",
+                principalTable: "Vulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationalSeverities_Vulnerabilities_VulnerabilityId",
+                table: "OrganizationalSeverities",
+                column: "VulnerabilityId",
+                principalTable: "Vulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AIReports_Vulnerabilities_VulnerabilityId",
+                table: "AIReports");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrganizationalSeverities_Vulnerabilities_VulnerabilityId",
+                table: "OrganizationalSeverities");
+
+            migrationBuilder.DropTable(
+                name: "DeviceBusinessLabels");
+
+            migrationBuilder.DropTable(
+                name: "DeviceRiskScores");
+
+            migrationBuilder.DropTable(
+                name: "DeviceRules");
+
+            migrationBuilder.DropTable(
+                name: "DeviceScanProfileAssignments");
+
+            migrationBuilder.DropTable(
+                name: "DeviceTags");
+
+            migrationBuilder.DropTable(
+                name: "FeatureFlagOverrides");
+
+            migrationBuilder.DropTable(
+                name: "InstalledSoftware");
+
+            migrationBuilder.DropTable(
+                name: "SecurityProfiles");
+
+            migrationBuilder.DropTable(
+                name: "SoftwareAliases");
+
+            migrationBuilder.DropTable(
+                name: "StagedDetectedSoftware");
+
+            migrationBuilder.DropTable(
+                name: "TenantSoftwareProductInsights");
+
+            migrationBuilder.DropTable(
+                name: "ThreatAssessments");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityApplicabilities");
+
+            migrationBuilder.DropTable(
+                name: "VulnerabilityReferences");
+
+            migrationBuilder.DropTable(
+                name: "Devices");
+
+            migrationBuilder.DropTable(
+                name: "SoftwareProducts");
+
+            migrationBuilder.DropTable(
+                name: "Vulnerabilities");
+
+            migrationBuilder.DropTable(
+                name: "SourceSystems");
+
+            migrationBuilder.RenameColumn(
+                name: "DeviceId",
+                table: "ScanJobs",
+                newName: "AssetId");
+
+            migrationBuilder.RenameColumn(
+                name: "VulnerabilityId",
+                table: "OrganizationalSeverities",
+                newName: "TenantVulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_OrganizationalSeverities_VulnerabilityId",
+                table: "OrganizationalSeverities",
+                newName: "IX_OrganizationalSeverities_TenantVulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_OrganizationalSeverities_TenantId_VulnerabilityId",
+                table: "OrganizationalSeverities",
+                newName: "IX_OrganizationalSeverities_TenantId_TenantVulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "VulnerabilityId",
+                table: "AIReports",
+                newName: "TenantVulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_AIReports_VulnerabilityId",
+                table: "AIReports",
+                newName: "IX_AIReports_TenantVulnerabilityId");
+
+            migrationBuilder.CreateTable(
+                name: "AssetScanProfileAssignments",
+                columns: table => new
+                {
+                    AssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScanProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssignedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    AssignedByRuleId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AssetScanProfileAssignments", x => new { x.AssetId, x.ScanProfileId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StagedAuthenticatedScanSoftware",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CanonicalName = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    CanonicalProductKey = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    CanonicalVendor = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Category = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    DetectedVersion = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    DeviceAssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PrimaryCpe23Uri = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    ScanJobId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScanProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StagedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StagedAuthenticatedScanSoftware", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityDefinitions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CvssScore = table.Column<decimal>(type: "numeric", nullable: true),
+                    CvssVector = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    ExternalId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ProductName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ProductVendor = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ProductVersion = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    PublishedDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Source = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Title = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    VendorSeverity = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityDefinitions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NormalizedSoftwareVulnerabilityProjections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantSoftwareId = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AffectedDeviceCount = table.Column<int>(type: "integer", nullable: false),
+                    AffectedInstallCount = table.Column<int>(type: "integer", nullable: false),
+                    AffectedVersionCount = table.Column<int>(type: "integer", nullable: false),
+                    BestConfidence = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    BestMatchMethod = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    EvidenceJson = table.Column<string>(type: "text", nullable: false),
+                    FirstSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ResolvedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    SnapshotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NormalizedSoftwareVulnerabilityProjections", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NormalizedSoftwareVulnerabilityProjections_TenantSoftware_T~",
+                        column: x => x.TenantSoftwareId,
+                        principalTable: "TenantSoftware",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NormalizedSoftwareVulnerabilityProjections_VulnerabilityDef~",
+                        column: x => x.VulnerabilityDefinitionId,
+                        principalTable: "VulnerabilityDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SoftwareVulnerabilityMatches",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareAssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Confidence = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Evidence = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: false),
+                    FirstSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    MatchMethod = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ResolvedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    SnapshotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SoftwareVulnerabilityMatches", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SoftwareVulnerabilityMatches_Assets_SoftwareAssetId",
+                        column: x => x.SoftwareAssetId,
+                        principalTable: "Assets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SoftwareVulnerabilityMatches_VulnerabilityDefinitions_Vulne~",
+                        column: x => x.VulnerabilityDefinitionId,
+                        principalTable: "VulnerabilityDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TenantVulnerabilities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    SourceKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenantVulnerabilities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TenantVulnerabilities_VulnerabilityDefinitions_Vulnerabilit~",
+                        column: x => x.VulnerabilityDefinitionId,
+                        principalTable: "VulnerabilityDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityDefinitionAffectedSoftware",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Criteria = table.Column<string>(type: "text", nullable: false),
+                    VersionEndExcluding = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    VersionEndIncluding = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    VersionStartExcluding = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    VersionStartIncluding = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Vulnerable = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityDefinitionAffectedSoftware", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityDefinitionAffectedSoftware_VulnerabilityDefini~",
+                        column: x => x.VulnerabilityDefinitionId,
+                        principalTable: "VulnerabilityDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityDefinitionReferences",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Source = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Tags = table.Column<string>(type: "text", nullable: false),
+                    Url = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityDefinitionReferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityDefinitionReferences_VulnerabilityDefinitions_~",
+                        column: x => x.VulnerabilityDefinitionId,
+                        principalTable: "VulnerabilityDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityThreatAssessments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ActiveAlert = table.Column<bool>(type: "boolean", nullable: false),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CalculationVersion = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    DefenderLastRefreshedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    EpssScore = table.Column<decimal>(type: "numeric(5,4)", precision: 5, scale: 4, nullable: true),
+                    ExploitLikelihoodScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    FactorsJson = table.Column<string>(type: "text", nullable: false),
+                    HasMalwareAssociation = table.Column<bool>(type: "boolean", nullable: false),
+                    HasRansomwareAssociation = table.Column<bool>(type: "boolean", nullable: false),
+                    KnownExploited = table.Column<bool>(type: "boolean", nullable: false),
+                    PublicExploit = table.Column<bool>(type: "boolean", nullable: false),
+                    TechnicalScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    ThreatActivityScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    ThreatScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityThreatAssessments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityThreatAssessments_VulnerabilityDefinitions_Vul~",
+                        column: x => x.VulnerabilityDefinitionId,
+                        principalTable: "VulnerabilityDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityAssetAssessments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssetSecurityProfileId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantVulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    BaseScore = table.Column<decimal>(type: "numeric", nullable: true),
+                    BaseSeverity = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    BaseVector = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CalculationVersion = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    EffectiveScore = table.Column<decimal>(type: "numeric", nullable: true),
+                    EffectiveSeverity = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    EffectiveVector = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    FactorsJson = table.Column<string>(type: "text", nullable: false),
+                    ReasonSummary = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: false),
+                    SnapshotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityAssetAssessments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssetAssessments_AssetSecurityProfiles_AssetSe~",
+                        column: x => x.AssetSecurityProfileId,
+                        principalTable: "AssetSecurityProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssetAssessments_Assets_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Assets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssetAssessments_TenantVulnerabilities_TenantV~",
+                        column: x => x.TenantVulnerabilityId,
+                        principalTable: "TenantVulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityAssetEpisodes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantVulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EpisodeNumber = table.Column<int>(type: "integer", nullable: false),
+                    FirstSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    MissingSyncCount = table.Column<int>(type: "integer", nullable: false),
+                    ResolvedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityAssetEpisodes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssetEpisodes_Assets_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Assets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssetEpisodes_TenantVulnerabilities_TenantVuln~",
+                        column: x => x.TenantVulnerabilityId,
+                        principalTable: "TenantVulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityAssets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantVulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DetectedDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ProductName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ProductVendor = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ProductVersion = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ResolvedDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    SnapshotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityAssets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssets_Assets_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Assets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityAssets_TenantVulnerabilities_TenantVulnerabili~",
+                        column: x => x.TenantVulnerabilityId,
+                        principalTable: "TenantVulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VulnerabilityEpisodeRiskAssessments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantVulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityAssetEpisodeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CalculationVersion = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ContextScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    EpisodeRiskScore = table.Column<decimal>(type: "numeric(7,2)", precision: 7, scale: 2, nullable: false),
+                    FactorsJson = table.Column<string>(type: "text", nullable: false),
+                    OperationalScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    ResolvedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    RiskBand = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    SnapshotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ThreatScore = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VulnerabilityEpisodeRiskAssessments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityEpisodeRiskAssessments_Assets_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Assets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityEpisodeRiskAssessments_TenantVulnerabilities_T~",
+                        column: x => x.TenantVulnerabilityId,
+                        principalTable: "TenantVulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VulnerabilityEpisodeRiskAssessments_VulnerabilityAssetEpiso~",
+                        column: x => x.VulnerabilityAssetEpisodeId,
+                        principalTable: "VulnerabilityAssetEpisodes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssetScanProfileAssignments_TenantId_ScanProfileId",
+                table: "AssetScanProfileAssignments",
+                columns: new[] { "TenantId", "ScanProfileId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NormalizedSoftwareVulnerabilityProjections_SnapshotId",
+                table: "NormalizedSoftwareVulnerabilityProjections",
+                column: "SnapshotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NormalizedSoftwareVulnerabilityProjections_TenantId",
+                table: "NormalizedSoftwareVulnerabilityProjections",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NormalizedSoftwareVulnerabilityProjections_TenantId_Snapsho~",
+                table: "NormalizedSoftwareVulnerabilityProjections",
+                columns: new[] { "TenantId", "SnapshotId", "TenantSoftwareId", "VulnerabilityDefinitionId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NormalizedSoftwareVulnerabilityProjections_TenantSoftwareId",
+                table: "NormalizedSoftwareVulnerabilityProjections",
+                column: "TenantSoftwareId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NormalizedSoftwareVulnerabilityProjections_VulnerabilityDef~",
+                table: "NormalizedSoftwareVulnerabilityProjections",
+                column: "VulnerabilityDefinitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareVulnerabilityMatches_SnapshotId",
+                table: "SoftwareVulnerabilityMatches",
+                column: "SnapshotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareVulnerabilityMatches_SoftwareAssetId",
+                table: "SoftwareVulnerabilityMatches",
+                column: "SoftwareAssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareVulnerabilityMatches_TenantId",
+                table: "SoftwareVulnerabilityMatches",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareVulnerabilityMatches_TenantId_SnapshotId_SoftwareAs~",
+                table: "SoftwareVulnerabilityMatches",
+                columns: new[] { "TenantId", "SnapshotId", "SoftwareAssetId", "VulnerabilityDefinitionId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareVulnerabilityMatches_VulnerabilityDefinitionId",
+                table: "SoftwareVulnerabilityMatches",
+                column: "VulnerabilityDefinitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StagedAuthenticatedScanSoftware_ScanJobId",
+                table: "StagedAuthenticatedScanSoftware",
+                column: "ScanJobId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantVulnerabilities_TenantId",
+                table: "TenantVulnerabilities",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantVulnerabilities_TenantId_SourceKey_Status",
+                table: "TenantVulnerabilities",
+                columns: new[] { "TenantId", "SourceKey", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantVulnerabilities_TenantId_VulnerabilityDefinitionId",
+                table: "TenantVulnerabilities",
+                columns: new[] { "TenantId", "VulnerabilityDefinitionId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantVulnerabilities_VulnerabilityDefinitionId",
+                table: "TenantVulnerabilities",
+                column: "VulnerabilityDefinitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetAssessments_AssetId",
+                table: "VulnerabilityAssetAssessments",
+                column: "AssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetAssessments_AssetSecurityProfileId",
+                table: "VulnerabilityAssetAssessments",
+                column: "AssetSecurityProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetAssessments_SnapshotId",
+                table: "VulnerabilityAssetAssessments",
+                column: "SnapshotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetAssessments_TenantId",
+                table: "VulnerabilityAssetAssessments",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetAssessments_TenantId_SnapshotId_TenantVul~",
+                table: "VulnerabilityAssetAssessments",
+                columns: new[] { "TenantId", "SnapshotId", "TenantVulnerabilityId", "AssetId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetAssessments_TenantVulnerabilityId",
+                table: "VulnerabilityAssetAssessments",
+                column: "TenantVulnerabilityId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetEpisodes_AssetId",
+                table: "VulnerabilityAssetEpisodes",
+                column: "AssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetEpisodes_TenantId",
+                table: "VulnerabilityAssetEpisodes",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetEpisodes_TenantId_Status_TenantVulnerabil~",
+                table: "VulnerabilityAssetEpisodes",
+                columns: new[] { "TenantId", "Status", "TenantVulnerabilityId", "AssetId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetEpisodes_TenantId_TenantVulnerabilityId_A~",
+                table: "VulnerabilityAssetEpisodes",
+                columns: new[] { "TenantId", "TenantVulnerabilityId", "AssetId", "EpisodeNumber" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssetEpisodes_TenantVulnerabilityId_AssetId_Ep~",
+                table: "VulnerabilityAssetEpisodes",
+                columns: new[] { "TenantVulnerabilityId", "AssetId", "EpisodeNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssets_AssetId",
+                table: "VulnerabilityAssets",
+                column: "AssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssets_SnapshotId",
+                table: "VulnerabilityAssets",
+                column: "SnapshotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityAssets_TenantVulnerabilityId_AssetId_SnapshotId",
+                table: "VulnerabilityAssets",
+                columns: new[] { "TenantVulnerabilityId", "AssetId", "SnapshotId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityDefinitionAffectedSoftware_VulnerabilityDefini~",
+                table: "VulnerabilityDefinitionAffectedSoftware",
+                column: "VulnerabilityDefinitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityDefinitionReferences_VulnerabilityDefinitionId",
+                table: "VulnerabilityDefinitionReferences",
+                column: "VulnerabilityDefinitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityDefinitions_ExternalId",
+                table: "VulnerabilityDefinitions",
+                column: "ExternalId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityDefinitions_Source",
+                table: "VulnerabilityDefinitions",
+                column: "Source");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityEpisodeRiskAssessments_AssetId",
+                table: "VulnerabilityEpisodeRiskAssessments",
+                column: "AssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityEpisodeRiskAssessments_TenantId",
+                table: "VulnerabilityEpisodeRiskAssessments",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityEpisodeRiskAssessments_TenantId_ResolvedAt",
+                table: "VulnerabilityEpisodeRiskAssessments",
+                columns: new[] { "TenantId", "ResolvedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityEpisodeRiskAssessments_TenantId_TenantVulnerab~",
+                table: "VulnerabilityEpisodeRiskAssessments",
+                columns: new[] { "TenantId", "TenantVulnerabilityId", "AssetId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityEpisodeRiskAssessments_TenantVulnerabilityId",
+                table: "VulnerabilityEpisodeRiskAssessments",
+                column: "TenantVulnerabilityId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityEpisodeRiskAssessments_VulnerabilityAssetEpiso~",
+                table: "VulnerabilityEpisodeRiskAssessments",
+                column: "VulnerabilityAssetEpisodeId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VulnerabilityThreatAssessments_VulnerabilityDefinitionId",
+                table: "VulnerabilityThreatAssessments",
+                column: "VulnerabilityDefinitionId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AIReports_TenantVulnerabilities_TenantVulnerabilityId",
+                table: "AIReports",
+                column: "TenantVulnerabilityId",
+                principalTable: "TenantVulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationalSeverities_TenantVulnerabilities_TenantVulner~",
+                table: "OrganizationalSeverities",
+                column: "TenantVulnerabilityId",
+                principalTable: "TenantVulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+++ b/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
@@ -4,6 +4,7 @@ using PatchHound.Core.Entities;
 using PatchHound.Core.Entities.AuthenticatedScans;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
+using PatchHound.Core.Common;
 
 namespace PatchHound.Infrastructure.Data;
 
@@ -116,6 +117,7 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
     public DbSet<RemediationWorkflowStageRecord> RemediationWorkflowStageRecords => Set<RemediationWorkflowStageRecord>();
     public DbSet<SentinelConnectorConfiguration> SentinelConnectorConfigurations =>
         Set<SentinelConnectorConfiguration>();
+    public DbSet<FeatureFlagOverride> FeatureFlagOverrides => Set<FeatureFlagOverride>();
 
     public async Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken ct = default)
     {

--- a/src/PatchHound.Infrastructure/FeatureFlags/DatabaseFeatureDefinitionProvider.cs
+++ b/src/PatchHound.Infrastructure/FeatureFlags/DatabaseFeatureDefinitionProvider.cs
@@ -1,0 +1,99 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.FeatureFlags;
+
+/// <summary>
+/// Resolves feature flag state with the following precedence (highest first):
+///   1. User-level override (non-expired)
+///   2. Tenant-level override (non-expired)
+///   3. Global default from IConfiguration ("FeatureManagement" section)
+/// </summary>
+public class DatabaseFeatureDefinitionProvider : IFeatureDefinitionProvider
+{
+    private readonly IDbContextFactory<PatchHoundDbContext> _dbContextFactory;
+    private readonly ITenantContext _tenantContext;
+    private readonly IConfiguration _configuration;
+
+    public DatabaseFeatureDefinitionProvider(
+        IDbContextFactory<PatchHoundDbContext> dbContextFactory,
+        ITenantContext tenantContext,
+        IConfiguration configuration
+    )
+    {
+        _dbContextFactory = dbContextFactory;
+        _tenantContext = tenantContext;
+        _configuration = configuration;
+    }
+
+    public async Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var userId = _tenantContext.CurrentUserId != Guid.Empty
+            ? _tenantContext.CurrentUserId
+            : (Guid?)null;
+        var tenantId = _tenantContext.CurrentTenantId;
+
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+
+        // 1. User-level override
+        if (userId.HasValue)
+        {
+            var userOverride = await db.FeatureFlagOverrides
+                .IgnoreQueryFilters()
+                .AsNoTracking()
+                .Where(o =>
+                    o.FlagName == featureName &&
+                    o.UserId == userId.Value &&
+                    (o.ExpiresAt == null || o.ExpiresAt > now))
+                .FirstOrDefaultAsync();
+
+            if (userOverride is not null)
+                return BuildDefinition(featureName, userOverride.IsEnabled);
+        }
+
+        // 2. Tenant-level override
+        if (tenantId.HasValue)
+        {
+            var tenantOverride = await db.FeatureFlagOverrides
+                .IgnoreQueryFilters()
+                .AsNoTracking()
+                .Where(o =>
+                    o.FlagName == featureName &&
+                    o.TenantId == tenantId.Value &&
+                    (o.ExpiresAt == null || o.ExpiresAt > now))
+                .FirstOrDefaultAsync();
+
+            if (tenantOverride is not null)
+                return BuildDefinition(featureName, tenantOverride.IsEnabled);
+        }
+
+        // 3. Global config default
+        var configValue = _configuration[$"FeatureManagement:{featureName}"];
+        var isEnabled = string.Equals(configValue, "true", StringComparison.OrdinalIgnoreCase);
+        return BuildDefinition(featureName, isEnabled);
+    }
+
+    public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync()
+    {
+        // Return definitions for all known registered flags
+        foreach (var flagName in Core.Common.FeatureFlags.Metadata.Keys)
+        {
+            yield return await GetFeatureDefinitionAsync(flagName);
+        }
+    }
+
+    private static FeatureDefinition BuildDefinition(string featureName, bool isEnabled)
+    {
+        return new FeatureDefinition
+        {
+            Name = featureName,
+            EnabledFor = isEnabled
+                ? [new FeatureFilterConfiguration { Name = "AlwaysOn" }]
+                : [],
+        };
+    }
+}

--- a/src/PatchHound.Infrastructure/PatchHound.Infrastructure.csproj
+++ b/src/PatchHound.Infrastructure/PatchHound.Infrastructure.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="4.4.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.1" />

--- a/src/PatchHound.Worker/appsettings.json
+++ b/src/PatchHound.Worker/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
+  },
+  "FeatureManagement": {
+    "Workflows": true,
+    "AuthenticatedScans": true
   }
 }

--- a/tests/PatchHound.Tests/Api/AdminFeatureFlagsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/AdminFeatureFlagsControllerTests.cs
@@ -1,0 +1,196 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Core.Common;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class AdminFeatureFlagsControllerTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly IFeatureManager _featureManager;
+    private readonly AdminFeatureFlagsController _controller;
+
+    public AdminFeatureFlagsControllerTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId);
+        _tenantContext.CurrentUserId.Returns(_userId);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+
+        _featureManager = Substitute.For<IFeatureManager>();
+        // Default: all flags enabled in the mock
+        _featureManager.IsEnabledAsync(Arg.Any<string>()).Returns(true);
+
+        _controller = new AdminFeatureFlagsController(_dbContext, _featureManager);
+    }
+
+    // ── GetFlags ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetFlags_ReturnsOneEntryPerRegisteredFlag()
+    {
+        var result = await _controller.GetFlags(CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var flags = ok.Value.Should().BeAssignableTo<IReadOnlyList<AdminFeatureFlagDto>>().Subject;
+
+        flags.Select(f => f.FlagName)
+            .Should().BeEquivalentTo(FeatureFlags.Metadata.Keys);
+    }
+
+    [Fact]
+    public async Task GetFlags_ReflectsFeatureManagerState()
+    {
+        _featureManager.IsEnabledAsync(FeatureFlags.Workflows).Returns(false);
+        _featureManager.IsEnabledAsync(FeatureFlags.AuthenticatedScans).Returns(true);
+
+        var result = await _controller.GetFlags(CancellationToken.None);
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var flags = ok.Value.Should().BeAssignableTo<IReadOnlyList<AdminFeatureFlagDto>>().Subject;
+
+        flags.Single(f => f.FlagName == FeatureFlags.Workflows).IsEnabled.Should().BeFalse();
+        flags.Single(f => f.FlagName == FeatureFlags.AuthenticatedScans).IsEnabled.Should().BeTrue();
+    }
+
+    // ── GetOverrides ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetOverrides_ReturnsEmpty_WhenNoneExist()
+    {
+        var result = await _controller.GetOverrides(null, null, CancellationToken.None);
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var overrides = ok.Value.Should().BeAssignableTo<IReadOnlyList<FeatureFlagOverrideDto>>().Subject;
+        overrides.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetOverrides_FiltersByTenantId()
+    {
+        var otherTenantId = Guid.NewGuid();
+        await _dbContext.FeatureFlagOverrides.AddRangeAsync(
+            FeatureFlagOverride.CreateTenantOverride(FeatureFlags.Workflows, _tenantId, true),
+            FeatureFlagOverride.CreateTenantOverride(FeatureFlags.Workflows, otherTenantId, false)
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetOverrides(_tenantId, null, CancellationToken.None);
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var overrides = ok.Value.Should().BeAssignableTo<IReadOnlyList<FeatureFlagOverrideDto>>().Subject;
+
+        overrides.Should().HaveCount(1);
+        overrides[0].TenantId.Should().Be(_tenantId);
+    }
+
+    // ── CreateOrUpdateOverride ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateOverride_PersistsTenantOverride()
+    {
+        var request = new UpsertFeatureFlagOverrideRequest(
+            FlagName: FeatureFlags.Workflows,
+            TenantId: _tenantId,
+            UserId: null,
+            IsEnabled: false,
+            ExpiresAt: null
+        );
+
+        var result = await _controller.CreateOrUpdateOverride(request, CancellationToken.None);
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<FeatureFlagOverrideDto>().Subject;
+
+        dto.FlagName.Should().Be(FeatureFlags.Workflows);
+        dto.TenantId.Should().Be(_tenantId);
+        dto.IsEnabled.Should().BeFalse();
+
+        var stored = await _dbContext.FeatureFlagOverrides.IgnoreQueryFilters().SingleAsync();
+        stored.TenantId.Should().Be(_tenantId);
+    }
+
+    [Fact]
+    public async Task CreateOverride_UpsertsExistingOverride()
+    {
+        // First create
+        var create = new UpsertFeatureFlagOverrideRequest(FeatureFlags.Workflows, _tenantId, null, false, null);
+        await _controller.CreateOrUpdateOverride(create, CancellationToken.None);
+
+        // Now upsert with isEnabled = true
+        var upsert = new UpsertFeatureFlagOverrideRequest(FeatureFlags.Workflows, _tenantId, null, true, null);
+        var result = await _controller.CreateOrUpdateOverride(upsert, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<FeatureFlagOverrideDto>().Subject;
+        dto.IsEnabled.Should().BeTrue();
+
+        // Should still be exactly one override
+        var count = await _dbContext.FeatureFlagOverrides.IgnoreQueryFilters().CountAsync();
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateOverride_ReturnsBadRequest_ForUnknownFlag()
+    {
+        var request = new UpsertFeatureFlagOverrideRequest("UnknownFlag", _tenantId, null, true, null);
+        var result = await _controller.CreateOrUpdateOverride(request, CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateOverride_ReturnsBadRequest_WhenBothTenantAndUserProvided()
+    {
+        var request = new UpsertFeatureFlagOverrideRequest(FeatureFlags.Workflows, _tenantId, _userId, true, null);
+        var result = await _controller.CreateOrUpdateOverride(request, CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateOverride_ReturnsBadRequest_WhenNeitherTenantNorUserProvided()
+    {
+        var request = new UpsertFeatureFlagOverrideRequest(FeatureFlags.Workflows, null, null, true, null);
+        var result = await _controller.CreateOrUpdateOverride(request, CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // ── DeleteOverride ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteOverride_RemovesExistingOverride()
+    {
+        var entity = FeatureFlagOverride.CreateTenantOverride(FeatureFlags.Workflows, _tenantId, true);
+        await _dbContext.FeatureFlagOverrides.AddAsync(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.DeleteOverride(entity.Id, CancellationToken.None);
+        result.Should().BeOfType<NoContentResult>();
+
+        var count = await _dbContext.FeatureFlagOverrides.IgnoreQueryFilters().CountAsync();
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DeleteOverride_ReturnsNotFound_ForMissingId()
+    {
+        var result = await _controller.DeleteOverride(Guid.NewGuid(), CancellationToken.None);
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/tests/PatchHound.Tests/Infrastructure/DatabaseFeatureDefinitionProviderTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/DatabaseFeatureDefinitionProviderTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using PatchHound.Core.Common;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.FeatureFlags;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Infrastructure;
+
+/// <summary>
+/// Tests the resolution precedence of DatabaseFeatureDefinitionProvider:
+///   1. User-level override beats tenant-level and global config.
+///   2. Tenant-level override beats global config.
+///   3. Global config is the final fallback.
+///   4. Expired overrides are ignored.
+/// </summary>
+public class DatabaseFeatureDefinitionProviderTests : IDisposable
+{
+    private static readonly string FlagName = FeatureFlags.Workflows;
+
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly string _databaseName = Guid.NewGuid().ToString();
+
+    public DatabaseFeatureDefinitionProviderTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId);
+        _tenantContext.CurrentUserId.Returns(_userId);
+
+        _dbContext = BuildDbContext();
+    }
+
+    private PatchHoundDbContext BuildDbContext()
+    {
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(_databaseName)
+            .Options;
+        return new PatchHoundDbContext(options, TestServiceProviderFactory.Create(_tenantContext));
+    }
+
+    private DatabaseFeatureDefinitionProvider BuildProvider(bool globalDefault)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"FeatureManagement:{FlagName}"] = globalDefault ? "true" : "false",
+            })
+            .Build();
+
+        var factory = new FakeDbContextFactory(BuildDbContext);
+        return new DatabaseFeatureDefinitionProvider(factory, _tenantContext, config);
+    }
+
+    [Fact]
+    public async Task GlobalConfig_IsReturnedWhenNoOverridesExist()
+    {
+        var provider = BuildProvider(globalDefault: true);
+        var definition = await provider.GetFeatureDefinitionAsync(FlagName);
+        definition.EnabledFor.Should().NotBeEmpty("global config has flag enabled");
+    }
+
+    [Fact]
+    public async Task GlobalConfig_Disabled_IsReturnedWhenNoOverridesExist()
+    {
+        var provider = BuildProvider(globalDefault: false);
+        var definition = await provider.GetFeatureDefinitionAsync(FlagName);
+        definition.EnabledFor.Should().BeEmpty("global config has flag disabled");
+    }
+
+    [Fact]
+    public async Task TenantOverride_WinsOverGlobalConfig()
+    {
+        // Global says disabled, tenant says enabled
+        await _dbContext.FeatureFlagOverrides.AddAsync(
+            FeatureFlagOverride.CreateTenantOverride(FlagName, _tenantId, isEnabled: true));
+        await _dbContext.SaveChangesAsync();
+
+        var provider = BuildProvider(globalDefault: false);
+        var definition = await provider.GetFeatureDefinitionAsync(FlagName);
+        definition.EnabledFor.Should().NotBeEmpty("tenant override enables the flag");
+    }
+
+    [Fact]
+    public async Task UserOverride_WinsOverTenantOverrideAndGlobalConfig()
+    {
+        // Tenant says disabled, user says enabled
+        await _dbContext.FeatureFlagOverrides.AddRangeAsync(
+            FeatureFlagOverride.CreateTenantOverride(FlagName, _tenantId, isEnabled: false),
+            FeatureFlagOverride.CreateUserOverride(FlagName, _userId, isEnabled: true)
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var provider = BuildProvider(globalDefault: false);
+        var definition = await provider.GetFeatureDefinitionAsync(FlagName);
+        definition.EnabledFor.Should().NotBeEmpty("user override takes highest precedence");
+    }
+
+    [Fact]
+    public async Task ExpiredOverride_IsBypassed_FallsBackToGlobal()
+    {
+        var expired = FeatureFlagOverride.CreateTenantOverride(
+            FlagName, _tenantId, isEnabled: true,
+            expiresAt: DateTimeOffset.UtcNow.AddHours(-1)); // already expired
+
+        await _dbContext.FeatureFlagOverrides.AddAsync(expired);
+        await _dbContext.SaveChangesAsync();
+
+        var provider = BuildProvider(globalDefault: false);
+        var definition = await provider.GetFeatureDefinitionAsync(FlagName);
+        definition.EnabledFor.Should().BeEmpty("expired override must not apply");
+    }
+
+    [Fact]
+    public async Task GetAllFeatureDefinitions_ReturnsOneDefinitionPerRegisteredFlag()
+    {
+        var provider = BuildProvider(globalDefault: true);
+        var definitions = new List<Microsoft.FeatureManagement.FeatureDefinition>();
+        await foreach (var def in provider.GetAllFeatureDefinitionsAsync())
+            definitions.Add(def);
+
+        definitions.Select(d => d.Name)
+            .Should().BeEquivalentTo(FeatureFlags.Metadata.Keys);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // Minimal IDbContextFactory<PatchHoundDbContext> that creates a fresh context
+    // sharing the same in-memory database, so each `await using` disposal is safe.
+    private sealed class FakeDbContextFactory(
+        Func<PatchHoundDbContext> factory) : Microsoft.EntityFrameworkCore.IDbContextFactory<PatchHoundDbContext>
+    {
+        public PatchHoundDbContext CreateDbContext() => factory();
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #16 — a full feature flag system backed by the database with per-tenant and per-user overrides, a self-describing API, and an admin UI for managing overrides.

## Backend

- **`FeatureFlags` registry** (`Core`) — `FeatureFlagStage` enum, `FeatureFlagMeta` record, static `FeatureFlags` class with `Workflows` and `AuthenticatedScans` flags and their metadata.
- **`FeatureFlagOverride` entity + EF config** — check constraint enforces exactly one of `TenantId`/`UserId`; cascade deletes; composite indexes on `(FlagName, TenantId)` and `(FlagName, UserId)`.
- **EF migration** — `AddFeatureFlagOverrides`.
- **`DatabaseFeatureDefinitionProvider`** — implements `IFeatureDefinitionProvider` with resolution order: user override → tenant override → global `appsettings.json` default. Expired overrides are ignored. Registered as `IFeatureDefinitionProvider` in DI (correct pattern for `Microsoft.FeatureManagement` v4.4.0 — `UseCustomFeatureDefinitionProvider` does not exist in this version).
- **`FeaturesController`** — `GET /api/features` (authenticated), returns `Record<flagName, { displayName, stage, isEnabled }>`.
- **`AdminFeatureFlagsController`** — `GET /api/admin/feature-flags`, `GET /api/admin/feature-flags/overrides`, `POST /api/admin/feature-flags/overrides` (upsert), `DELETE /api/admin/feature-flags/overrides/{id}` — all behind `ManageGlobalSettings` policy.

## Frontend

- **`auth.functions.ts`** — fetches `/api/features` during `getCurrentUser` and exposes `featureFlags` on the user context object.
- **`admin/index.tsx`** — added `featureFlag?` field to `AdminArea`; `Workflows` card is now gated behind the `Workflows` flag; added **Feature flags** card in Platform configuration.
- **`feature-flags.schemas.ts`** — Zod schemas for all flag/override shapes.
- **`feature-flags.functions.ts`** — server functions: `fetchFeatureFlags`, `fetchAdminFeatureFlags`, `fetchFeatureFlagOverrides`, `upsertFeatureFlagOverride`, `deleteFeatureFlagOverride`.
- **`admin/platform/feature-flags.tsx`** — admin page showing global flag state and a full override management UI (create with tenant/user target + expiry, delete).

## Tests

17 new tests, all passing (526 total, 0 failures):

- `DatabaseFeatureDefinitionProviderTests` — resolution precedence, expired override bypass, `GetAllFeatureDefinitions` completeness.
- `AdminFeatureFlagsControllerTests` — `GetFlags`, `GetOverrides` (with filter), upsert (create + idempotent update), bad-request validation, delete.