### PR TITLE
Phase 4: RemediationCase — case-first data model cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ frontend/.tanstack/
 .claude/
 .codex/
 .superpowers/
-docs/superpowers/
 .gitnexus

--- a/docs/superpowers/plans/2026-04-01-approval-task-detail-redesign.md
+++ b/docs/superpowers/plans/2026-04-01-approval-task-detail-redesign.md
@@ -1,0 +1,638 @@
+# ApprovalTaskDetail Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure ApprovalTaskDetail.tsx from single-column stacked layout to a two-column layout with context sidebar cards matching the design mockup.
+
+**Architecture:** Single-file refactor of `ApprovalTaskDetail.tsx`. The component's JSX is reorganized into a CSS grid (`lg:grid-cols-[1fr_320px]`) with the main content on the left and three sidebar cards on the right. A recharts `RadialBarChart` is added for the risk gauge. No new files, no schema changes.
+
+**Tech Stack:** React, Tailwind CSS, recharts (RadialBarChart/RadialBar/PolarAngleAxis), lucide-react icons
+
+---
+
+## File Map
+
+- **Modify:** `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx` — all layout changes happen here
+
+---
+
+### Task 1: Restructure to Two-Column Grid Layout
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+This task replaces the outer `<section className="space-y-5">` wrapper with a two-column grid and moves existing content into the left column. The right column is left empty (populated in later tasks). No functionality changes.
+
+- [ ] **Step 1: Update the outer wrapper and add column containers**
+
+Replace the outermost element (line 122):
+
+```tsx
+// OLD:
+<section className="space-y-5">
+  <header className="rounded-[28px] ...">...</header>
+  <section className="rounded-[28px] ...">...tabs...</section>
+</section>
+
+// NEW:
+<div className="grid gap-5 lg:grid-cols-[1fr_320px]">
+  {/* Left column */}
+  <section className="min-w-0 space-y-5">
+    <header className="rounded-[28px] ...">...</header>
+    {/* Reviewer verdict card will go here (Task 3) */}
+    <section className="rounded-[28px] ...">...tabs...</section>
+  </section>
+
+  {/* Right column — sidebar */}
+  <aside className="space-y-5">
+    {/* Sidebar cards will go here (Tasks 4, 5, 6) */}
+  </aside>
+</div>
+```
+
+The `<header>` and tabs `<section>` move inside the left column `<section>` unchanged.
+
+- [ ] **Step 2: Verify the app renders correctly**
+
+Run: `cd frontend && npm run dev`
+
+Open the approval detail page. The layout should look identical to before (single column on small screens), with an empty right margin on large screens. All existing functionality (tabs, approve/deny, pagination) must still work.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "refactor: wrap ApprovalTaskDetail in two-column grid layout"
+```
+
+---
+
+### Task 2: Simplify the Header
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Simplify the header: change title format, move badges/expiry inline, remove the metadata sidebar box and the "Requested decision" sub-section (that data moves to sidebar cards in later tasks).
+
+- [ ] **Step 1: Update the header content**
+
+Inside the `<header>` element, replace its children with this simplified structure:
+
+```tsx
+<header className="rounded-[28px] border border-border/70 bg-[linear-gradient(135deg,color-mix(in_oklab,var(--primary)_8%,transparent),transparent_48%),var(--color-card)] p-5">
+  <div className="space-y-3">
+    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+      Approval task
+    </p>
+    <div className="flex flex-wrap items-center gap-3">
+      <h1 className="text-3xl font-semibold tracking-[-0.04em]">
+        Remediation Approval: {startCase(data.softwareName)}
+      </h1>
+      {!isPending && !data.readAt ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onMarkRead}
+          title="Mark as read"
+          aria-label="Mark as read"
+          className="size-8 rounded-full border border-border/70"
+        >
+          <Eye className="size-4" />
+        </Button>
+      ) : null}
+    </div>
+    <div className="flex flex-wrap items-center gap-2">
+      <span
+        className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-medium ${toneBadge(severityTone(data.criticality))}`}
+      >
+        Severity: {data.criticality}
+      </span>
+      <ApprovalStatusBadge status={data.status} />
+      {isPending ? (
+        <ApprovalExpiryCountdown expiresAt={data.expiresAt} compact />
+      ) : null}
+    </div>
+  </div>
+</header>
+```
+
+Key changes from the current header:
+- Title now prefixed with "Remediation Approval: "
+- The subtitle paragraph ("Review the owner decision...") is removed
+- `ApprovalTypeBadge` removed (not in the mockup)
+- Severity badge text changed to "Severity: {value}" format
+- Expiry countdown rendered inline as `compact` variant
+- The metadata sidebar box (`min-w-[220px] rounded-2xl...`) is removed entirely
+- The "Requested decision" sub-section (`border-primary/15`) is removed entirely
+- The entire approve/deny `isPending` section is removed from the header (moves to Task 3)
+
+- [ ] **Step 2: Verify the header renders correctly**
+
+Run: `cd frontend && npm run dev`
+
+The header should show: label, title with "Remediation Approval:" prefix, badges row with severity + status + expiry inline. The approve/deny controls are temporarily missing (added back in Task 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "refactor: simplify approval header with inline badges and expiry"
+```
+
+---
+
+### Task 3: Extract Reviewer Verdict as Standalone Card
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Add the Reviewer Verdict card between the header and tabs in the left column. This contains the approval justification editor and approve/deny buttons, only shown when `isPending`.
+
+- [ ] **Step 1: Add new icon imports**
+
+Update the lucide-react import at the top of the file:
+
+```tsx
+import { CheckCircle, XCircle, Eye, AlertTriangle, MessageSquare, ShieldCheck } from 'lucide-react'
+```
+
+- [ ] **Step 2: Add the Reviewer Verdict card JSX**
+
+In the left column, between `</header>` and the tabs `<section>`, add:
+
+```tsx
+{isPending ? (
+  <section className="rounded-2xl border border-border/70 bg-card p-5">
+    <div className="flex items-start justify-between">
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="size-5 text-muted-foreground" />
+        <h2 className="text-lg font-semibold tracking-[-0.02em]">
+          Reviewer Verdict
+        </h2>
+      </div>
+      <CheckCircle className="size-10 text-muted-foreground/30" />
+    </div>
+
+    <div className="mt-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <label className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          Approval justification
+        </label>
+        {justificationRequired ? (
+          <span className="inline-flex rounded-full border border-border/70 bg-background/70 px-2.5 py-1 text-[11px] text-muted-foreground">
+            Required
+          </span>
+        ) : null}
+      </div>
+
+      {maintenanceWindowRequired ? (
+        <div className="space-y-2">
+          <label className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            Maintenance window date
+          </label>
+          <Input
+            type="date"
+            value={maintenanceWindowDate}
+            onChange={(e) => setMaintenanceWindowDate(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            The technical manager sets when the approved patch is expected to be in place.
+          </p>
+        </div>
+      ) : null}
+
+      <Textarea
+        placeholder="Provide technical rationale for this decision..."
+        value={justification}
+        onChange={(e) => setJustification(e.target.value)}
+        rows={4}
+      />
+
+      {resolveAction && justificationRequired && !justification.trim() ? (
+        <p className="flex items-center gap-1.5 text-sm text-tone-danger-foreground">
+          <AlertTriangle className="size-3.5" />
+          Justification is required to {resolveAction} this task.
+        </p>
+      ) : null}
+      {resolveAction === 'approve' && maintenanceWindowRequired && !maintenanceWindowDate ? (
+        <p className="flex items-center gap-1.5 text-sm text-tone-danger-foreground">
+          <AlertTriangle className="size-3.5" />
+          Maintenance window date is required to approve this patching request.
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap gap-3 pt-1">
+        <Button onClick={() => handleResolve('approve')} className="min-w-[180px]">
+          <CheckCircle className="mr-1.5 size-4" />
+          Approve Remediation
+        </Button>
+        <Button variant="destructive" onClick={() => handleResolve('deny')} className="min-w-[180px]">
+          <XCircle className="mr-1.5 size-4" />
+          Deny Request
+        </Button>
+      </div>
+    </div>
+  </section>
+) : null}
+```
+
+- [ ] **Step 3: Verify approve/deny functionality**
+
+Run: `cd frontend && npm run dev`
+
+Navigate to a pending approval task. The Reviewer Verdict card should appear between header and tabs, with the shield icon, editor, and buttons. Test: try to approve without justification when required — validation error should appear. Try approving with justification — should call `onResolve`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "feat: add standalone Reviewer Verdict card for approval actions"
+```
+
+---
+
+### Task 4: Add Requested Action Sidebar Card
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Add the first sidebar card showing the requested outcome and vulnerable software versions.
+
+- [ ] **Step 1: Add Package icon import**
+
+Update the lucide-react import:
+
+```tsx
+import { CheckCircle, XCircle, Eye, AlertTriangle, MessageSquare, ShieldCheck, Package, Info } from 'lucide-react'
+```
+
+- [ ] **Step 2: Compute vulnerable cohorts**
+
+Add this computed value after the existing `affectedDeviceCount` computation (around line 98):
+
+```tsx
+const vulnerableCohorts = data.deviceVersionCohorts.filter(
+  (c) => c.activeVulnerabilityCount > 0
+)
+```
+
+- [ ] **Step 3: Add the Requested Action card in the sidebar `<aside>`**
+
+Inside the `<aside className="space-y-5">` element, add:
+
+```tsx
+<section className="rounded-2xl border border-border/70 bg-background/60 p-5 space-y-4">
+  <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+    Requested action
+  </p>
+  <p className="text-lg font-semibold tracking-[-0.02em]">
+    {outcomeLabel(data.outcome)} for this software scope
+  </p>
+  <div className="rounded-xl border border-border/60 bg-background/45 p-3">
+    <div className="flex items-center gap-3">
+      <div className="flex size-10 items-center justify-center rounded-lg border border-border/60 bg-muted/30">
+        <Package className="size-5 text-muted-foreground" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium truncate">{startCase(data.softwareName)}</p>
+        <p className="text-xs text-muted-foreground">Software Library</p>
+      </div>
+      <Info className="size-4 shrink-0 text-muted-foreground" />
+    </div>
+  </div>
+  {vulnerableCohorts.length > 0 ? (
+    <div className="space-y-1.5">
+      <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        Vulnerable versions
+      </p>
+      <ul className="space-y-1 text-sm">
+        {vulnerableCohorts.map((cohort) => (
+          <li key={normalizeVersion(cohort.version) || '__unknown__'} className="flex items-center justify-between text-foreground/90">
+            <span className="font-mono text-xs">{formatVersion(cohort.version)}</span>
+            <span className="text-xs text-muted-foreground">
+              {cohort.activeVulnerabilityCount} vuln{cohort.activeVulnerabilityCount === 1 ? '' : 's'}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ) : (
+    <p className="text-xs text-muted-foreground">No vulnerable versions</p>
+  )}
+</section>
+```
+
+- [ ] **Step 4: Verify the sidebar card renders**
+
+Run: `cd frontend && npm run dev`
+
+The right column should now show the Requested Action card with the outcome label, software name with package icon, and a list of vulnerable version cohorts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "feat: add Requested Action sidebar card with vulnerable versions"
+```
+
+---
+
+### Task 5: Add Risk Context Sidebar Card with Gauge
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Add the Risk Context card with a large score number, recharts semicircular gauge, and stat boxes for vulnerability and device counts.
+
+- [ ] **Step 1: Add recharts imports**
+
+Add at the top of the file:
+
+```tsx
+import { RadialBarChart, RadialBar, PolarAngleAxis } from 'recharts'
+```
+
+- [ ] **Step 2: Add a tone-to-CSS-color helper**
+
+Add this function after the existing `riskBandTone` function. Recharts needs raw CSS color strings, not Tailwind classes. We use `getComputedStyle` to resolve the CSS custom property at render time:
+
+```tsx
+const toneColorVar: Record<string, string> = {
+  danger: '--color-tone-danger-foreground',
+  warning: '--color-tone-warning-foreground',
+  success: '--color-tone-success-foreground',
+  info: '--color-tone-info-foreground',
+  neutral: '--color-foreground',
+}
+
+function useToneCssColor(tone: string): string {
+  // Resolve CSS custom property to a usable color string for recharts
+  if (typeof window === 'undefined') return 'currentColor'
+  const varName = toneColorVar[tone] ?? toneColorVar.neutral
+  return getComputedStyle(document.documentElement).getPropertyValue(varName).trim() || 'currentColor'
+}
+```
+
+- [ ] **Step 3: Add the Risk Context card in the sidebar**
+
+Inside the `<aside>`, after the Requested Action card, add:
+
+```tsx
+<section className="rounded-2xl border border-border/70 bg-background/60 p-5 space-y-4">
+  <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+    Risk context
+  </p>
+  {data.riskScore != null && data.riskBand ? (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-4xl font-bold tabular-nums tracking-tight">
+            {data.riskScore.toFixed(1)}
+          </p>
+          <p className={`text-xs font-semibold uppercase tracking-[0.1em] ${toneText(riskBandTone(data.riskBand))}`}>
+            {data.riskBand} risk score
+          </p>
+        </div>
+        <RiskGauge score={data.riskScore} tone={riskBandTone(data.riskBand)} />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-border/60 bg-background/45 p-3 text-center">
+          <p className="text-2xl font-bold tabular-nums">{vulnerabilityCount}</p>
+          <p className="text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            Open<br />vulnerability
+          </p>
+        </div>
+        <div className="rounded-xl border border-border/60 bg-background/45 p-3 text-center">
+          <p className="text-2xl font-bold tabular-nums">{affectedDeviceCount}</p>
+          <p className="text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            Affected<br />device
+          </p>
+        </div>
+      </div>
+    </>
+  ) : (
+    <p className="text-sm text-muted-foreground">No risk data available</p>
+  )}
+</section>
+```
+
+- [ ] **Step 4: Add the RiskGauge helper component**
+
+Add this function component above the main `ApprovalTaskDetail` export (after `useToneCssColor`):
+
+```tsx
+function RiskGauge({ score, tone }: { score: number; tone: Tone }) {
+  const color = useToneCssColor(tone)
+  const gaugeData = [{ value: score, fill: color }]
+
+  return (
+    <div className="size-[100px]">
+      <RadialBarChart
+        width={100}
+        height={60}
+        cx={50}
+        cy={55}
+        innerRadius={35}
+        outerRadius={50}
+        startAngle={180}
+        endAngle={0}
+        data={gaugeData}
+        barSize={10}
+      >
+        <PolarAngleAxis
+          type="number"
+          domain={[0, 10]}
+          angleAxisId={0}
+          tick={false}
+        />
+        <RadialBar
+          dataKey="value"
+          cornerRadius={5}
+          background={{ fill: 'var(--color-muted)' }}
+          angleAxisId={0}
+        />
+      </RadialBarChart>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Add `toneText` import**
+
+Update the import from `@/lib/tone-classes`:
+
+```tsx
+import { toneBadge, toneText } from '@/lib/tone-classes'
+```
+
+Also add the `Tone` type import:
+
+```tsx
+import { toneBadge, toneText, type Tone } from '@/lib/tone-classes'
+```
+
+- [ ] **Step 6: Import `riskBandTone` from remediation-utils instead of local**
+
+Update the import from remediation-utils to also include `riskBandTone`:
+
+```tsx
+import {
+  outcomeLabel,
+  outcomeTone,
+  riskBandTone,
+} from '@/components/features/remediation/remediation-utils'
+```
+
+Then remove the local `riskBandTone` function (lines 45-58 in the original file) since it duplicates the utility.
+
+- [ ] **Step 7: Verify the Risk Context card renders**
+
+Run: `cd frontend && npm run dev`
+
+The sidebar should now show two cards. The Risk Context card displays the score, a semicircular gauge arc colored by risk band, and two stat boxes. For tasks with null `riskScore`, it shows the fallback text.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "feat: add Risk Context sidebar card with recharts gauge"
+```
+
+---
+
+### Task 6: Add Threat Intelligence Placeholder Card
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Add the third sidebar card as a placeholder for future threat intelligence data.
+
+- [ ] **Step 1: Add the Threat Intelligence card in the sidebar**
+
+Inside the `<aside>`, after the Risk Context card, add:
+
+```tsx
+<section className="rounded-2xl border border-border/70 bg-background/40 p-5 space-y-3">
+  <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+    Threat intelligence
+  </p>
+  <p className="text-sm leading-relaxed text-muted-foreground italic">
+    Threat intelligence summary will appear here when available.
+  </p>
+</section>
+```
+
+- [ ] **Step 2: Verify it renders**
+
+Run: `cd frontend && npm run dev`
+
+Three sidebar cards should now be visible in the right column.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "feat: add Threat Intelligence placeholder sidebar card"
+```
+
+---
+
+### Task 7: Update Justification Tab with Requester Footer
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Add a requester info footer to the Justification tab content, showing who created the approval task and when.
+
+- [ ] **Step 1: Compute the requester name**
+
+Add this computed value alongside the other derived values (near `auditEvents`):
+
+```tsx
+const requesterName =
+  data.auditTrail.find((e) => e.action === 'Created')?.userDisplayName ??
+  data.decidedByName
+```
+
+- [ ] **Step 2: Add the footer card to the Justification tab**
+
+Inside `<TabsContent value="justification">`, after the last `</section>` (the analyst recommendations section or the decision justification section if no recommendations), add:
+
+```tsx
+<section className="rounded-2xl border border-border/70 bg-background/60 p-5">
+  <div className="flex flex-wrap items-center gap-6">
+    <div>
+      <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        Requested by
+      </p>
+      <p className="mt-1 text-sm font-medium">{requesterName}</p>
+    </div>
+    <div>
+      <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        Request date
+      </p>
+      <p className="mt-1 text-sm font-medium">{formatDateTime(data.createdAt)}</p>
+    </div>
+  </div>
+</section>
+```
+
+- [ ] **Step 3: Add `formatDateTime` import**
+
+Update the formatting import:
+
+```tsx
+import { formatDate, formatDateTime, startCase } from '@/lib/formatting'
+```
+
+- [ ] **Step 4: Verify the footer renders in the Justification tab**
+
+Run: `cd frontend && npm run dev`
+
+Navigate to the Justification tab. A footer card with "Requested by" and "Request date" should appear at the bottom.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "feat: add requester info footer to Justification tab"
+```
+
+---
+
+### Task 8: Clean Up Unused Code
+
+**Files:**
+- Modify: `frontend/src/components/features/approvals/ApprovalTaskDetail.tsx`
+
+Remove the local `severityTone` and `riskBandTone` functions that are now unused or replaced by imports from `remediation-utils`. The local `severityTone` is still used in the vulnerabilities and devices tables — import it from `remediation-utils` instead (it's already exported there as `severityTone`).
+
+- [ ] **Step 1: Update remediation-utils import to include severityTone**
+
+```tsx
+import {
+  outcomeLabel,
+  outcomeTone,
+  riskBandTone,
+  severityTone,
+} from '@/components/features/remediation/remediation-utils'
+```
+
+- [ ] **Step 2: Remove local `severityTone` and `riskBandTone` functions**
+
+Delete the local `severityTone` function (lines 30-43) and `riskBandTone` function (lines 45-58). Both are now imported.
+
+Note: The local `severityTone` maps 'Medium' to `'neutral'` while the remediation-utils version maps it to `'info'`. This is a minor inconsistency — the utils version (`'info'`) is correct per the design system. Verify that Medium severity badges look acceptable with the info tone.
+
+- [ ] **Step 3: Verify everything still renders correctly**
+
+Run: `cd frontend && npm run dev`
+
+Check all tabs, all badge colors, approve/deny flow. Medium severity badges will now use the info tone (blue-ish) instead of neutral (gray). All other functionality must be unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+git commit -m "refactor: use shared severity/risk tone functions from remediation-utils"
+```

--- a/docs/superpowers/plans/2026-04-05-authenticated-scans-01-backend-foundations.md
+++ b/docs/superpowers/plans/2026-04-05-authenticated-scans-01-backend-foundations.md
@@ -1,0 +1,3135 @@
+# Authenticated Scans — Plan 1: Backend Foundations
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the backend foundation for authenticated scans — new entities, EF migration, CRUD controllers, OpenBao secret handling, ingestion service with validation+staging+merge, scan-job dispatcher, and asset-rule "AssignScanProfile" operation. No scheduler, no runner binary, no UI in this plan.
+
+**Architecture:** All new entities follow the existing pattern (private setters, static `Create`, update methods, EF configuration). Domain entities in `PatchHound.Core/Entities/`, EF configs in `PatchHound.Infrastructure/Data/Configurations/AuthenticatedScans/`, services in `PatchHound.Infrastructure/AuthenticatedScans/`, controllers in `PatchHound.Api/Controllers/`. One migration at the end adds all tables.
+
+**Tech Stack:** .NET 8, EF Core, PostgreSQL, xUnit, OpenBao (existing `ISecretStore`), existing `ITenantContext` + `AuditLogWriter` patterns.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-05-authenticated-scans-design.md` (sections 4, 7).
+
+---
+
+## File Map
+
+**New entities** (`src/PatchHound.Core/Entities/AuthenticatedScans/`):
+- `ConnectionProfile.cs`
+- `ScanRunner.cs`
+- `ScanningTool.cs` + `ScanningToolVersion.cs`
+- `ScanProfile.cs` + `ScanProfileTool.cs`
+- `AssetScanProfileAssignment.cs`
+- `AuthenticatedScanRun.cs`
+- `ScanJob.cs` + `ScanJobResult.cs` + `ScanJobValidationIssue.cs`
+- `StagedAuthenticatedScanSoftware.cs`
+
+**Enum change** (`src/PatchHound.Core/Enums/SoftwareIdentitySourceSystem.cs`): add `AuthenticatedScan = 2`.
+
+**EF configurations** (`src/PatchHound.Infrastructure/Data/Configurations/AuthenticatedScans/`): one per entity.
+
+**DbSets** added to `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`.
+
+**Services** (`src/PatchHound.Infrastructure/AuthenticatedScans/`):
+- `AuthenticatedScanIngestionService.cs`
+- `AuthenticatedScanOutputValidator.cs`
+- `ScanJobDispatcher.cs`
+- `ConnectionProfileSecretWriter.cs`
+
+**Controllers** (`src/PatchHound.Api/Controllers/`):
+- `ConnectionProfilesController.cs`
+- `ScanRunnersController.cs`
+- `ScanningToolsController.cs`
+- `ScanProfilesController.cs`
+
+**DTOs** (`src/PatchHound.Api/Models/AuthenticatedScans/`): request/response records per controller.
+
+**Asset-rule integration** (`src/PatchHound.Core/Services/AssetRuleEvaluationService.cs` or wherever `IAssetRuleEvaluationService` lives): handle `"AssignScanProfile"` operation.
+
+**Tests** (`tests/PatchHound.Tests/`):
+- `Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionServiceTests.cs`
+- `Infrastructure/AuthenticatedScans/AuthenticatedScanOutputValidatorTests.cs`
+- `Infrastructure/AuthenticatedScans/ScanJobDispatcherTests.cs`
+- `Infrastructure/AuthenticatedScans/ScanningToolVersionRetentionTests.cs`
+- `Api/ConnectionProfilesControllerTests.cs`
+- `Api/ScanRunnersControllerTests.cs`
+- `Api/ScanningToolsControllerTests.cs`
+- `Api/ScanProfilesControllerTests.cs`
+- `Core/AssetRuleEvaluationAssignScanProfileTests.cs`
+
+**Migration** (`src/PatchHound.Infrastructure/Data/Migrations/`): `AddAuthenticatedScans`.
+
+---
+
+## Task 1: Add `AuthenticatedScan` to `SoftwareIdentitySourceSystem` enum
+
+**Files:**
+- Modify: `src/PatchHound.Core/Enums/SoftwareIdentitySourceSystem.cs`
+
+- [ ] **Step 1: Edit the enum**
+
+```csharp
+namespace PatchHound.Core.Enums;
+
+public enum SoftwareIdentitySourceSystem
+{
+    Defender = 1,
+    AuthenticatedScan = 2,
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build PatchHound.slnx`
+Expected: build succeeds (this is an additive enum value, no consumers need updates yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Core/Enums/SoftwareIdentitySourceSystem.cs
+git commit -m "feat: add AuthenticatedScan source system"
+```
+
+---
+
+## Task 2: `ConnectionProfile` entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ConnectionProfile.cs`
+
+- [ ] **Step 1: Write the entity**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ConnectionProfile
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public string Kind { get; private set; } = "ssh";
+    public string SshHost { get; private set; } = string.Empty;
+    public int SshPort { get; private set; } = 22;
+    public string SshUsername { get; private set; } = string.Empty;
+    public string AuthMethod { get; private set; } = "password"; // "password" | "privateKey"
+    public string SecretRef { get; private set; } = string.Empty;
+    public string? HostKeyFingerprint { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private ConnectionProfile() { }
+
+    public static ConnectionProfile Create(
+        Guid tenantId,
+        string name,
+        string description,
+        string sshHost,
+        int sshPort,
+        string sshUsername,
+        string authMethod,
+        string secretRef,
+        string? hostKeyFingerprint)
+    {
+        if (authMethod is not ("password" or "privateKey"))
+            throw new ArgumentException("authMethod must be 'password' or 'privateKey'", nameof(authMethod));
+        var now = DateTimeOffset.UtcNow;
+        return new ConnectionProfile
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description.Trim(),
+            Kind = "ssh",
+            SshHost = sshHost.Trim(),
+            SshPort = sshPort,
+            SshUsername = sshUsername.Trim(),
+            AuthMethod = authMethod,
+            SecretRef = secretRef,
+            HostKeyFingerprint = string.IsNullOrWhiteSpace(hostKeyFingerprint) ? null : hostKeyFingerprint.Trim(),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Update(
+        string name,
+        string description,
+        string sshHost,
+        int sshPort,
+        string sshUsername,
+        string authMethod,
+        string? hostKeyFingerprint)
+    {
+        if (authMethod is not ("password" or "privateKey"))
+            throw new ArgumentException("authMethod must be 'password' or 'privateKey'", nameof(authMethod));
+        Name = name.Trim();
+        Description = description.Trim();
+        SshHost = sshHost.Trim();
+        SshPort = sshPort;
+        SshUsername = sshUsername.Trim();
+        AuthMethod = authMethod;
+        HostKeyFingerprint = string.IsNullOrWhiteSpace(hostKeyFingerprint) ? null : hostKeyFingerprint.Trim();
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void SetSecretRef(string secretRef)
+    {
+        SecretRef = secretRef;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build src/PatchHound.Core`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/AuthenticatedScans/ConnectionProfile.cs
+git commit -m "feat: add ConnectionProfile entity"
+```
+
+---
+
+## Task 3: `ScanRunner` entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanRunner.cs`
+
+- [ ] **Step 1: Write the entity**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanRunner
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public string SecretHash { get; private set; } = string.Empty;
+    public DateTimeOffset? LastSeenAt { get; private set; }
+    public string Version { get; private set; } = string.Empty;
+    public bool Enabled { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private ScanRunner() { }
+
+    public static ScanRunner Create(Guid tenantId, string name, string description, string secretHash)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ScanRunner
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description.Trim(),
+            SecretHash = secretHash,
+            Enabled = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Update(string name, string description, bool enabled)
+    {
+        Name = name.Trim();
+        Description = description.Trim();
+        Enabled = enabled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void RotateSecret(string newHash)
+    {
+        SecretHash = newHash;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void RecordHeartbeat(string version, DateTimeOffset at)
+    {
+        Version = version.Trim();
+        LastSeenAt = at;
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build src/PatchHound.Core`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/AuthenticatedScans/ScanRunner.cs
+git commit -m "feat: add ScanRunner entity"
+```
+
+---
+
+## Task 4: `ScanningTool` + `ScanningToolVersion` entities
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanningTool.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanningToolVersion.cs`
+
+- [ ] **Step 1: Write `ScanningToolVersion`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanningToolVersion
+{
+    public Guid Id { get; private set; }
+    public Guid ScanningToolId { get; private set; }
+    public int VersionNumber { get; private set; }
+    public string ScriptContent { get; private set; } = string.Empty;
+    public Guid EditedByUserId { get; private set; }
+    public DateTimeOffset EditedAt { get; private set; }
+
+    private ScanningToolVersion() { }
+
+    public static ScanningToolVersion Create(
+        Guid scanningToolId,
+        int versionNumber,
+        string scriptContent,
+        Guid editedByUserId)
+    {
+        return new ScanningToolVersion
+        {
+            Id = Guid.NewGuid(),
+            ScanningToolId = scanningToolId,
+            VersionNumber = versionNumber,
+            ScriptContent = scriptContent,
+            EditedByUserId = editedByUserId,
+            EditedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Write `ScanningTool`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanningTool
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public string ScriptType { get; private set; } = "python";   // "python"|"bash"|"powershell"
+    public string InterpreterPath { get; private set; } = string.Empty;
+    public int TimeoutSeconds { get; private set; } = 300;
+    public string OutputModel { get; private set; } = "NormalizedSoftware";
+    public Guid? CurrentVersionId { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private ScanningTool() { }
+
+    public static ScanningTool Create(
+        Guid tenantId,
+        string name,
+        string description,
+        string scriptType,
+        string interpreterPath,
+        int timeoutSeconds,
+        string outputModel)
+    {
+        ValidateScriptType(scriptType);
+        if (outputModel != "NormalizedSoftware")
+            throw new ArgumentException("outputModel must be 'NormalizedSoftware' in v1", nameof(outputModel));
+        if (timeoutSeconds is < 5 or > 3600)
+            throw new ArgumentException("timeoutSeconds must be between 5 and 3600", nameof(timeoutSeconds));
+        var now = DateTimeOffset.UtcNow;
+        return new ScanningTool
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description.Trim(),
+            ScriptType = scriptType,
+            InterpreterPath = interpreterPath.Trim(),
+            TimeoutSeconds = timeoutSeconds,
+            OutputModel = outputModel,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void UpdateMetadata(string name, string description, string scriptType, string interpreterPath, int timeoutSeconds)
+    {
+        ValidateScriptType(scriptType);
+        if (timeoutSeconds is < 5 or > 3600)
+            throw new ArgumentException("timeoutSeconds must be between 5 and 3600", nameof(timeoutSeconds));
+        Name = name.Trim();
+        Description = description.Trim();
+        ScriptType = scriptType;
+        InterpreterPath = interpreterPath.Trim();
+        TimeoutSeconds = timeoutSeconds;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void SetCurrentVersion(Guid versionId)
+    {
+        CurrentVersionId = versionId;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private static void ValidateScriptType(string value)
+    {
+        if (value is not ("python" or "bash" or "powershell"))
+            throw new ArgumentException("scriptType must be python|bash|powershell", nameof(value));
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/PatchHound.Core`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/AuthenticatedScans/ScanningTool.cs src/PatchHound.Core/Entities/AuthenticatedScans/ScanningToolVersion.cs
+git commit -m "feat: add ScanningTool and ScanningToolVersion entities"
+```
+
+---
+
+## Task 5: `ScanProfile`, `ScanProfileTool`, `AssetScanProfileAssignment` entities
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanProfile.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanProfileTool.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/AssetScanProfileAssignment.cs`
+
+- [ ] **Step 1: Write `ScanProfile`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanProfile
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public string CronSchedule { get; private set; } = string.Empty; // "" = manual only
+    public Guid ConnectionProfileId { get; private set; }
+    public Guid ScanRunnerId { get; private set; }
+    public bool Enabled { get; private set; }
+    public DateTimeOffset? ManualRequestedAt { get; private set; }
+    public DateTimeOffset? LastRunStartedAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private ScanProfile() { }
+
+    public static ScanProfile Create(
+        Guid tenantId,
+        string name,
+        string description,
+        string cronSchedule,
+        Guid connectionProfileId,
+        Guid scanRunnerId,
+        bool enabled)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ScanProfile
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description.Trim(),
+            CronSchedule = cronSchedule.Trim(),
+            ConnectionProfileId = connectionProfileId,
+            ScanRunnerId = scanRunnerId,
+            Enabled = enabled,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Update(string name, string description, string cronSchedule,
+                       Guid connectionProfileId, Guid scanRunnerId, bool enabled)
+    {
+        Name = name.Trim();
+        Description = description.Trim();
+        CronSchedule = cronSchedule.Trim();
+        ConnectionProfileId = connectionProfileId;
+        ScanRunnerId = scanRunnerId;
+        Enabled = enabled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void RequestManualRun(DateTimeOffset at)
+    {
+        ManualRequestedAt = at;
+        UpdatedAt = at;
+    }
+
+    public void ClearManualRequest()
+    {
+        ManualRequestedAt = null;
+    }
+
+    public void RecordRunStarted(DateTimeOffset at)
+    {
+        LastRunStartedAt = at;
+    }
+}
+```
+
+- [ ] **Step 2: Write `ScanProfileTool` (join table)**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanProfileTool
+{
+    public Guid ScanProfileId { get; private set; }
+    public Guid ScanningToolId { get; private set; }
+    public int ExecutionOrder { get; private set; }
+
+    private ScanProfileTool() { }
+
+    public static ScanProfileTool Create(Guid scanProfileId, Guid scanningToolId, int executionOrder) =>
+        new() { ScanProfileId = scanProfileId, ScanningToolId = scanningToolId, ExecutionOrder = executionOrder };
+}
+```
+
+- [ ] **Step 3: Write `AssetScanProfileAssignment`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class AssetScanProfileAssignment
+{
+    public Guid TenantId { get; private set; }
+    public Guid AssetId { get; private set; }
+    public Guid ScanProfileId { get; private set; }
+    public Guid? AssignedByRuleId { get; private set; }
+    public DateTimeOffset AssignedAt { get; private set; }
+
+    private AssetScanProfileAssignment() { }
+
+    public static AssetScanProfileAssignment Create(Guid tenantId, Guid assetId, Guid scanProfileId, Guid? assignedByRuleId) =>
+        new()
+        {
+            TenantId = tenantId,
+            AssetId = assetId,
+            ScanProfileId = scanProfileId,
+            AssignedByRuleId = assignedByRuleId,
+            AssignedAt = DateTimeOffset.UtcNow,
+        };
+}
+```
+
+- [ ] **Step 4: Build & commit**
+
+```bash
+dotnet build src/PatchHound.Core
+git add src/PatchHound.Core/Entities/AuthenticatedScans/ScanProfile.cs src/PatchHound.Core/Entities/AuthenticatedScans/ScanProfileTool.cs src/PatchHound.Core/Entities/AuthenticatedScans/AssetScanProfileAssignment.cs
+git commit -m "feat: add ScanProfile, ScanProfileTool, AssetScanProfileAssignment entities"
+```
+
+---
+
+## Task 6: Run/Job entities and staging table
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/AuthenticatedScanRun.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanJob.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanJobResult.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanJobValidationIssue.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/StagedAuthenticatedScanSoftware.cs`
+
+- [ ] **Step 1: Write `AuthenticatedScanRun`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public static class AuthenticatedScanRunStatuses
+{
+    public const string Queued = "Queued";
+    public const string Running = "Running";
+    public const string Succeeded = "Succeeded";
+    public const string PartiallyFailed = "PartiallyFailed";
+    public const string Failed = "Failed";
+}
+
+public class AuthenticatedScanRun
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid ScanProfileId { get; private set; }
+    public string TriggerKind { get; private set; } = "scheduled"; // "scheduled"|"manual"
+    public Guid? TriggeredByUserId { get; private set; }
+    public DateTimeOffset StartedAt { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+    public string Status { get; private set; } = AuthenticatedScanRunStatuses.Queued;
+    public int TotalDevices { get; private set; }
+    public int SucceededCount { get; private set; }
+    public int FailedCount { get; private set; }
+    public int EntriesIngested { get; private set; }
+
+    private AuthenticatedScanRun() { }
+
+    public static AuthenticatedScanRun Start(
+        Guid tenantId, Guid scanProfileId, string triggerKind, Guid? triggeredByUserId, DateTimeOffset at)
+    {
+        return new AuthenticatedScanRun
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ScanProfileId = scanProfileId,
+            TriggerKind = triggerKind,
+            TriggeredByUserId = triggeredByUserId,
+            StartedAt = at,
+            Status = AuthenticatedScanRunStatuses.Queued,
+        };
+    }
+
+    public void MarkRunning(int totalDevices)
+    {
+        TotalDevices = totalDevices;
+        Status = AuthenticatedScanRunStatuses.Running;
+    }
+
+    public void Complete(int succeeded, int failed, int entriesIngested, DateTimeOffset at)
+    {
+        SucceededCount = succeeded;
+        FailedCount = failed;
+        EntriesIngested = entriesIngested;
+        CompletedAt = at;
+        Status = (failed, succeeded) switch
+        {
+            (0, _) => AuthenticatedScanRunStatuses.Succeeded,
+            (_, 0) => AuthenticatedScanRunStatuses.Failed,
+            _      => AuthenticatedScanRunStatuses.PartiallyFailed,
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Write `ScanJob`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public static class ScanJobStatuses
+{
+    public const string Pending = "Pending";
+    public const string Dispatched = "Dispatched";
+    public const string Running = "Running";
+    public const string Succeeded = "Succeeded";
+    public const string Failed = "Failed";
+    public const string TimedOut = "TimedOut";
+}
+
+public class ScanJob
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid RunId { get; private set; }
+    public Guid ScanRunnerId { get; private set; }
+    public Guid AssetId { get; private set; }
+    public Guid ConnectionProfileId { get; private set; }
+    public string ScanningToolVersionIdsJson { get; private set; } = "[]";
+    public string Status { get; private set; } = ScanJobStatuses.Pending;
+    public DateTimeOffset? LeaseExpiresAt { get; private set; }
+    public int AttemptCount { get; private set; }
+    public DateTimeOffset? StartedAt { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+    public string ErrorMessage { get; private set; } = string.Empty;
+    public int StdoutBytes { get; private set; }
+    public int StderrBytes { get; private set; }
+    public int EntriesIngested { get; private set; }
+
+    private ScanJob() { }
+
+    public static ScanJob Create(
+        Guid tenantId, Guid runId, Guid scanRunnerId, Guid assetId,
+        Guid connectionProfileId, string scanningToolVersionIdsJson)
+    {
+        return new ScanJob
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RunId = runId,
+            ScanRunnerId = scanRunnerId,
+            AssetId = assetId,
+            ConnectionProfileId = connectionProfileId,
+            ScanningToolVersionIdsJson = scanningToolVersionIdsJson,
+            Status = ScanJobStatuses.Pending,
+        };
+    }
+
+    public void Dispatch(DateTimeOffset leaseExpiresAt)
+    {
+        Status = ScanJobStatuses.Dispatched;
+        LeaseExpiresAt = leaseExpiresAt;
+        AttemptCount++;
+    }
+
+    public void ReturnToPending(string reason)
+    {
+        Status = ScanJobStatuses.Pending;
+        LeaseExpiresAt = null;
+        ErrorMessage = reason;
+    }
+
+    public void CompleteSucceeded(int stdoutBytes, int stderrBytes, int entriesIngested, DateTimeOffset at)
+    {
+        Status = ScanJobStatuses.Succeeded;
+        StdoutBytes = stdoutBytes;
+        StderrBytes = stderrBytes;
+        EntriesIngested = entriesIngested;
+        CompletedAt = at;
+    }
+
+    public void CompleteFailed(string status, string errorMessage, DateTimeOffset at)
+    {
+        Status = status; // Failed | TimedOut
+        ErrorMessage = errorMessage;
+        CompletedAt = at;
+    }
+}
+```
+
+- [ ] **Step 3: Write `ScanJobResult`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanJobResult
+{
+    public Guid Id { get; private set; }
+    public Guid ScanJobId { get; private set; }
+    public string RawStdout { get; private set; } = string.Empty;
+    public string RawStderr { get; private set; } = string.Empty;
+    public string ParsedJson { get; private set; } = string.Empty;
+    public DateTimeOffset CapturedAt { get; private set; }
+
+    private ScanJobResult() { }
+
+    public static ScanJobResult Create(Guid scanJobId, string rawStdout, string rawStderr, string parsedJson) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            ScanJobId = scanJobId,
+            RawStdout = rawStdout,
+            RawStderr = rawStderr,
+            ParsedJson = parsedJson,
+            CapturedAt = DateTimeOffset.UtcNow,
+        };
+}
+```
+
+- [ ] **Step 4: Write `ScanJobValidationIssue`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class ScanJobValidationIssue
+{
+    public Guid Id { get; private set; }
+    public Guid ScanJobId { get; private set; }
+    public string FieldPath { get; private set; } = string.Empty;
+    public string Message { get; private set; } = string.Empty;
+    public int EntryIndex { get; private set; }
+
+    private ScanJobValidationIssue() { }
+
+    public static ScanJobValidationIssue Create(Guid scanJobId, string fieldPath, string message, int entryIndex) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            ScanJobId = scanJobId,
+            FieldPath = fieldPath,
+            Message = message,
+            EntryIndex = entryIndex,
+        };
+}
+```
+
+- [ ] **Step 5: Write `StagedAuthenticatedScanSoftware`**
+
+```csharp
+namespace PatchHound.Core.Entities.AuthenticatedScans;
+
+public class StagedAuthenticatedScanSoftware
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid ScanJobId { get; private set; }
+    public Guid DeviceAssetId { get; private set; }
+    public Guid ScanProfileId { get; private set; }
+    public string CanonicalName { get; private set; } = string.Empty;
+    public string CanonicalProductKey { get; private set; } = string.Empty;
+    public string? CanonicalVendor { get; private set; }
+    public string? Category { get; private set; }
+    public string? PrimaryCpe23Uri { get; private set; }
+    public string? DetectedVersion { get; private set; }
+    public DateTimeOffset StagedAt { get; private set; }
+
+    private StagedAuthenticatedScanSoftware() { }
+
+    public static StagedAuthenticatedScanSoftware Create(
+        Guid tenantId, Guid scanJobId, Guid deviceAssetId, Guid scanProfileId,
+        string canonicalName, string canonicalProductKey,
+        string? canonicalVendor, string? category, string? primaryCpe23Uri, string? detectedVersion) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ScanJobId = scanJobId,
+            DeviceAssetId = deviceAssetId,
+            ScanProfileId = scanProfileId,
+            CanonicalName = canonicalName.Trim(),
+            CanonicalProductKey = canonicalProductKey.Trim(),
+            CanonicalVendor = string.IsNullOrWhiteSpace(canonicalVendor) ? null : canonicalVendor.Trim(),
+            Category = string.IsNullOrWhiteSpace(category) ? null : category.Trim(),
+            PrimaryCpe23Uri = string.IsNullOrWhiteSpace(primaryCpe23Uri) ? null : primaryCpe23Uri.Trim(),
+            DetectedVersion = string.IsNullOrWhiteSpace(detectedVersion) ? null : detectedVersion.Trim(),
+            StagedAt = DateTimeOffset.UtcNow,
+        };
+}
+```
+
+- [ ] **Step 6: Build & commit**
+
+```bash
+dotnet build src/PatchHound.Core
+git add src/PatchHound.Core/Entities/AuthenticatedScans/
+git commit -m "feat: add scan run, job, result, issue, and staging entities"
+```
+
+---
+
+## Task 7: EF configurations + register DbSets
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/AuthenticatedScans/` (11 files)
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+
+- [ ] **Step 1: Create all configurations**
+
+Create one file per entity following the `AdvancedToolConfiguration` pattern. Full contents:
+
+`ConnectionProfileConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ConnectionProfileConfiguration : IEntityTypeConfiguration<ConnectionProfile>
+{
+    public void Configure(EntityTypeBuilder<ConnectionProfile> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Name).HasMaxLength(256).IsRequired();
+        b.Property(x => x.Description).HasColumnType("text").IsRequired();
+        b.Property(x => x.Kind).HasMaxLength(32).IsRequired();
+        b.Property(x => x.SshHost).HasMaxLength(512).IsRequired();
+        b.Property(x => x.SshUsername).HasMaxLength(256).IsRequired();
+        b.Property(x => x.AuthMethod).HasMaxLength(32).IsRequired();
+        b.Property(x => x.SecretRef).HasMaxLength(512).IsRequired();
+        b.Property(x => x.HostKeyFingerprint).HasMaxLength(128);
+        b.HasIndex(x => new { x.TenantId, x.Name }).IsUnique();
+    }
+}
+```
+
+`ScanRunnerConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanRunnerConfiguration : IEntityTypeConfiguration<ScanRunner>
+{
+    public void Configure(EntityTypeBuilder<ScanRunner> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Name).HasMaxLength(256).IsRequired();
+        b.Property(x => x.Description).HasColumnType("text").IsRequired();
+        b.Property(x => x.SecretHash).HasMaxLength(128).IsRequired();
+        b.Property(x => x.Version).HasMaxLength(128).IsRequired();
+        b.HasIndex(x => new { x.TenantId, x.Name }).IsUnique();
+    }
+}
+```
+
+`ScanningToolConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanningToolConfiguration : IEntityTypeConfiguration<ScanningTool>
+{
+    public void Configure(EntityTypeBuilder<ScanningTool> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Name).HasMaxLength(256).IsRequired();
+        b.Property(x => x.Description).HasColumnType("text").IsRequired();
+        b.Property(x => x.ScriptType).HasMaxLength(32).IsRequired();
+        b.Property(x => x.InterpreterPath).HasMaxLength(512).IsRequired();
+        b.Property(x => x.OutputModel).HasMaxLength(64).IsRequired();
+        b.HasIndex(x => new { x.TenantId, x.Name }).IsUnique();
+    }
+}
+```
+
+`ScanningToolVersionConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanningToolVersionConfiguration : IEntityTypeConfiguration<ScanningToolVersion>
+{
+    public void Configure(EntityTypeBuilder<ScanningToolVersion> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.ScriptContent).HasColumnType("text").IsRequired();
+        b.HasIndex(x => new { x.ScanningToolId, x.VersionNumber }).IsUnique();
+    }
+}
+```
+
+`ScanProfileConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanProfileConfiguration : IEntityTypeConfiguration<ScanProfile>
+{
+    public void Configure(EntityTypeBuilder<ScanProfile> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Name).HasMaxLength(256).IsRequired();
+        b.Property(x => x.Description).HasColumnType("text").IsRequired();
+        b.Property(x => x.CronSchedule).HasMaxLength(128).IsRequired();
+        b.HasIndex(x => new { x.TenantId, x.Name }).IsUnique();
+    }
+}
+```
+
+`ScanProfileToolConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanProfileToolConfiguration : IEntityTypeConfiguration<ScanProfileTool>
+{
+    public void Configure(EntityTypeBuilder<ScanProfileTool> b)
+    {
+        b.HasKey(x => new { x.ScanProfileId, x.ScanningToolId });
+    }
+}
+```
+
+`AssetScanProfileAssignmentConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class AssetScanProfileAssignmentConfiguration : IEntityTypeConfiguration<AssetScanProfileAssignment>
+{
+    public void Configure(EntityTypeBuilder<AssetScanProfileAssignment> b)
+    {
+        b.HasKey(x => new { x.AssetId, x.ScanProfileId });
+        b.HasIndex(x => new { x.TenantId, x.ScanProfileId });
+    }
+}
+```
+
+`AuthenticatedScanRunConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class AuthenticatedScanRunConfiguration : IEntityTypeConfiguration<AuthenticatedScanRun>
+{
+    public void Configure(EntityTypeBuilder<AuthenticatedScanRun> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.TriggerKind).HasMaxLength(32).IsRequired();
+        b.Property(x => x.Status).HasMaxLength(32).IsRequired();
+        b.HasIndex(x => new { x.TenantId, x.ScanProfileId, x.StartedAt });
+    }
+}
+```
+
+`ScanJobConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanJobConfiguration : IEntityTypeConfiguration<ScanJob>
+{
+    public void Configure(EntityTypeBuilder<ScanJob> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.ScanningToolVersionIdsJson).HasColumnType("text").IsRequired();
+        b.Property(x => x.Status).HasMaxLength(32).IsRequired();
+        b.Property(x => x.ErrorMessage).HasColumnType("text").IsRequired();
+        b.HasIndex(x => new { x.ScanRunnerId, x.Status });
+        b.HasIndex(x => x.RunId);
+    }
+}
+```
+
+`ScanJobResultConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanJobResultConfiguration : IEntityTypeConfiguration<ScanJobResult>
+{
+    public void Configure(EntityTypeBuilder<ScanJobResult> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.RawStdout).HasColumnType("text").IsRequired();
+        b.Property(x => x.RawStderr).HasColumnType("text").IsRequired();
+        b.Property(x => x.ParsedJson).HasColumnType("text").IsRequired();
+        b.HasIndex(x => x.ScanJobId).IsUnique();
+    }
+}
+```
+
+`ScanJobValidationIssueConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class ScanJobValidationIssueConfiguration : IEntityTypeConfiguration<ScanJobValidationIssue>
+{
+    public void Configure(EntityTypeBuilder<ScanJobValidationIssue> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.FieldPath).HasMaxLength(256).IsRequired();
+        b.Property(x => x.Message).HasColumnType("text").IsRequired();
+        b.HasIndex(x => x.ScanJobId);
+    }
+}
+```
+
+`StagedAuthenticatedScanSoftwareConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities.AuthenticatedScans;
+
+namespace PatchHound.Infrastructure.Data.Configurations.AuthenticatedScans;
+
+public class StagedAuthenticatedScanSoftwareConfiguration : IEntityTypeConfiguration<StagedAuthenticatedScanSoftware>
+{
+    public void Configure(EntityTypeBuilder<StagedAuthenticatedScanSoftware> b)
+    {
+        b.HasKey(x => x.Id);
+        b.Property(x => x.CanonicalName).HasMaxLength(1024).IsRequired();
+        b.Property(x => x.CanonicalProductKey).HasMaxLength(1024).IsRequired();
+        b.Property(x => x.CanonicalVendor).HasMaxLength(1024);
+        b.Property(x => x.Category).HasMaxLength(1024);
+        b.Property(x => x.PrimaryCpe23Uri).HasMaxLength(1024);
+        b.Property(x => x.DetectedVersion).HasMaxLength(256);
+        b.HasIndex(x => x.ScanJobId);
+    }
+}
+```
+
+- [ ] **Step 2: Register DbSets in `PatchHoundDbContext`**
+
+Add `using PatchHound.Core.Entities.AuthenticatedScans;` at the top and add these DbSets after the existing ones:
+
+```csharp
+public DbSet<ConnectionProfile> ConnectionProfiles => Set<ConnectionProfile>();
+public DbSet<ScanRunner> ScanRunners => Set<ScanRunner>();
+public DbSet<ScanningTool> ScanningTools => Set<ScanningTool>();
+public DbSet<ScanningToolVersion> ScanningToolVersions => Set<ScanningToolVersion>();
+public DbSet<ScanProfile> ScanProfiles => Set<ScanProfile>();
+public DbSet<ScanProfileTool> ScanProfileTools => Set<ScanProfileTool>();
+public DbSet<AssetScanProfileAssignment> AssetScanProfileAssignments => Set<AssetScanProfileAssignment>();
+public DbSet<AuthenticatedScanRun> AuthenticatedScanRuns => Set<AuthenticatedScanRun>();
+public DbSet<ScanJob> ScanJobs => Set<ScanJob>();
+public DbSet<ScanJobResult> ScanJobResults => Set<ScanJobResult>();
+public DbSet<ScanJobValidationIssue> ScanJobValidationIssues => Set<ScanJobValidationIssue>();
+public DbSet<StagedAuthenticatedScanSoftware> StagedAuthenticatedScanSoftware => Set<StagedAuthenticatedScanSoftware>();
+```
+
+Confirm configurations auto-register: check `OnModelCreating` in `PatchHoundDbContext.cs`. If it calls `modelBuilder.ApplyConfigurationsFromAssembly(...)` the new configs pick up automatically. If not, add `modelBuilder.ApplyConfiguration(new ConnectionProfileConfiguration());` etc. (inspect existing `OnModelCreating` to match style).
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build PatchHound.slnx`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Data/Configurations/AuthenticatedScans/ src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+git commit -m "feat: add EF configurations and DbSets for authenticated scans"
+```
+
+---
+
+## Task 8: EF migration
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Data/Migrations/*_AddAuthenticatedScans.cs` (generated)
+
+- [ ] **Step 1: Generate migration**
+
+Run:
+```bash
+cd src/PatchHound.Infrastructure
+dotnet ef migrations add AddAuthenticatedScans --startup-project ../PatchHound.Api
+```
+
+Expected: migration files created under `Data/Migrations/`.
+
+- [ ] **Step 2: Inspect migration**
+
+Open the newly generated `*_AddAuthenticatedScans.cs`. Confirm all 12 new tables are created with expected columns, indexes, and FK constraints.
+
+- [ ] **Step 3: Apply migration to test DB**
+
+Run:
+```bash
+dotnet ef database update --startup-project ../PatchHound.Api
+```
+
+Expected: migration applies without error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ../..
+git add src/PatchHound.Infrastructure/Data/Migrations/
+git commit -m "feat: add migration for authenticated scans tables"
+```
+
+---
+
+## Task 9: `ConnectionProfileSecretWriter` — OpenBao writes
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/AuthenticatedScans/ConnectionProfileSecretWriter.cs`
+
+Stores SSH credentials in OpenBao at `tenants/{tenantId}/auth-scan-connections/{profileId}` using the existing `ISecretStore`.
+
+- [ ] **Step 1: Write the class**
+
+```csharp
+using PatchHound.Infrastructure.Secrets;
+
+namespace PatchHound.Infrastructure.AuthenticatedScans;
+
+public class ConnectionProfileSecretWriter
+{
+    private readonly ISecretStore _secretStore;
+
+    public ConnectionProfileSecretWriter(ISecretStore secretStore)
+    {
+        _secretStore = secretStore;
+    }
+
+    public static string BuildPath(Guid tenantId, Guid profileId) =>
+        $"tenants/{tenantId}/auth-scan-connections/{profileId}";
+
+    public async Task<string> WritePasswordAsync(Guid tenantId, Guid profileId, string password, CancellationToken ct)
+    {
+        var path = BuildPath(tenantId, profileId);
+        await _secretStore.PutSecretAsync(path, new Dictionary<string, string> { ["password"] = password }, ct);
+        return path;
+    }
+
+    public async Task<string> WritePrivateKeyAsync(
+        Guid tenantId, Guid profileId, string privateKey, string? passphrase, CancellationToken ct)
+    {
+        var path = BuildPath(tenantId, profileId);
+        var dict = new Dictionary<string, string> { ["privateKey"] = privateKey };
+        if (!string.IsNullOrEmpty(passphrase)) dict["passphrase"] = passphrase;
+        await _secretStore.PutSecretAsync(path, dict, ct);
+        return path;
+    }
+
+    public async Task DeleteAsync(Guid tenantId, Guid profileId, CancellationToken ct)
+    {
+        await _secretStore.DeleteSecretPathAsync(BuildPath(tenantId, profileId), ct);
+    }
+}
+```
+
+- [ ] **Step 2: Register in DI**
+
+Find `src/PatchHound.Infrastructure/DependencyInjection.cs`. Add `services.AddScoped<ConnectionProfileSecretWriter>();` in the appropriate extension method.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build PatchHound.slnx`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/ConnectionProfileSecretWriter.cs src/PatchHound.Infrastructure/DependencyInjection.cs
+git commit -m "feat: add ConnectionProfileSecretWriter for OpenBao secret handling"
+```
+
+---
+
+## Task 10: `AuthenticatedScanOutputValidator` with tests (TDD)
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanOutputValidator.cs`
+- Create: `tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/AuthenticatedScanOutputValidatorTests.cs`
+
+Validates parsed JSON per §7.1/§7.2 of the spec.
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using PatchHound.Infrastructure.AuthenticatedScans;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.AuthenticatedScans;
+
+public class AuthenticatedScanOutputValidatorTests
+{
+    private readonly AuthenticatedScanOutputValidator _sut = new();
+
+    [Fact]
+    public void Validate_returns_all_entries_when_valid()
+    {
+        var json = """{"software":[{"canonicalName":"nginx","canonicalProductKey":"nginx:nginx","detectedVersion":"1.24.0"}]}""";
+        var result = _sut.Validate(json);
+        Assert.Empty(result.Issues);
+        Assert.Single(result.ValidEntries);
+        Assert.Equal("nginx", result.ValidEntries[0].CanonicalName);
+        Assert.Equal("1.24.0", result.ValidEntries[0].DetectedVersion);
+    }
+
+    [Fact]
+    public void Validate_flags_missing_required_fields_and_keeps_valid_entries()
+    {
+        var json = """
+        {"software":[
+          {"canonicalName":"nginx","canonicalProductKey":"nginx:nginx"},
+          {"canonicalName":""},
+          {"canonicalProductKey":"acme:foo"}
+        ]}""";
+        var result = _sut.Validate(json);
+        Assert.Single(result.ValidEntries);
+        Assert.Equal(2, result.Issues.Count);
+        Assert.Contains(result.Issues, i => i.EntryIndex == 1 && i.FieldPath.Contains("canonicalName"));
+        Assert.Contains(result.Issues, i => i.EntryIndex == 2 && i.FieldPath.Contains("canonicalName"));
+    }
+
+    [Fact]
+    public void Validate_rejects_missing_software_array()
+    {
+        var json = """{"notSoftware":[]}""";
+        var result = _sut.Validate(json);
+        Assert.True(result.FatalError);
+        Assert.Contains("software", result.FatalErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_rejects_non_array_software()
+    {
+        var result = _sut.Validate("""{"software":"not-an-array"}""");
+        Assert.True(result.FatalError);
+    }
+
+    [Fact]
+    public void Validate_rejects_entry_count_over_5000()
+    {
+        var entries = string.Join(",", Enumerable.Range(0, 5001)
+            .Select(i => $$"""{"canonicalName":"a","canonicalProductKey":"k{{i}}"}"""));
+        var json = $$"""{"software":[{{entries}}]}""";
+        var result = _sut.Validate(json);
+        Assert.True(result.FatalError);
+        Assert.Contains("5000", result.FatalErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_rejects_string_over_1024_chars()
+    {
+        var longStr = new string('x', 1025);
+        var json = $$"""{"software":[{"canonicalName":"{{longStr}}","canonicalProductKey":"k"}]}""";
+        var result = _sut.Validate(json);
+        Assert.Empty(result.ValidEntries);
+        Assert.Single(result.Issues);
+        Assert.Contains("1024", result.Issues[0].Message);
+    }
+
+    [Fact]
+    public void Validate_rejects_invalid_json()
+    {
+        var result = _sut.Validate("not json");
+        Assert.True(result.FatalError);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~AuthenticatedScanOutputValidatorTests`
+Expected: FAIL (class doesn't exist).
+
+- [ ] **Step 3: Implement the validator**
+
+```csharp
+using System.Text.Json;
+
+namespace PatchHound.Infrastructure.AuthenticatedScans;
+
+public record ValidatedSoftwareEntry(
+    string CanonicalName,
+    string CanonicalProductKey,
+    string? CanonicalVendor,
+    string? Category,
+    string? PrimaryCpe23Uri,
+    string? DetectedVersion);
+
+public record ValidationIssueRecord(int EntryIndex, string FieldPath, string Message);
+
+public record OutputValidationResult(
+    bool FatalError,
+    string FatalErrorMessage,
+    List<ValidatedSoftwareEntry> ValidEntries,
+    List<ValidationIssueRecord> Issues);
+
+public class AuthenticatedScanOutputValidator
+{
+    private const int MaxEntries = 5000;
+    private const int MaxStringLength = 1024;
+
+    public OutputValidationResult Validate(string json)
+    {
+        var valid = new List<ValidatedSoftwareEntry>();
+        var issues = new List<ValidationIssueRecord>();
+
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(json); }
+        catch (JsonException ex) { return Fatal($"invalid JSON: {ex.Message}"); }
+        using (doc)
+        {
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return Fatal("root must be an object");
+            if (!doc.RootElement.TryGetProperty("software", out var arr))
+                return Fatal("missing 'software' property");
+            if (arr.ValueKind != JsonValueKind.Array)
+                return Fatal("'software' must be an array");
+            var count = arr.GetArrayLength();
+            if (count > MaxEntries)
+                return Fatal($"entry count {count} exceeds limit of {MaxEntries}");
+
+            var index = 0;
+            foreach (var element in arr.EnumerateArray())
+            {
+                var entryValid = TryValidateEntry(element, index, issues, out var entry);
+                if (entryValid) valid.Add(entry!);
+                index++;
+            }
+        }
+
+        return new OutputValidationResult(false, string.Empty, valid, issues);
+    }
+
+    private static OutputValidationResult Fatal(string msg) =>
+        new(true, msg, new(), new());
+
+    private static bool TryValidateEntry(JsonElement el, int index, List<ValidationIssueRecord> issues, out ValidatedSoftwareEntry? entry)
+    {
+        entry = null;
+        if (el.ValueKind != JsonValueKind.Object)
+        {
+            issues.Add(new(index, "$", "entry must be an object"));
+            return false;
+        }
+
+        var name = ReadRequiredString(el, "canonicalName", index, issues);
+        var key = ReadRequiredString(el, "canonicalProductKey", index, issues);
+        var vendor = ReadOptionalString(el, "canonicalVendor", index, issues);
+        var category = ReadOptionalString(el, "category", index, issues);
+        var cpe = ReadOptionalString(el, "primaryCpe23Uri", index, issues);
+        var version = ReadOptionalString(el, "detectedVersion", index, issues);
+
+        if (name is null || key is null) return false;
+        entry = new ValidatedSoftwareEntry(name, key, vendor, category, cpe, version);
+        return true;
+    }
+
+    private static string? ReadRequiredString(JsonElement el, string prop, int index, List<ValidationIssueRecord> issues)
+    {
+        if (!el.TryGetProperty(prop, out var v) || v.ValueKind == JsonValueKind.Null)
+        {
+            issues.Add(new(index, $"$.software[{index}].{prop}", $"missing required field '{prop}'"));
+            return null;
+        }
+        if (v.ValueKind != JsonValueKind.String)
+        {
+            issues.Add(new(index, $"$.software[{index}].{prop}", $"'{prop}' must be a string"));
+            return null;
+        }
+        var s = v.GetString() ?? "";
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            issues.Add(new(index, $"$.software[{index}].{prop}", $"'{prop}' cannot be empty"));
+            return null;
+        }
+        if (s.Length > MaxStringLength)
+        {
+            issues.Add(new(index, $"$.software[{index}].{prop}", $"'{prop}' exceeds {MaxStringLength} chars"));
+            return null;
+        }
+        return s;
+    }
+
+    private static string? ReadOptionalString(JsonElement el, string prop, int index, List<ValidationIssueRecord> issues)
+    {
+        if (!el.TryGetProperty(prop, out var v) || v.ValueKind == JsonValueKind.Null) return null;
+        if (v.ValueKind != JsonValueKind.String)
+        {
+            issues.Add(new(index, $"$.software[{index}].{prop}", $"'{prop}' must be a string"));
+            return null;
+        }
+        var s = v.GetString() ?? "";
+        if (s.Length > MaxStringLength)
+        {
+            issues.Add(new(index, $"$.software[{index}].{prop}", $"'{prop}' exceeds {MaxStringLength} chars"));
+            return null;
+        }
+        return s;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~AuthenticatedScanOutputValidatorTests`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanOutputValidator.cs tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/AuthenticatedScanOutputValidatorTests.cs
+git commit -m "feat: add scan output validator with tests"
+```
+
+---
+
+## Task 11: `AuthenticatedScanIngestionService` — staging + merge
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs`
+- Create: `tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionServiceTests.cs`
+
+Validates a job's parsed JSON, writes staging rows, merges into `NormalizedSoftware` + `NormalizedSoftwareInstallation` with per-source deactivation, updates the job's final status.
+
+Read §7 of the spec before writing this service.
+
+- [ ] **Step 1: Examine how Defender's staging → merge logic upserts `NormalizedSoftware` today**
+
+Run: `grep -r "NormalizedSoftware" src/PatchHound.Infrastructure --include="*.cs" -l`
+Open the hits, locate the logic that creates/updates `NormalizedSoftware` + `NormalizedSoftwareInstallation` + `DeviceSoftwareInstallation` + `TenantSoftware` rows. The new service must upsert these rows the same way, but scoped to a single `(tenantId, deviceAssetId, SourceSystem=AuthenticatedScan)`. If the existing logic lives in a shared helper, **reuse it**. If it's private to the Defender pipeline, extract it to a small shared helper class (e.g. `NormalizedSoftwareMergeHelper`) in `src/PatchHound.Infrastructure/AuthenticatedScans/` that both pipelines call. Record the decision in this task's commit message.
+
+- [ ] **Step 2: Write failing integration test (happy path, Defender coexistence)**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.AuthenticatedScans;
+
+public class AuthenticatedScanIngestionServiceTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private AuthenticatedScanIngestionService _sut = null!;
+    private Guid _tenantId = Guid.NewGuid();
+    private Guid _deviceAssetId;
+    private Guid _scanProfileId = Guid.NewGuid();
+    private Guid _scanJobId = Guid.NewGuid();
+
+    public async Task InitializeAsync()
+    {
+        _db = TestDbContextFactory.CreateInMemory(); // use existing shared factory
+        // seed: tenant, device asset
+        _deviceAssetId = await TestData.SeedDevice(_db, _tenantId, "host-1");
+        var job = ScanJob.Create(_tenantId, Guid.NewGuid(), Guid.NewGuid(), _deviceAssetId, Guid.NewGuid(), "[]");
+        // reflection or internal setter to set Id = _scanJobId, or use returned Id
+        _scanJobId = job.Id;
+        _db.ScanJobs.Add(job);
+        _db.ScanJobResults.Add(ScanJobResult.Create(job.Id, "stdout", "", "{}"));
+        await _db.SaveChangesAsync();
+        _sut = new AuthenticatedScanIngestionService(_db, new AuthenticatedScanOutputValidator());
+    }
+
+    public Task DisposeAsync() { _db.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public async Task Ingest_creates_normalized_software_installation_for_valid_entry()
+    {
+        var json = """{"software":[{"canonicalName":"nginx","canonicalProductKey":"nginx:nginx","detectedVersion":"1.24.0"}]}""";
+        await UpdateJobResult(json);
+
+        var summary = await _sut.IngestAsync(_scanJobId, _scanProfileId, CancellationToken.None);
+
+        Assert.Equal(1, summary.EntriesIngested);
+        var installation = await _db.NormalizedSoftwareInstallations
+            .SingleAsync(i => i.DeviceAssetId == _deviceAssetId && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan);
+        Assert.Equal("1.24.0", installation.DetectedVersion);
+        Assert.True(installation.IsActive);
+    }
+
+    [Fact]
+    public async Task Ingest_deactivates_previously_reported_software_not_in_new_run()
+    {
+        // first run: nginx present
+        await UpdateJobResult("""{"software":[{"canonicalName":"nginx","canonicalProductKey":"nginx:nginx"}]}""");
+        await _sut.IngestAsync(_scanJobId, _scanProfileId, CancellationToken.None);
+
+        // second run: nginx absent, httpd present
+        var job2 = ScanJob.Create(_tenantId, Guid.NewGuid(), Guid.NewGuid(), _deviceAssetId, Guid.NewGuid(), "[]");
+        _db.ScanJobs.Add(job2);
+        _db.ScanJobResults.Add(ScanJobResult.Create(job2.Id, "", "",
+            """{"software":[{"canonicalName":"httpd","canonicalProductKey":"apache:httpd"}]}"""));
+        await _db.SaveChangesAsync();
+
+        await _sut.IngestAsync(job2.Id, _scanProfileId, CancellationToken.None);
+
+        var nginx = await _db.NormalizedSoftwareInstallations
+            .SingleAsync(i => i.DeviceAssetId == _deviceAssetId
+                && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan
+                && EF.Property<string>(i, "CanonicalProductKey") == "nginx:nginx");
+        Assert.False(nginx.IsActive);
+        var httpd = await _db.NormalizedSoftwareInstallations
+            .SingleAsync(i => i.DeviceAssetId == _deviceAssetId && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan
+                && EF.Property<string>(i, "CanonicalProductKey") == "apache:httpd");
+        Assert.True(httpd.IsActive);
+    }
+
+    [Fact]
+    public async Task Ingest_does_not_touch_defender_source_rows()
+    {
+        // pre-seed a Defender row for the same device+software
+        await TestData.SeedDefenderInstallation(_db, _tenantId, _deviceAssetId, "nginx:nginx", "1.20.0");
+
+        await UpdateJobResult("""{"software":[{"canonicalName":"nginx","canonicalProductKey":"nginx:nginx","detectedVersion":"1.24.0"}]}""");
+        await _sut.IngestAsync(_scanJobId, _scanProfileId, CancellationToken.None);
+
+        var defender = await _db.NormalizedSoftwareInstallations
+            .SingleAsync(i => i.DeviceAssetId == _deviceAssetId && i.SourceSystem == SoftwareIdentitySourceSystem.Defender);
+        Assert.Equal("1.20.0", defender.DetectedVersion);
+        Assert.True(defender.IsActive);
+
+        var auth = await _db.NormalizedSoftwareInstallations
+            .SingleAsync(i => i.DeviceAssetId == _deviceAssetId && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan);
+        Assert.Equal("1.24.0", auth.DetectedVersion);
+    }
+
+    [Fact]
+    public async Task Ingest_records_validation_issues_and_ingests_valid_entries()
+    {
+        await UpdateJobResult("""
+            {"software":[
+              {"canonicalName":"nginx","canonicalProductKey":"nginx:nginx"},
+              {"canonicalName":""}
+            ]}""");
+        var summary = await _sut.IngestAsync(_scanJobId, _scanProfileId, CancellationToken.None);
+        Assert.Equal(1, summary.EntriesIngested);
+        var issues = await _db.ScanJobValidationIssues.Where(i => i.ScanJobId == _scanJobId).ToListAsync();
+        Assert.Single(issues);
+    }
+
+    [Fact]
+    public async Task Ingest_fails_job_when_zero_valid_entries()
+    {
+        await UpdateJobResult("""{"software":[{"canonicalName":""}]}""");
+        var summary = await _sut.IngestAsync(_scanJobId, _scanProfileId, CancellationToken.None);
+        Assert.Equal(0, summary.EntriesIngested);
+        Assert.True(summary.JobFailed);
+        var job = await _db.ScanJobs.SingleAsync(j => j.Id == _scanJobId);
+        Assert.Equal(ScanJobStatuses.Failed, job.Status);
+    }
+
+    private async Task UpdateJobResult(string json)
+    {
+        var r = await _db.ScanJobResults.SingleAsync(x => x.ScanJobId == _scanJobId);
+        // update ParsedJson via reflection or re-create — depends on entity model; simplest: remove + add
+        _db.ScanJobResults.Remove(r);
+        _db.ScanJobResults.Add(ScanJobResult.Create(_scanJobId, "", "", json));
+        await _db.SaveChangesAsync();
+    }
+}
+```
+
+Note: this uses a `TestDbContextFactory.CreateInMemory()` and `TestData.SeedDevice` / `TestData.SeedDefenderInstallation` helpers — check `tests/PatchHound.Tests/TestData/` for existing equivalents and reuse them; if they don't exist for these cases, add them to the shared TestData module.
+
+- [ ] **Step 3: Run tests — expected to fail (service doesn't exist)**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~AuthenticatedScanIngestionServiceTests`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the service**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.AuthenticatedScans;
+
+public record IngestionSummary(int EntriesIngested, bool JobFailed, string? ErrorMessage);
+
+public class AuthenticatedScanIngestionService
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly AuthenticatedScanOutputValidator _validator;
+
+    public AuthenticatedScanIngestionService(PatchHoundDbContext db, AuthenticatedScanOutputValidator validator)
+    {
+        _db = db;
+        _validator = validator;
+    }
+
+    public async Task<IngestionSummary> IngestAsync(Guid scanJobId, Guid scanProfileId, CancellationToken ct)
+    {
+        var job = await _db.ScanJobs.SingleAsync(j => j.Id == scanJobId, ct);
+        var result = await _db.ScanJobResults.SingleAsync(r => r.ScanJobId == scanJobId, ct);
+
+        var validation = _validator.Validate(result.ParsedJson);
+        if (validation.FatalError)
+        {
+            job.CompleteFailed(ScanJobStatuses.Failed, $"output validation failed: {validation.FatalErrorMessage}", DateTimeOffset.UtcNow);
+            await _db.SaveChangesAsync(ct);
+            return new IngestionSummary(0, true, validation.FatalErrorMessage);
+        }
+
+        foreach (var issue in validation.Issues)
+        {
+            _db.ScanJobValidationIssues.Add(
+                ScanJobValidationIssue.Create(scanJobId, issue.FieldPath, issue.Message, issue.EntryIndex));
+        }
+
+        if (validation.ValidEntries.Count == 0)
+        {
+            job.CompleteFailed(ScanJobStatuses.Failed, $"all {validation.Issues.Count} entries failed validation", DateTimeOffset.UtcNow);
+            await _db.SaveChangesAsync(ct);
+            return new IngestionSummary(0, true, "all entries invalid");
+        }
+
+        // Stage
+        foreach (var entry in validation.ValidEntries)
+        {
+            _db.StagedAuthenticatedScanSoftware.Add(
+                StagedAuthenticatedScanSoftware.Create(
+                    job.TenantId, scanJobId, job.AssetId, scanProfileId,
+                    entry.CanonicalName, entry.CanonicalProductKey,
+                    entry.CanonicalVendor, entry.Category, entry.PrimaryCpe23Uri, entry.DetectedVersion));
+        }
+
+        // Merge
+        await MergeAsync(job.TenantId, job.AssetId, validation.ValidEntries, ct);
+
+        job.CompleteSucceeded(
+            stdoutBytes: result.RawStdout.Length,
+            stderrBytes: result.RawStderr.Length,
+            entriesIngested: validation.ValidEntries.Count,
+            at: DateTimeOffset.UtcNow);
+
+        await _db.SaveChangesAsync(ct);
+        return new IngestionSummary(validation.ValidEntries.Count, false, null);
+    }
+
+    private async Task MergeAsync(Guid tenantId, Guid deviceAssetId, List<ValidatedSoftwareEntry> entries, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var e in entries)
+        {
+            seenKeys.Add(e.CanonicalProductKey);
+
+            // 1. Upsert NormalizedSoftware by CanonicalProductKey
+            var normalized = await _db.NormalizedSoftware
+                .SingleOrDefaultAsync(n => n.CanonicalProductKey == e.CanonicalProductKey, ct);
+            if (normalized is null)
+            {
+                normalized = NormalizedSoftware.Create(
+                    e.CanonicalName, e.CanonicalVendor, e.Category, e.CanonicalProductKey, e.PrimaryCpe23Uri,
+                    SoftwareNormalizationMethod.ExternalSource, SoftwareNormalizationConfidence.High, now);
+                _db.NormalizedSoftware.Add(normalized);
+                await _db.SaveChangesAsync(ct);
+            }
+
+            // 2. Ensure TenantSoftware + software Asset exist.
+            //    Reuse existing helper (see Step 1). If not extracted, add a helper that
+            //    returns (tenantSoftwareId, softwareAssetId) for a given (tenantId, normalizedSoftwareId).
+            var (tenantSoftwareId, softwareAssetId) = await EnsureTenantSoftwareAsync(tenantId, normalized.Id, ct);
+
+            // 3. Upsert NormalizedSoftwareInstallation by (tenantId, deviceAssetId, tenantSoftwareId, SourceSystem)
+            var installation = await _db.NormalizedSoftwareInstallations
+                .SingleOrDefaultAsync(i => i.TenantId == tenantId
+                    && i.DeviceAssetId == deviceAssetId
+                    && i.TenantSoftwareId == tenantSoftwareId
+                    && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan, ct);
+
+            if (installation is null)
+            {
+                installation = NormalizedSoftwareInstallation.Create(
+                    tenantId, snapshotId: null, tenantSoftwareId, softwareAssetId, deviceAssetId,
+                    SoftwareIdentitySourceSystem.AuthenticatedScan, e.DetectedVersion,
+                    firstSeenAt: now, lastSeenAt: now, removedAt: null, isActive: true, currentEpisodeNumber: 1);
+                _db.NormalizedSoftwareInstallations.Add(installation);
+            }
+            else
+            {
+                installation.UpdateProjection(
+                    snapshotId: null, tenantSoftwareId, SoftwareIdentitySourceSystem.AuthenticatedScan,
+                    e.DetectedVersion,
+                    firstSeenAt: installation.FirstSeenAt, lastSeenAt: now, removedAt: null,
+                    isActive: true, currentEpisodeNumber: installation.CurrentEpisodeNumber);
+            }
+
+            // 4. Touch DeviceSoftwareInstallation
+            var dsi = await _db.DeviceSoftwareInstallations.SingleOrDefaultAsync(
+                d => d.TenantId == tenantId && d.DeviceAssetId == deviceAssetId && d.SoftwareAssetId == softwareAssetId, ct);
+            if (dsi is null)
+                _db.DeviceSoftwareInstallations.Add(DeviceSoftwareInstallation.Create(tenantId, deviceAssetId, softwareAssetId, now));
+            else
+                dsi.Touch(now);
+        }
+
+        // 5. Deactivate prior auth-scan rows for this device that are not in the current set.
+        var existing = await _db.NormalizedSoftwareInstallations
+            .Where(i => i.TenantId == tenantId
+                && i.DeviceAssetId == deviceAssetId
+                && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan
+                && i.IsActive)
+            .Join(_db.NormalizedSoftware, i => i.TenantSoftwareId /*via TenantSoftware->NormalizedSoftware*/, n => n.Id, (i, n) => new { i, n.CanonicalProductKey })
+            .ToListAsync(ct);
+
+        foreach (var row in existing.Where(r => !seenKeys.Contains(r.CanonicalProductKey)))
+        {
+            row.i.UpdateProjection(
+                snapshotId: null, row.i.TenantSoftwareId, SoftwareIdentitySourceSystem.AuthenticatedScan,
+                row.i.DetectedVersion,
+                firstSeenAt: row.i.FirstSeenAt, lastSeenAt: row.i.LastSeenAt, removedAt: now,
+                isActive: false, currentEpisodeNumber: row.i.CurrentEpisodeNumber);
+        }
+    }
+
+    private async Task<(Guid tenantSoftwareId, Guid softwareAssetId)> EnsureTenantSoftwareAsync(
+        Guid tenantId, Guid normalizedSoftwareId, CancellationToken ct)
+    {
+        // TODO (during implementation): replace this placeholder with a call into the existing
+        // helper identified in Task 11 Step 1. If extracted, call NormalizedSoftwareMergeHelper.EnsureTenantSoftwareAsync.
+        // If the existing Defender pipeline has this behavior inline, lift it into such a helper first.
+        throw new NotImplementedException(
+            "Implement using existing tenant-software ensure logic from the Defender ingestion pipeline. "
+            + "See Task 11 Step 1 for the refactor direction.");
+    }
+}
+```
+
+Note: the join in step 5 uses `TenantSoftwareId` as if it equals `NormalizedSoftware.Id` for notational convenience. In reality you must navigate through `TenantSoftware` → `NormalizedSoftwareId`. Adjust the query to join `NormalizedSoftwareInstallation.TenantSoftwareId` → `TenantSoftware.Id`, then `TenantSoftware.NormalizedSoftwareId` → `NormalizedSoftware.Id`.
+
+- [ ] **Step 5: Register service in DI**
+
+In `src/PatchHound.Infrastructure/DependencyInjection.cs`:
+
+```csharp
+services.AddScoped<AuthenticatedScanOutputValidator>();
+services.AddScoped<AuthenticatedScanIngestionService>();
+```
+
+- [ ] **Step 6: Run tests until green**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~AuthenticatedScanIngestionServiceTests`
+Expected: all pass. Fix join/ensure-tenant-software logic until green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs src/PatchHound.Infrastructure/DependencyInjection.cs tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionServiceTests.cs
+git commit -m "feat: add AuthenticatedScanIngestionService with staging+merge and per-source deactivation"
+```
+
+---
+
+## Task 12: `ScanJobDispatcher` with tests (TDD)
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/AuthenticatedScans/ScanJobDispatcher.cs`
+- Create: `tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/ScanJobDispatcherTests.cs`
+
+Per §6.2 of the spec: creates a run, enumerates assigned assets, snapshots tool version ids, creates `ScanJob` per asset. Rejects when profile has an active non-terminal run.
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.AuthenticatedScans;
+
+public class ScanJobDispatcherTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private ScanJobDispatcher _sut = null!;
+    private Guid _tenantId = Guid.NewGuid();
+    private ScanProfile _profile = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = TestDbContextFactory.CreateInMemory();
+        var runnerId = Guid.NewGuid();
+        var connId = Guid.NewGuid();
+        _db.ScanRunners.Add(ScanRunner.Create(_tenantId, "r1", "", "hash"));
+        _db.ConnectionProfiles.Add(ConnectionProfile.Create(_tenantId, "c1", "", "h", 22, "u", "password", "path", null));
+        _profile = ScanProfile.Create(_tenantId, "p1", "", "", connId, runnerId, true);
+        _db.ScanProfiles.Add(_profile);
+
+        // one tool with a current version
+        var tool = ScanningTool.Create(_tenantId, "t1", "", "python", "/usr/bin/python3", 300, "NormalizedSoftware");
+        var v = ScanningToolVersion.Create(tool.Id, 1, "print('hi')", Guid.NewGuid());
+        tool.SetCurrentVersion(v.Id);
+        _db.ScanningTools.Add(tool);
+        _db.ScanningToolVersions.Add(v);
+        _db.ScanProfileTools.Add(ScanProfileTool.Create(_profile.Id, tool.Id, 0));
+        await _db.SaveChangesAsync();
+
+        _sut = new ScanJobDispatcher(_db);
+    }
+
+    public Task DisposeAsync() { _db.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public async Task StartRun_creates_one_job_per_assigned_asset()
+    {
+        var a1 = await TestData.SeedDevice(_db, _tenantId, "h1");
+        var a2 = await TestData.SeedDevice(_db, _tenantId, "h2");
+        _db.AssetScanProfileAssignments.Add(AssetScanProfileAssignment.Create(_tenantId, a1, _profile.Id, null));
+        _db.AssetScanProfileAssignments.Add(AssetScanProfileAssignment.Create(_tenantId, a2, _profile.Id, null));
+        await _db.SaveChangesAsync();
+
+        var runId = await _sut.StartRunAsync(_profile.Id, "scheduled", null, CancellationToken.None);
+
+        var run = await _db.AuthenticatedScanRuns.SingleAsync(r => r.Id == runId);
+        Assert.Equal(2, run.TotalDevices);
+        Assert.Equal(AuthenticatedScanRunStatuses.Running, run.Status);
+        Assert.Equal(2, await _db.ScanJobs.CountAsync(j => j.RunId == runId));
+    }
+
+    [Fact]
+    public async Task StartRun_with_zero_assets_marks_run_succeeded_immediately()
+    {
+        var runId = await _sut.StartRunAsync(_profile.Id, "scheduled", null, CancellationToken.None);
+        var run = await _db.AuthenticatedScanRuns.SingleAsync(r => r.Id == runId);
+        Assert.Equal(AuthenticatedScanRunStatuses.Succeeded, run.Status);
+        Assert.Equal(0, run.TotalDevices);
+        Assert.NotNull(run.CompletedAt);
+    }
+
+    [Fact]
+    public async Task StartRun_throws_when_profile_has_active_run()
+    {
+        var a1 = await TestData.SeedDevice(_db, _tenantId, "h1");
+        _db.AssetScanProfileAssignments.Add(AssetScanProfileAssignment.Create(_tenantId, a1, _profile.Id, null));
+        await _db.SaveChangesAsync();
+
+        await _sut.StartRunAsync(_profile.Id, "scheduled", null, CancellationToken.None);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.StartRunAsync(_profile.Id, "manual", Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task StartRun_snapshots_current_tool_version_ids_into_job()
+    {
+        var a1 = await TestData.SeedDevice(_db, _tenantId, "h1");
+        _db.AssetScanProfileAssignments.Add(AssetScanProfileAssignment.Create(_tenantId, a1, _profile.Id, null));
+        await _db.SaveChangesAsync();
+
+        var runId = await _sut.StartRunAsync(_profile.Id, "scheduled", null, CancellationToken.None);
+        var job = await _db.ScanJobs.SingleAsync(j => j.RunId == runId);
+        Assert.Contains("\"", job.ScanningToolVersionIdsJson);
+        Assert.NotEqual("[]", job.ScanningToolVersionIdsJson);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expected to fail**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanJobDispatcherTests`
+Expected: FAIL (class doesn't exist).
+
+- [ ] **Step 3: Implement the dispatcher**
+
+```csharp
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.AuthenticatedScans;
+
+public class ScanJobDispatcher
+{
+    private readonly PatchHoundDbContext _db;
+    public ScanJobDispatcher(PatchHoundDbContext db) { _db = db; }
+
+    public async Task<Guid> StartRunAsync(Guid scanProfileId, string triggerKind, Guid? triggeredByUserId, CancellationToken ct)
+    {
+        var profile = await _db.ScanProfiles.SingleAsync(p => p.Id == scanProfileId, ct);
+
+        // Guard: no active run for this profile
+        var active = await _db.AuthenticatedScanRuns.AnyAsync(r => r.ScanProfileId == scanProfileId
+            && r.Status != AuthenticatedScanRunStatuses.Succeeded
+            && r.Status != AuthenticatedScanRunStatuses.Failed
+            && r.Status != AuthenticatedScanRunStatuses.PartiallyFailed, ct);
+        if (active)
+            throw new InvalidOperationException($"scan profile {scanProfileId} already has an active run");
+
+        var now = DateTimeOffset.UtcNow;
+        var run = AuthenticatedScanRun.Start(profile.TenantId, scanProfileId, triggerKind, triggeredByUserId, now);
+        _db.AuthenticatedScanRuns.Add(run);
+
+        // Snapshot tool version ids
+        var toolIds = await _db.ScanProfileTools
+            .Where(t => t.ScanProfileId == scanProfileId)
+            .OrderBy(t => t.ExecutionOrder)
+            .Select(t => t.ScanningToolId).ToListAsync(ct);
+        var versionIds = await _db.ScanningTools
+            .Where(t => toolIds.Contains(t.Id) && t.CurrentVersionId != null)
+            .Select(t => t.CurrentVersionId!.Value)
+            .ToListAsync(ct);
+        var versionIdsJson = JsonSerializer.Serialize(versionIds);
+
+        // Assigned assets
+        var assetIds = await _db.AssetScanProfileAssignments
+            .Where(a => a.ScanProfileId == scanProfileId)
+            .Select(a => a.AssetId).ToListAsync(ct);
+
+        if (assetIds.Count == 0)
+        {
+            run.MarkRunning(0);
+            run.Complete(0, 0, 0, now);
+            await _db.SaveChangesAsync(ct);
+            return run.Id;
+        }
+
+        foreach (var assetId in assetIds)
+        {
+            _db.ScanJobs.Add(ScanJob.Create(
+                profile.TenantId, run.Id, profile.ScanRunnerId, assetId, profile.ConnectionProfileId, versionIdsJson));
+        }
+        run.MarkRunning(assetIds.Count);
+        profile.RecordRunStarted(now);
+        profile.ClearManualRequest();
+
+        await _db.SaveChangesAsync(ct);
+        return run.Id;
+    }
+}
+```
+
+- [ ] **Step 4: Register in DI + run tests**
+
+Add `services.AddScoped<ScanJobDispatcher>();` in `DependencyInjection.cs`.
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanJobDispatcherTests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/ScanJobDispatcher.cs src/PatchHound.Infrastructure/DependencyInjection.cs tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/ScanJobDispatcherTests.cs
+git commit -m "feat: add ScanJobDispatcher with concurrency guardrail and version snapshot"
+```
+
+---
+
+## Task 13: Scanning tool version retention (10-version rolling window) with tests
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/AuthenticatedScans/ScanningToolVersionStore.cs`
+- Create: `tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/ScanningToolVersionRetentionTests.cs`
+
+When an admin saves a new version of a scanning tool's script, store it and prune oldest so only 10 remain per tool.
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.AuthenticatedScans;
+
+public class ScanningToolVersionRetentionTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private ScanningToolVersionStore _sut = null!;
+    private ScanningTool _tool = null!;
+    private Guid _userId = Guid.NewGuid();
+
+    public async Task InitializeAsync()
+    {
+        _db = TestDbContextFactory.CreateInMemory();
+        _tool = ScanningTool.Create(Guid.NewGuid(), "t", "", "bash", "/bin/bash", 60, "NormalizedSoftware");
+        _db.ScanningTools.Add(_tool);
+        await _db.SaveChangesAsync();
+        _sut = new ScanningToolVersionStore(_db);
+    }
+    public Task DisposeAsync() { _db.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public async Task AppendVersion_assigns_incrementing_version_numbers_starting_at_1()
+    {
+        var v1 = await _sut.AppendAsync(_tool.Id, "echo 1", _userId, CancellationToken.None);
+        var v2 = await _sut.AppendAsync(_tool.Id, "echo 2", _userId, CancellationToken.None);
+        Assert.Equal(1, v1.VersionNumber);
+        Assert.Equal(2, v2.VersionNumber);
+    }
+
+    [Fact]
+    public async Task AppendVersion_sets_tool_CurrentVersionId_to_new_version()
+    {
+        var v = await _sut.AppendAsync(_tool.Id, "echo 1", _userId, CancellationToken.None);
+        var refreshed = await _db.ScanningTools.SingleAsync(t => t.Id == _tool.Id);
+        Assert.Equal(v.Id, refreshed.CurrentVersionId);
+    }
+
+    [Fact]
+    public async Task AppendVersion_prunes_oldest_keeping_newest_10()
+    {
+        for (var i = 1; i <= 12; i++)
+            await _sut.AppendAsync(_tool.Id, $"echo {i}", _userId, CancellationToken.None);
+        var remaining = await _db.ScanningToolVersions
+            .Where(v => v.ScanningToolId == _tool.Id)
+            .OrderBy(v => v.VersionNumber)
+            .ToListAsync();
+        Assert.Equal(10, remaining.Count);
+        Assert.Equal(3, remaining.First().VersionNumber);
+        Assert.Equal(12, remaining.Last().VersionNumber);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expected to fail**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanningToolVersionRetentionTests`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the store**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.AuthenticatedScans;
+
+public class ScanningToolVersionStore
+{
+    private const int RetainCount = 10;
+    private readonly PatchHoundDbContext _db;
+    public ScanningToolVersionStore(PatchHoundDbContext db) { _db = db; }
+
+    public async Task<ScanningToolVersion> AppendAsync(Guid scanningToolId, string scriptContent, Guid editedByUserId, CancellationToken ct)
+    {
+        var tool = await _db.ScanningTools.SingleAsync(t => t.Id == scanningToolId, ct);
+        var maxVersion = await _db.ScanningToolVersions
+            .Where(v => v.ScanningToolId == scanningToolId)
+            .Select(v => (int?)v.VersionNumber).MaxAsync(ct) ?? 0;
+        var next = ScanningToolVersion.Create(scanningToolId, maxVersion + 1, scriptContent, editedByUserId);
+        _db.ScanningToolVersions.Add(next);
+        tool.SetCurrentVersion(next.Id);
+
+        // Prune oldest beyond RetainCount
+        var stale = await _db.ScanningToolVersions
+            .Where(v => v.ScanningToolId == scanningToolId)
+            .OrderByDescending(v => v.VersionNumber)
+            .Skip(RetainCount - 1) // -1 because the new version will be added at SaveChanges
+            .ToListAsync(ct);
+        _db.ScanningToolVersions.RemoveRange(stale);
+        await _db.SaveChangesAsync(ct);
+        return next;
+    }
+}
+```
+
+- [ ] **Step 4: Register in DI + run tests**
+
+Add `services.AddScoped<ScanningToolVersionStore>();` to `DependencyInjection.cs`.
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanningToolVersionRetentionTests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/ScanningToolVersionStore.cs src/PatchHound.Infrastructure/DependencyInjection.cs tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/ScanningToolVersionRetentionTests.cs
+git commit -m "feat: add ScanningToolVersionStore with 10-version rolling window"
+```
+
+---
+
+## Task 14: `ConnectionProfilesController` with DTOs and tests
+
+**Files:**
+- Create: `src/PatchHound.Api/Models/AuthenticatedScans/ConnectionProfileDtos.cs`
+- Create: `src/PatchHound.Api/Controllers/ConnectionProfilesController.cs`
+- Create: `tests/PatchHound.Tests/Api/ConnectionProfilesControllerTests.cs`
+
+CRUD endpoints guarded by `Policies.ConfigureTenant` (same as existing admin controllers).
+
+- [ ] **Step 1: DTOs**
+
+```csharp
+namespace PatchHound.Api.Models.AuthenticatedScans;
+
+public record ConnectionProfileDto(
+    Guid Id, string Name, string Description, string Kind,
+    string SshHost, int SshPort, string SshUsername, string AuthMethod,
+    string? HostKeyFingerprint, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
+public record CreateConnectionProfileRequest(
+    string Name, string Description, string SshHost, int SshPort, string SshUsername,
+    string AuthMethod,
+    string? Password, string? PrivateKey, string? PrivateKeyPassphrase,
+    string? HostKeyFingerprint);
+
+public record UpdateConnectionProfileRequest(
+    string Name, string Description, string SshHost, int SshPort, string SshUsername,
+    string AuthMethod, string? HostKeyFingerprint);
+
+public record ReplaceConnectionProfileSecretRequest(
+    string AuthMethod, string? Password, string? PrivateKey, string? PrivateKeyPassphrase);
+```
+
+- [ ] **Step 2: Controller**
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models.AuthenticatedScans;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/authenticated-scans/connection-profiles")]
+[Authorize(Policy = Policies.ConfigureTenant)]
+public class ConnectionProfilesController : ControllerBase
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly ITenantContext _tenant;
+    private readonly ConnectionProfileSecretWriter _secrets;
+    private readonly AuditLogWriter _audit;
+
+    public ConnectionProfilesController(PatchHoundDbContext db, ITenantContext tenant,
+        ConnectionProfileSecretWriter secrets, AuditLogWriter audit)
+    { _db = db; _tenant = tenant; _secrets = secrets; _audit = audit; }
+
+    [HttpGet]
+    public async Task<IEnumerable<ConnectionProfileDto>> List(CancellationToken ct)
+    {
+        var items = await _db.ConnectionProfiles.AsNoTracking()
+            .Where(c => c.TenantId == _tenant.TenantId)
+            .OrderBy(c => c.Name).ToListAsync(ct);
+        return items.Select(ToDto);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ConnectionProfileDto>> Get(Guid id, CancellationToken ct)
+    {
+        var item = await _db.ConnectionProfiles.AsNoTracking()
+            .SingleOrDefaultAsync(c => c.Id == id && c.TenantId == _tenant.TenantId, ct);
+        return item is null ? NotFound() : ToDto(item);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ConnectionProfileDto>> Create([FromBody] CreateConnectionProfileRequest req, CancellationToken ct)
+    {
+        var profileId = Guid.NewGuid();
+        string secretRef;
+        if (req.AuthMethod == "password")
+        {
+            if (string.IsNullOrEmpty(req.Password)) return BadRequest("password required");
+            secretRef = await _secrets.WritePasswordAsync(_tenant.TenantId, profileId, req.Password, ct);
+        }
+        else if (req.AuthMethod == "privateKey")
+        {
+            if (string.IsNullOrEmpty(req.PrivateKey)) return BadRequest("privateKey required");
+            secretRef = await _secrets.WritePrivateKeyAsync(_tenant.TenantId, profileId, req.PrivateKey, req.PrivateKeyPassphrase, ct);
+        }
+        else return BadRequest("authMethod must be password|privateKey");
+
+        var profile = ConnectionProfile.Create(
+            _tenant.TenantId, req.Name, req.Description, req.SshHost, req.SshPort,
+            req.SshUsername, req.AuthMethod, secretRef, req.HostKeyFingerprint);
+        // force id to match secret path
+        typeof(ConnectionProfile).GetProperty(nameof(ConnectionProfile.Id))!.SetValue(profile, profileId);
+        _db.ConnectionProfiles.Add(profile);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ConnectionProfile.Created", profile.Id.ToString(), ct);
+        return CreatedAtAction(nameof(Get), new { id = profile.Id }, ToDto(profile));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<ConnectionProfileDto>> Update(Guid id, [FromBody] UpdateConnectionProfileRequest req, CancellationToken ct)
+    {
+        var p = await _db.ConnectionProfiles.SingleOrDefaultAsync(c => c.Id == id && c.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        p.Update(req.Name, req.Description, req.SshHost, req.SshPort, req.SshUsername, req.AuthMethod, req.HostKeyFingerprint);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ConnectionProfile.Updated", id.ToString(), ct);
+        return ToDto(p);
+    }
+
+    [HttpPost("{id:guid}/replace-secret")]
+    public async Task<IActionResult> ReplaceSecret(Guid id, [FromBody] ReplaceConnectionProfileSecretRequest req, CancellationToken ct)
+    {
+        var p = await _db.ConnectionProfiles.SingleOrDefaultAsync(c => c.Id == id && c.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        string secretRef;
+        if (req.AuthMethod == "password")
+        {
+            if (string.IsNullOrEmpty(req.Password)) return BadRequest("password required");
+            secretRef = await _secrets.WritePasswordAsync(_tenant.TenantId, id, req.Password, ct);
+        }
+        else if (req.AuthMethod == "privateKey")
+        {
+            if (string.IsNullOrEmpty(req.PrivateKey)) return BadRequest("privateKey required");
+            secretRef = await _secrets.WritePrivateKeyAsync(_tenant.TenantId, id, req.PrivateKey, req.PrivateKeyPassphrase, ct);
+        }
+        else return BadRequest("authMethod must be password|privateKey");
+        p.SetSecretRef(secretRef);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ConnectionProfile.SecretReplaced", id.ToString(), ct);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var p = await _db.ConnectionProfiles.SingleOrDefaultAsync(c => c.Id == id && c.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        // guard: reject if referenced by a ScanProfile
+        var inUse = await _db.ScanProfiles.AnyAsync(sp => sp.ConnectionProfileId == id, ct);
+        if (inUse) return Conflict("connection profile is referenced by a scan profile");
+        _db.ConnectionProfiles.Remove(p);
+        await _secrets.DeleteAsync(_tenant.TenantId, id, ct);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ConnectionProfile.Deleted", id.ToString(), ct);
+        return NoContent();
+    }
+
+    private static ConnectionProfileDto ToDto(ConnectionProfile p) =>
+        new(p.Id, p.Name, p.Description, p.Kind, p.SshHost, p.SshPort, p.SshUsername, p.AuthMethod,
+            p.HostKeyFingerprint, p.CreatedAt, p.UpdatedAt);
+}
+```
+
+Note: reflection to force-set `Id` is used for secret-path consistency. Alternative: modify `ConnectionProfile.Create` to accept an `id` parameter. If you prefer the cleaner approach, add an internal `SetId` method or an overload that takes `id`.
+
+- [ ] **Step 3: Write controller tests (one happy-path per endpoint)**
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using PatchHound.Api.Models.AuthenticatedScans;
+using Xunit;
+
+namespace PatchHound.Tests.Api;
+
+public class ConnectionProfilesControllerTests : IClassFixture<TestApiFactory>
+{
+    private readonly HttpClient _client;
+    public ConnectionProfilesControllerTests(TestApiFactory f) { _client = f.CreateAuthedClient(); }
+
+    [Fact]
+    public async Task Create_stores_profile_without_persisting_password()
+    {
+        var req = new CreateConnectionProfileRequest(
+            Name: "dc-west", Description: "", SshHost: "h.example.com", SshPort: 22, SshUsername: "root",
+            AuthMethod: "password", Password: "hunter2", PrivateKey: null, PrivateKeyPassphrase: null,
+            HostKeyFingerprint: null);
+        var resp = await _client.PostAsJsonAsync("/api/authenticated-scans/connection-profiles", req);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<ConnectionProfileDto>();
+        Assert.Equal("password", dto!.AuthMethod);
+        // No password/secretRef in response DTO
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("hunter2", body);
+        Assert.DoesNotContain("SecretRef", body);
+    }
+
+    [Fact]
+    public async Task List_only_returns_current_tenant_profiles()
+    {
+        // Relies on TestApiFactory seeding; add a row for another tenant and confirm it's not returned.
+        var resp = await _client.GetAsync("/api/authenticated-scans/connection-profiles");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_rejects_when_referenced_by_scan_profile()
+    {
+        // (requires seeding of a ScanProfile referencing the ConnectionProfile)
+        // Test body follows fixture conventions; see existing *ControllerTests for patterns.
+    }
+}
+```
+
+(`TestApiFactory` should follow patterns of the existing controller tests in `tests/PatchHound.Tests/Api/`. If a tenant-context fixture doesn't exist, inspect existing admin controller tests like `AssetRulesControllerTests.cs` to mirror.)
+
+- [ ] **Step 4: Run + commit**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ConnectionProfilesControllerTests`
+Expected: all pass.
+
+```bash
+git add src/PatchHound.Api/Models/AuthenticatedScans/ConnectionProfileDtos.cs src/PatchHound.Api/Controllers/ConnectionProfilesController.cs tests/PatchHound.Tests/Api/ConnectionProfilesControllerTests.cs
+git commit -m "feat: add ConnectionProfilesController with OpenBao secret handling"
+```
+
+---
+
+## Task 15: `ScanRunnersController` with bearer-secret lifecycle
+
+**Files:**
+- Create: `src/PatchHound.Api/Models/AuthenticatedScans/ScanRunnerDtos.cs`
+- Create: `src/PatchHound.Api/Controllers/ScanRunnersController.cs`
+- Create: `tests/PatchHound.Tests/Api/ScanRunnersControllerTests.cs`
+
+Endpoints: list, get, create (returns one-time secret), update, rotate-secret, delete. Authenticated Api admin endpoints only; runner-facing `/api/scan-runner/*` endpoints come in Plan 2.
+
+- [ ] **Step 1: DTOs**
+
+```csharp
+namespace PatchHound.Api.Models.AuthenticatedScans;
+
+public record ScanRunnerDto(
+    Guid Id, string Name, string Description, bool Enabled, string Version,
+    DateTimeOffset? LastSeenAt, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
+public record CreateScanRunnerRequest(string Name, string Description);
+public record UpdateScanRunnerRequest(string Name, string Description, bool Enabled);
+
+public record ScanRunnerCreatedDto(ScanRunnerDto Runner, string Secret, string RunnerYamlSnippet);
+public record ScanRunnerSecretRotatedDto(string Secret);
+```
+
+- [ ] **Step 2: Controller + token hashing helper**
+
+Create a small helper `ScanRunnerTokens` in `src/PatchHound.Infrastructure/AuthenticatedScans/ScanRunnerTokens.cs`:
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PatchHound.Infrastructure.AuthenticatedScans;
+
+public static class ScanRunnerTokens
+{
+    public static string GenerateSecret()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+    public static string Hash(string secret)
+    {
+        var bytes = Encoding.UTF8.GetBytes(secret);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+```
+
+Controller:
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models.AuthenticatedScans;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/authenticated-scans/scan-runners")]
+[Authorize(Policy = Policies.ConfigureTenant)]
+public class ScanRunnersController : ControllerBase
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly ITenantContext _tenant;
+    private readonly AuditLogWriter _audit;
+
+    public ScanRunnersController(PatchHoundDbContext db, ITenantContext tenant, AuditLogWriter audit)
+    { _db = db; _tenant = tenant; _audit = audit; }
+
+    [HttpGet]
+    public async Task<IEnumerable<ScanRunnerDto>> List(CancellationToken ct) =>
+        (await _db.ScanRunners.AsNoTracking()
+            .Where(r => r.TenantId == _tenant.TenantId)
+            .OrderBy(r => r.Name).ToListAsync(ct)).Select(ToDto);
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ScanRunnerDto>> Get(Guid id, CancellationToken ct)
+    {
+        var r = await _db.ScanRunners.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        return r is null ? NotFound() : ToDto(r);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ScanRunnerCreatedDto>> Create([FromBody] CreateScanRunnerRequest req, CancellationToken ct)
+    {
+        var secret = ScanRunnerTokens.GenerateSecret();
+        var runner = ScanRunner.Create(_tenant.TenantId, req.Name, req.Description, ScanRunnerTokens.Hash(secret));
+        _db.ScanRunners.Add(runner);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanRunner.Created", runner.Id.ToString(), ct);
+        var yaml = $"tenantId: {_tenant.TenantId}\nrunnerId: {runner.Id}\nbearerSecret: {secret}\ncentralUrl: https://<your-api>\n";
+        return new ScanRunnerCreatedDto(ToDto(runner), secret, yaml);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<ScanRunnerDto>> Update(Guid id, [FromBody] UpdateScanRunnerRequest req, CancellationToken ct)
+    {
+        var r = await _db.ScanRunners.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (r is null) return NotFound();
+        r.Update(req.Name, req.Description, req.Enabled);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanRunner.Updated", id.ToString(), ct);
+        return ToDto(r);
+    }
+
+    [HttpPost("{id:guid}/rotate-secret")]
+    public async Task<ActionResult<ScanRunnerSecretRotatedDto>> Rotate(Guid id, CancellationToken ct)
+    {
+        var r = await _db.ScanRunners.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (r is null) return NotFound();
+        var secret = ScanRunnerTokens.GenerateSecret();
+        r.RotateSecret(ScanRunnerTokens.Hash(secret));
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanRunner.SecretRotated", id.ToString(), ct);
+        return new ScanRunnerSecretRotatedDto(secret);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var r = await _db.ScanRunners.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (r is null) return NotFound();
+        var inUse = await _db.ScanProfiles.AnyAsync(sp => sp.ScanRunnerId == id, ct);
+        if (inUse) return Conflict("runner is referenced by a scan profile");
+        _db.ScanRunners.Remove(r);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanRunner.Deleted", id.ToString(), ct);
+        return NoContent();
+    }
+
+    private static ScanRunnerDto ToDto(ScanRunner r) =>
+        new(r.Id, r.Name, r.Description, r.Enabled, r.Version, r.LastSeenAt, r.CreatedAt, r.UpdatedAt);
+}
+```
+
+- [ ] **Step 3: Tests**
+
+Add happy-path tests for create (returns secret once, secret is not stored plaintext in DB), rotate (DB hash changes), delete-blocked-when-in-use. Follow pattern from `ConnectionProfilesControllerTests.cs`.
+
+- [ ] **Step 4: Run + commit**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanRunnersControllerTests`
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/ScanRunnerTokens.cs src/PatchHound.Api/Models/AuthenticatedScans/ScanRunnerDtos.cs src/PatchHound.Api/Controllers/ScanRunnersController.cs tests/PatchHound.Tests/Api/ScanRunnersControllerTests.cs
+git commit -m "feat: add ScanRunnersController with bearer-secret lifecycle"
+```
+
+---
+
+## Task 16: `ScanningToolsController` using `ScanningToolVersionStore`
+
+**Files:**
+- Create: `src/PatchHound.Api/Models/AuthenticatedScans/ScanningToolDtos.cs`
+- Create: `src/PatchHound.Api/Controllers/ScanningToolsController.cs`
+- Create: `tests/PatchHound.Tests/Api/ScanningToolsControllerTests.cs`
+
+CRUD over `ScanningTool`. Script content managed through a dedicated `PUT /scanning-tools/{id}/script` endpoint that calls `ScanningToolVersionStore.AppendAsync` and auto-prunes.
+
+- [ ] **Step 1: DTOs**
+
+```csharp
+namespace PatchHound.Api.Models.AuthenticatedScans;
+
+public record ScanningToolDto(
+    Guid Id, string Name, string Description, string ScriptType, string InterpreterPath,
+    int TimeoutSeconds, string OutputModel, Guid? CurrentVersionId,
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
+public record CreateScanningToolRequest(
+    string Name, string Description, string ScriptType, string InterpreterPath,
+    int TimeoutSeconds, string OutputModel, string InitialScript);
+
+public record UpdateScanningToolRequest(
+    string Name, string Description, string ScriptType, string InterpreterPath, int TimeoutSeconds);
+
+public record UpdateScriptRequest(string ScriptContent);
+
+public record ScanningToolVersionDto(Guid Id, int VersionNumber, Guid EditedByUserId, DateTimeOffset EditedAt);
+
+public record ScanningToolVersionContentDto(
+    Guid Id, int VersionNumber, string ScriptContent, Guid EditedByUserId, DateTimeOffset EditedAt);
+```
+
+- [ ] **Step 2: Controller**
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models.AuthenticatedScans;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/authenticated-scans/scanning-tools")]
+[Authorize(Policy = Policies.ConfigureTenant)]
+public class ScanningToolsController : ControllerBase
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly ITenantContext _tenant;
+    private readonly ScanningToolVersionStore _versions;
+    private readonly AuditLogWriter _audit;
+
+    public ScanningToolsController(PatchHoundDbContext db, ITenantContext tenant,
+        ScanningToolVersionStore versions, AuditLogWriter audit)
+    { _db = db; _tenant = tenant; _versions = versions; _audit = audit; }
+
+    [HttpGet]
+    public async Task<IEnumerable<ScanningToolDto>> List(CancellationToken ct) =>
+        (await _db.ScanningTools.AsNoTracking()
+            .Where(t => t.TenantId == _tenant.TenantId)
+            .OrderBy(t => t.Name).ToListAsync(ct)).Select(ToDto);
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ScanningToolDto>> Get(Guid id, CancellationToken ct)
+    {
+        var t = await _db.ScanningTools.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        return t is null ? NotFound() : ToDto(t);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ScanningToolDto>> Create([FromBody] CreateScanningToolRequest req, CancellationToken ct)
+    {
+        var tool = ScanningTool.Create(_tenant.TenantId, req.Name, req.Description,
+            req.ScriptType, req.InterpreterPath, req.TimeoutSeconds, req.OutputModel);
+        _db.ScanningTools.Add(tool);
+        await _db.SaveChangesAsync(ct);
+        var userId = _tenant.UserId ?? Guid.Empty;
+        await _versions.AppendAsync(tool.Id, req.InitialScript, userId, ct);
+        await _audit.WriteAsync("ScanningTool.Created", tool.Id.ToString(), ct);
+        return CreatedAtAction(nameof(Get), new { id = tool.Id }, ToDto(tool));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<ScanningToolDto>> Update(Guid id, [FromBody] UpdateScanningToolRequest req, CancellationToken ct)
+    {
+        var t = await _db.ScanningTools.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (t is null) return NotFound();
+        t.UpdateMetadata(req.Name, req.Description, req.ScriptType, req.InterpreterPath, req.TimeoutSeconds);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanningTool.Updated", id.ToString(), ct);
+        return ToDto(t);
+    }
+
+    [HttpPut("{id:guid}/script")]
+    public async Task<ActionResult<ScanningToolVersionDto>> UpdateScript(Guid id, [FromBody] UpdateScriptRequest req, CancellationToken ct)
+    {
+        var t = await _db.ScanningTools.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (t is null) return NotFound();
+        var userId = _tenant.UserId ?? Guid.Empty;
+        var v = await _versions.AppendAsync(id, req.ScriptContent, userId, ct);
+        await _audit.WriteAsync("ScanningTool.ScriptUpdated", id.ToString(), ct);
+        return new ScanningToolVersionDto(v.Id, v.VersionNumber, v.EditedByUserId, v.EditedAt);
+    }
+
+    [HttpGet("{id:guid}/versions")]
+    public async Task<ActionResult<IEnumerable<ScanningToolVersionDto>>> ListVersions(Guid id, CancellationToken ct)
+    {
+        var tool = await _db.ScanningTools.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (tool is null) return NotFound();
+        var versions = await _db.ScanningToolVersions.AsNoTracking()
+            .Where(v => v.ScanningToolId == id)
+            .OrderByDescending(v => v.VersionNumber)
+            .Select(v => new ScanningToolVersionDto(v.Id, v.VersionNumber, v.EditedByUserId, v.EditedAt))
+            .ToListAsync(ct);
+        return Ok(versions);
+    }
+
+    [HttpGet("{id:guid}/versions/{versionId:guid}")]
+    public async Task<ActionResult<ScanningToolVersionContentDto>> GetVersion(Guid id, Guid versionId, CancellationToken ct)
+    {
+        var tool = await _db.ScanningTools.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (tool is null) return NotFound();
+        var v = await _db.ScanningToolVersions.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == versionId && x.ScanningToolId == id, ct);
+        return v is null ? NotFound() : new ScanningToolVersionContentDto(v.Id, v.VersionNumber, v.ScriptContent, v.EditedByUserId, v.EditedAt);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var t = await _db.ScanningTools.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (t is null) return NotFound();
+        var inUse = await _db.ScanProfileTools.AnyAsync(pt => pt.ScanningToolId == id, ct);
+        if (inUse) return Conflict("tool is referenced by a scan profile");
+        _db.ScanningToolVersions.RemoveRange(_db.ScanningToolVersions.Where(v => v.ScanningToolId == id));
+        _db.ScanningTools.Remove(t);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanningTool.Deleted", id.ToString(), ct);
+        return NoContent();
+    }
+
+    private static ScanningToolDto ToDto(ScanningTool t) =>
+        new(t.Id, t.Name, t.Description, t.ScriptType, t.InterpreterPath, t.TimeoutSeconds,
+            t.OutputModel, t.CurrentVersionId, t.CreatedAt, t.UpdatedAt);
+}
+```
+
+Note: `_tenant.UserId` — confirm the existing `ITenantContext` exposes a user id (search for it). If the field is named differently (e.g. `CurrentUserId`), adjust.
+
+- [ ] **Step 3: Controller tests (happy path per endpoint)**
+
+At minimum: create (stores initial version), update-script (creates v2), list-versions (returns newest first), delete-blocked-when-referenced.
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanningToolsControllerTests
+git add src/PatchHound.Api/Models/AuthenticatedScans/ScanningToolDtos.cs src/PatchHound.Api/Controllers/ScanningToolsController.cs tests/PatchHound.Tests/Api/ScanningToolsControllerTests.cs
+git commit -m "feat: add ScanningToolsController with script versioning"
+```
+
+---
+
+## Task 17: `ScanProfilesController` (incl. tool assignment + manual trigger request)
+
+**Files:**
+- Create: `src/PatchHound.Api/Models/AuthenticatedScans/ScanProfileDtos.cs`
+- Create: `src/PatchHound.Api/Controllers/ScanProfilesController.cs`
+- Create: `tests/PatchHound.Tests/Api/ScanProfilesControllerTests.cs`
+
+CRUD + `POST /{id}/trigger-run` (writes `ManualRequestedAt` — actual scheduler firing comes in Plan 2).
+
+- [ ] **Step 1: DTOs**
+
+```csharp
+namespace PatchHound.Api.Models.AuthenticatedScans;
+
+public record ScanProfileToolDto(Guid ScanningToolId, int ExecutionOrder);
+
+public record ScanProfileDto(
+    Guid Id, string Name, string Description, string CronSchedule,
+    Guid ConnectionProfileId, Guid ScanRunnerId, bool Enabled,
+    DateTimeOffset? ManualRequestedAt, DateTimeOffset? LastRunStartedAt,
+    IReadOnlyList<ScanProfileToolDto> Tools,
+    DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+
+public record CreateScanProfileRequest(
+    string Name, string Description, string CronSchedule,
+    Guid ConnectionProfileId, Guid ScanRunnerId, bool Enabled,
+    IReadOnlyList<ScanProfileToolDto> Tools);
+
+public record UpdateScanProfileRequest(
+    string Name, string Description, string CronSchedule,
+    Guid ConnectionProfileId, Guid ScanRunnerId, bool Enabled,
+    IReadOnlyList<ScanProfileToolDto> Tools);
+```
+
+- [ ] **Step 2: Controller**
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models.AuthenticatedScans;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/authenticated-scans/scan-profiles")]
+[Authorize(Policy = Policies.ConfigureTenant)]
+public class ScanProfilesController : ControllerBase
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly ITenantContext _tenant;
+    private readonly AuditLogWriter _audit;
+
+    public ScanProfilesController(PatchHoundDbContext db, ITenantContext tenant, AuditLogWriter audit)
+    { _db = db; _tenant = tenant; _audit = audit; }
+
+    [HttpGet]
+    public async Task<IEnumerable<ScanProfileDto>> List(CancellationToken ct)
+    {
+        var items = await _db.ScanProfiles.AsNoTracking()
+            .Where(p => p.TenantId == _tenant.TenantId)
+            .OrderBy(p => p.Name).ToListAsync(ct);
+        var toolsByProfile = (await _db.ScanProfileTools.AsNoTracking()
+            .Where(t => items.Select(p => p.Id).Contains(t.ScanProfileId))
+            .ToListAsync(ct)).GroupBy(t => t.ScanProfileId).ToDictionary(g => g.Key, g => g.ToList());
+        return items.Select(p => ToDto(p, toolsByProfile.GetValueOrDefault(p.Id) ?? new()));
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ScanProfileDto>> Get(Guid id, CancellationToken ct)
+    {
+        var p = await _db.ScanProfiles.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        var tools = await _db.ScanProfileTools.AsNoTracking().Where(t => t.ScanProfileId == id).ToListAsync(ct);
+        return ToDto(p, tools);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ScanProfileDto>> Create([FromBody] CreateScanProfileRequest req, CancellationToken ct)
+    {
+        await ValidateReferencesAsync(req.ConnectionProfileId, req.ScanRunnerId, req.Tools.Select(t => t.ScanningToolId), ct);
+        var p = ScanProfile.Create(_tenant.TenantId, req.Name, req.Description, req.CronSchedule,
+            req.ConnectionProfileId, req.ScanRunnerId, req.Enabled);
+        _db.ScanProfiles.Add(p);
+        foreach (var t in req.Tools)
+            _db.ScanProfileTools.Add(ScanProfileTool.Create(p.Id, t.ScanningToolId, t.ExecutionOrder));
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanProfile.Created", p.Id.ToString(), ct);
+        return CreatedAtAction(nameof(Get), new { id = p.Id }, ToDto(p, await _db.ScanProfileTools.Where(t => t.ScanProfileId == p.Id).ToListAsync(ct)));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<ScanProfileDto>> Update(Guid id, [FromBody] UpdateScanProfileRequest req, CancellationToken ct)
+    {
+        var p = await _db.ScanProfiles.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        await ValidateReferencesAsync(req.ConnectionProfileId, req.ScanRunnerId, req.Tools.Select(t => t.ScanningToolId), ct);
+        p.Update(req.Name, req.Description, req.CronSchedule, req.ConnectionProfileId, req.ScanRunnerId, req.Enabled);
+        _db.ScanProfileTools.RemoveRange(_db.ScanProfileTools.Where(t => t.ScanProfileId == id));
+        foreach (var t in req.Tools)
+            _db.ScanProfileTools.Add(ScanProfileTool.Create(id, t.ScanningToolId, t.ExecutionOrder));
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanProfile.Updated", id.ToString(), ct);
+        var tools = await _db.ScanProfileTools.AsNoTracking().Where(t => t.ScanProfileId == id).ToListAsync(ct);
+        return ToDto(p, tools);
+    }
+
+    [HttpPost("{id:guid}/trigger-run")]
+    public async Task<IActionResult> TriggerRun(Guid id, CancellationToken ct)
+    {
+        var p = await _db.ScanProfiles.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        var active = await _db.AuthenticatedScanRuns.AnyAsync(r => r.ScanProfileId == id
+            && r.Status != AuthenticatedScanRunStatuses.Succeeded
+            && r.Status != AuthenticatedScanRunStatuses.Failed
+            && r.Status != AuthenticatedScanRunStatuses.PartiallyFailed, ct);
+        if (active) return Conflict("profile already has an active run");
+        p.RequestManualRun(DateTimeOffset.UtcNow);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanProfile.ManualTriggerRequested", id.ToString(), ct);
+        return Accepted();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var p = await _db.ScanProfiles.SingleOrDefaultAsync(x => x.Id == id && x.TenantId == _tenant.TenantId, ct);
+        if (p is null) return NotFound();
+        _db.ScanProfileTools.RemoveRange(_db.ScanProfileTools.Where(t => t.ScanProfileId == id));
+        _db.AssetScanProfileAssignments.RemoveRange(_db.AssetScanProfileAssignments.Where(a => a.ScanProfileId == id));
+        _db.ScanProfiles.Remove(p);
+        await _db.SaveChangesAsync(ct);
+        await _audit.WriteAsync("ScanProfile.Deleted", id.ToString(), ct);
+        return NoContent();
+    }
+
+    private async Task ValidateReferencesAsync(Guid connId, Guid runnerId, IEnumerable<Guid> toolIds, CancellationToken ct)
+    {
+        if (!await _db.ConnectionProfiles.AnyAsync(c => c.Id == connId && c.TenantId == _tenant.TenantId, ct))
+            throw new BadHttpRequestException("invalid connectionProfileId");
+        if (!await _db.ScanRunners.AnyAsync(r => r.Id == runnerId && r.TenantId == _tenant.TenantId, ct))
+            throw new BadHttpRequestException("invalid scanRunnerId");
+        var ids = toolIds.ToList();
+        var found = await _db.ScanningTools.CountAsync(t => ids.Contains(t.Id) && t.TenantId == _tenant.TenantId, ct);
+        if (found != ids.Count) throw new BadHttpRequestException("one or more invalid scanningToolIds");
+    }
+
+    private static ScanProfileDto ToDto(ScanProfile p, List<ScanProfileTool> tools) =>
+        new(p.Id, p.Name, p.Description, p.CronSchedule, p.ConnectionProfileId, p.ScanRunnerId, p.Enabled,
+            p.ManualRequestedAt, p.LastRunStartedAt,
+            tools.OrderBy(t => t.ExecutionOrder).Select(t => new ScanProfileToolDto(t.ScanningToolId, t.ExecutionOrder)).ToList(),
+            p.CreatedAt, p.UpdatedAt);
+}
+```
+
+- [ ] **Step 3: Controller tests**
+
+Happy path: create with tools, update to re-order tools, trigger-run writes ManualRequestedAt, trigger-run returns 409 when an active run already exists, invalid references return 400, delete cascades tools and assignments.
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~ScanProfilesControllerTests
+git add src/PatchHound.Api/Models/AuthenticatedScans/ScanProfileDtos.cs src/PatchHound.Api/Controllers/ScanProfilesController.cs tests/PatchHound.Tests/Api/ScanProfilesControllerTests.cs
+git commit -m "feat: add ScanProfilesController with tool assignment and manual trigger"
+```
+
+---
+
+## Task 18: Asset-rule `AssignScanProfile` operation — evaluation wiring + tests
+
+**Files:**
+- Modify: wherever `IAssetRuleEvaluationService` is implemented (search below)
+- Create: `tests/PatchHound.Tests/Core/AssetRuleEvaluationAssignScanProfileTests.cs`
+
+When an asset rule has operation `{ "type": "AssignScanProfile", "parameters": {"scanProfileId": "<guid>"} }`, evaluating it inserts/upserts an `AssetScanProfileAssignment` for every matched asset.
+
+- [ ] **Step 1: Locate the evaluation service**
+
+Run: `grep -rn "IAssetRuleEvaluationService" src/ --include="*.cs"`
+Open the implementation — likely `src/PatchHound.Core/Services/AssetRuleEvaluationService.cs` or `src/PatchHound.Infrastructure/Services/`. Find the operation dispatch (likely a switch on `operation.Type`). Note the file path.
+
+- [ ] **Step 2: Write failing test**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class AssetRuleEvaluationAssignScanProfileTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private Guid _tenantId = Guid.NewGuid();
+    private Guid _assetId;
+    private Guid _scanProfileId = Guid.NewGuid();
+    private Guid _ruleId;
+
+    public async Task InitializeAsync()
+    {
+        _db = TestDbContextFactory.CreateInMemory();
+        _assetId = await TestData.SeedDevice(_db, _tenantId, "h1");
+        // seed a ScanProfile stub (enough FKs to satisfy constraints, adjust to test data factories)
+        _db.ConnectionProfiles.Add(ConnectionProfile.Create(_tenantId, "c", "", "h", 22, "u", "password", "p", null));
+        _db.ScanRunners.Add(ScanRunner.Create(_tenantId, "r", "", "hash"));
+        var prof = ScanProfile.Create(_tenantId, "p", "", "", Guid.NewGuid(), Guid.NewGuid(), true);
+        typeof(ScanProfile).GetProperty(nameof(ScanProfile.Id))!.SetValue(prof, _scanProfileId);
+        _db.ScanProfiles.Add(prof);
+        // Simplest filter: match all assets for this tenant
+        var rule = AssetRule.Create(
+            tenantId: _tenantId, name: "all", description: null, priority: 0,
+            filter: new FilterGroup("AND", new List<FilterNode>()),
+            operations: new List<AssetRuleOperation>
+            {
+                new("AssignScanProfile", new Dictionary<string,string> { ["scanProfileId"] = _scanProfileId.ToString() }),
+            });
+        _db.AssetRules.Add(rule);
+        _ruleId = rule.Id;
+        await _db.SaveChangesAsync();
+    }
+    public Task DisposeAsync() { _db.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public async Task Evaluating_rule_inserts_assignment_for_matched_assets()
+    {
+        var service = new AssetRuleEvaluationService(_db /*, other deps */);
+        await service.EvaluateRuleAsync(_ruleId, CancellationToken.None);
+
+        var assignment = await _db.AssetScanProfileAssignments.SingleAsync();
+        Assert.Equal(_assetId, assignment.AssetId);
+        Assert.Equal(_scanProfileId, assignment.ScanProfileId);
+        Assert.Equal(_ruleId, assignment.AssignedByRuleId);
+    }
+
+    [Fact]
+    public async Task Evaluating_rule_twice_does_not_duplicate_assignment()
+    {
+        var service = new AssetRuleEvaluationService(_db);
+        await service.EvaluateRuleAsync(_ruleId, CancellationToken.None);
+        await service.EvaluateRuleAsync(_ruleId, CancellationToken.None);
+        Assert.Equal(1, await _db.AssetScanProfileAssignments.CountAsync());
+    }
+}
+```
+
+Adapt the service constructor + method signature to the real one found in Step 1.
+
+- [ ] **Step 3: Run failing test**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~AssetRuleEvaluationAssignScanProfileTests`
+Expected: FAIL.
+
+- [ ] **Step 4: Add the `"AssignScanProfile"` case to the operation handler**
+
+In the evaluation service's operation switch, add:
+
+```csharp
+case "AssignScanProfile":
+    if (!operation.Parameters.TryGetValue("scanProfileId", out var profileStr) || !Guid.TryParse(profileStr, out var scanProfileId))
+        break; // or log skip
+    foreach (var assetId in matchedAssetIds)
+    {
+        var exists = await _db.AssetScanProfileAssignments
+            .AnyAsync(a => a.AssetId == assetId && a.ScanProfileId == scanProfileId, ct);
+        if (!exists)
+        {
+            _db.AssetScanProfileAssignments.Add(
+                AssetScanProfileAssignment.Create(rule.TenantId, assetId, scanProfileId, rule.Id));
+        }
+    }
+    break;
+```
+
+(Adapt variable names `matchedAssetIds`, `rule`, `_db`, `ct` to match the real service's code.)
+
+- [ ] **Step 5: Run tests until green**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~AssetRuleEvaluationAssignScanProfileTests`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add <evaluation-service-file> tests/PatchHound.Tests/Core/AssetRuleEvaluationAssignScanProfileTests.cs
+git commit -m "feat: support AssignScanProfile operation in asset rule evaluation"
+```
+
+---
+
+## Task 19: End-to-end backend sanity test
+
+**Files:**
+- Create: `tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/BackendEndToEndTests.cs`
+
+One high-level test that wires up connection profile → tool → scan profile → assignment → dispatcher → fake result → ingestion service → assert installation exists.
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.AuthenticatedScans;
+
+public class BackendEndToEndTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private readonly Guid _tenantId = Guid.NewGuid();
+
+    public async Task InitializeAsync() { _db = TestDbContextFactory.CreateInMemory(); await Task.CompletedTask; }
+    public Task DisposeAsync() { _db.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public async Task Full_backend_flow_dispatches_and_ingests_software()
+    {
+        // Arrange: seed all config
+        var asset = await TestData.SeedDevice(_db, _tenantId, "host-1");
+        var conn = ConnectionProfile.Create(_tenantId, "c1", "", "h", 22, "u", "password", "secrets/tenants/x/conn/y", null);
+        var runner = ScanRunner.Create(_tenantId, "r1", "", "hash");
+        var tool = ScanningTool.Create(_tenantId, "t1", "", "python", "/usr/bin/python3", 300, "NormalizedSoftware");
+        var vStore = new ScanningToolVersionStore(_db);
+        _db.ConnectionProfiles.Add(conn); _db.ScanRunners.Add(runner); _db.ScanningTools.Add(tool);
+        await _db.SaveChangesAsync();
+        await vStore.AppendAsync(tool.Id, "print('{}')", Guid.NewGuid(), CancellationToken.None);
+        var profile = ScanProfile.Create(_tenantId, "p1", "", "", conn.Id, runner.Id, true);
+        _db.ScanProfiles.Add(profile);
+        _db.ScanProfileTools.Add(ScanProfileTool.Create(profile.Id, tool.Id, 0));
+        _db.AssetScanProfileAssignments.Add(AssetScanProfileAssignment.Create(_tenantId, asset, profile.Id, null));
+        await _db.SaveChangesAsync();
+
+        // Act: dispatcher creates jobs
+        var dispatcher = new ScanJobDispatcher(_db);
+        var runId = await dispatcher.StartRunAsync(profile.Id, "manual", Guid.NewGuid(), CancellationToken.None);
+        var job = await _db.ScanJobs.SingleAsync(j => j.RunId == runId);
+        _db.ScanJobResults.Add(ScanJobResult.Create(job.Id, "ok", "",
+            """{"software":[{"canonicalName":"nginx","canonicalProductKey":"nginx:nginx","detectedVersion":"1.24.0"}]}"""));
+        await _db.SaveChangesAsync();
+
+        // Act: ingest the job
+        var ingest = new AuthenticatedScanIngestionService(_db, new AuthenticatedScanOutputValidator());
+        var summary = await ingest.IngestAsync(job.Id, profile.Id, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, summary.EntriesIngested);
+        Assert.True(await _db.NormalizedSoftwareInstallations
+            .AnyAsync(i => i.DeviceAssetId == asset && i.SourceSystem == SoftwareIdentitySourceSystem.AuthenticatedScan));
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `dotnet test tests/PatchHound.Tests --filter FullyQualifiedName~BackendEndToEndTests`
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/BackendEndToEndTests.cs
+git commit -m "test: add backend end-to-end sanity test for authenticated scans"
+```
+
+---
+
+## Task 20: Final build + test sweep
+
+- [ ] **Step 1: Full solution build**
+
+Run: `dotnet build PatchHound.slnx`
+Expected: succeeds with no errors or new warnings.
+
+- [ ] **Step 2: Full test run**
+
+Run: `dotnet test tests/PatchHound.Tests`
+Expected: all tests pass (pre-existing + new ones).
+
+- [ ] **Step 3: Verify no plaintext secrets anywhere**
+
+Run: `grep -rn "Password\|SecretRef" src/PatchHound.Api/Models/AuthenticatedScans/`
+Confirm no DTO exposes `SecretRef`, `Password`, `PrivateKey`, or `Passphrase` in response shapes. Only request DTOs should have them.
+
+- [ ] **Step 4: Verify EF migration applies cleanly from scratch**
+
+Run (if you maintain a dev compose / test container):
+```bash
+dotnet ef database drop --force --startup-project src/PatchHound.Api --project src/PatchHound.Infrastructure
+dotnet ef database update --startup-project src/PatchHound.Api --project src/PatchHound.Infrastructure
+```
+Expected: applies without error.
+
+- [ ] **Step 5: Commit any final cleanups** (if any)
+
+```bash
+git commit --allow-empty -m "chore: backend foundations for authenticated scans complete"
+```
+
+---
+
+## Self-Review (plan author)
+
+**Spec coverage:**
+- §4.1 Configuration entities → Tasks 2, 3, 4, 5
+- §4.2 Run/execution entities → Task 6
+- §4.3 Enum + AssetRule op → Tasks 1, 18
+- §5.1 Enrollment (runner create + secret once) → Task 15 (admin-side only; runner-side `/scan-runner/heartbeat` is Plan 2)
+- §6.2 ScanJobDispatcher.StartRun → Task 12
+- §7.1 Output contract → documented via validator tests (Task 10)
+- §7.2 Validation rules → Task 10
+- §7.3 Staging + merge + precedence → Task 11
+- §8 UI → **deferred to Plan 3** (out of scope here, per plan split)
+- §9 Security (credentials in OpenBao, hashed runner secrets, audit via existing interceptor, tenant scoping, size caps) → Tasks 9, 11, 14, 15
+
+**Confirmed out of scope for this plan** (tracked in subsequent plans):
+- `ScanSchedulerWorker` + cron ticking + stale sweeper → Plan 2
+- `/api/scan-runner/*` endpoints (pull jobs, heartbeat, post results) → Plan 2
+- `PatchHound.ScanRunner` binary → Plan 2
+- Run completion detection on result post → Plan 2
+- Admin workbench UI → Plan 3
+- Sources admin tab + reports + asset-rules UI → Plan 4
+
+**Type consistency:** `AuthenticatedScanRunStatuses`, `ScanJobStatuses` constants used consistently across entities, dispatcher, ingestion service, and controllers. `SoftwareIdentitySourceSystem.AuthenticatedScan` used consistently. `ConnectionProfile.Id` reused as OpenBao path segment (matched via reflection-set or Create-with-id).
+
+**Known gaps/decisions surfaced to implementer:**
+- Task 11 Step 1: the exact shape of the `EnsureTenantSoftwareAsync` call depends on existing Defender merge logic that must be located and possibly extracted.
+- Task 14 Step 2: reflection-set of `ConnectionProfile.Id` is a temporary measure; the implementer may choose to add an overload `Create(id, tenantId, …)` instead.
+- Task 16 Step 2: `_tenant.UserId` availability depends on the existing `ITenantContext` shape.
+- Task 18 Step 1: asset-rule evaluation service location requires `grep` at implementation time.

--- a/docs/superpowers/plans/2026-04-07-authenticated-scans-04-admin-ui-workbench.md
+++ b/docs/superpowers/plans/2026-04-07-authenticated-scans-04-admin-ui-workbench.md
@@ -1,0 +1,2070 @@
+# Authenticated Scans Plan 4: Admin UI Workbench
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Authenticated Scans admin workbench page — a tabbed interface for managing scan profiles, scanning tools, connection profiles, and scan runners, with full CRUD operations.
+
+**Architecture:** TanStack Start route at `/admin/authenticated-scans` with 4 tabs driven by `?tab=` search param. Each tab has a DataTable + create/edit dialogs. Server functions call the existing backend controllers (`ScanProfilesController`, `ScanningToolsController`, `ConnectionProfilesController`, `ScanRunnersController`). Zod schemas validate API responses. Role-gated on `CustomerAdmin`.
+
+**Tech Stack:** React 19, TanStack Router + React Query, shadcn/ui (Tabs, DataTable, Dialog, Select, Input), Zod, Sonner toasts
+
+---
+
+## Scope
+
+**In scope:** API schemas, server functions, workbench route with all 4 tabs (data tables + create/edit/delete dialogs), scan runner secret-once modal, manual trigger button on profiles.
+
+**Out of scope (Plan 5):** CodeMirror script editor for tools, version history panel, sources admin tab, asset rule `AssignScanProfile` operation, run report dialog.
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `frontend/src/api/authenticated-scans.schemas.ts` | Zod schemas for all 4 entity types |
+| `frontend/src/api/authenticated-scans.functions.ts` | Server functions (fetch, create, update, delete, trigger) for all entities |
+| `frontend/src/routes/_authed/admin/authenticated-scans.tsx` | Route definition + workbench page with tab routing |
+| `frontend/src/components/features/admin/scan-profiles/ScanProfilesTab.tsx` | Profiles tab: data table + create/edit dialog |
+| `frontend/src/components/features/admin/scan-profiles/ScanProfileDialog.tsx` | Create/edit dialog for scan profiles |
+| `frontend/src/components/features/admin/scanning-tools/ScanningToolsTab.tsx` | Tools tab: data table + create dialog (basic, no CodeMirror yet) |
+| `frontend/src/components/features/admin/connection-profiles/ConnectionProfilesTab.tsx` | Connections tab: data table + create/edit dialog |
+| `frontend/src/components/features/admin/connection-profiles/ConnectionProfileDialog.tsx` | Create/edit dialog for connection profiles |
+| `frontend/src/components/features/admin/scan-runners/ScanRunnersTab.tsx` | Runners tab: data table + create dialog + secret modal |
+| `frontend/src/components/features/admin/scan-runners/RunnerSecretModal.tsx` | One-time secret display modal with copy + runner.yaml snippet |
+
+---
+
+## Task 1: Zod schemas for all authenticated scan entities
+
+**Files:**
+- Create: `frontend/src/api/authenticated-scans.schemas.ts`
+
+- [ ] **Step 1: Create schemas file**
+
+```typescript
+import { z } from 'zod'
+import { isoDateTimeSchema, nullableIsoDateTimeSchema } from './common.schemas'
+import { pagedResponseMetaSchema } from './pagination.schemas'
+
+// --- Scan Profiles ---
+
+export const scanProfileSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  cronSchedule: z.string(),
+  connectionProfileId: z.string().uuid(),
+  scanRunnerId: z.string().uuid(),
+  enabled: z.boolean(),
+  manualRequestedAt: nullableIsoDateTimeSchema,
+  lastRunStartedAt: nullableIsoDateTimeSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+  toolIds: z.array(z.string().uuid()),
+})
+
+export const pagedScanProfilesSchema = pagedResponseMetaSchema.extend({
+  items: z.array(scanProfileSchema),
+})
+
+export type ScanProfile = z.infer<typeof scanProfileSchema>
+export type PagedScanProfiles = z.infer<typeof pagedScanProfilesSchema>
+
+// --- Scanning Tools ---
+
+export const scanningToolSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  scriptType: z.string(),
+  interpreterPath: z.string(),
+  timeoutSeconds: z.number(),
+  outputModel: z.string(),
+  currentVersionId: z.string().uuid().nullable(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+})
+
+export const pagedScanningToolsSchema = pagedResponseMetaSchema.extend({
+  items: z.array(scanningToolSchema),
+})
+
+export type ScanningTool = z.infer<typeof scanningToolSchema>
+export type PagedScanningTools = z.infer<typeof pagedScanningToolsSchema>
+
+export const scanningToolVersionSchema = z.object({
+  id: z.string().uuid(),
+  scanningToolId: z.string().uuid(),
+  versionNumber: z.number(),
+  scriptContent: z.string(),
+  editedByUserId: z.string().uuid(),
+  editedAt: isoDateTimeSchema,
+})
+
+export type ScanningToolVersion = z.infer<typeof scanningToolVersionSchema>
+
+// --- Connection Profiles ---
+
+export const connectionProfileSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  sshHost: z.string(),
+  sshPort: z.number(),
+  sshUsername: z.string(),
+  authMethod: z.string(),
+  hostKeyFingerprint: z.string().nullable(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+})
+
+export const pagedConnectionProfilesSchema = pagedResponseMetaSchema.extend({
+  items: z.array(connectionProfileSchema),
+})
+
+export type ConnectionProfile = z.infer<typeof connectionProfileSchema>
+export type PagedConnectionProfiles = z.infer<typeof pagedConnectionProfilesSchema>
+
+// --- Scan Runners ---
+
+export const scanRunnerSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  lastSeenAt: nullableIsoDateTimeSchema,
+  version: z.string(),
+  enabled: z.boolean(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+})
+
+export const pagedScanRunnersSchema = pagedResponseMetaSchema.extend({
+  items: z.array(scanRunnerSchema),
+})
+
+export const createScanRunnerResponseSchema = z.object({
+  runner: scanRunnerSchema,
+  bearerSecret: z.string(),
+})
+
+export const rotateSecretResponseSchema = z.object({
+  bearerSecret: z.string(),
+})
+
+export const triggerRunResponseSchema = z.object({
+  runId: z.string().uuid(),
+})
+
+export type ScanRunner = z.infer<typeof scanRunnerSchema>
+export type PagedScanRunners = z.infer<typeof pagedScanRunnersSchema>
+export type CreateScanRunnerResponse = z.infer<typeof createScanRunnerResponseSchema>
+export type RotateSecretResponse = z.infer<typeof rotateSecretResponseSchema>
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/authenticated-scans.schemas.ts
+git commit -m "feat: add Zod schemas for authenticated scan entities"
+```
+
+---
+
+## Task 2: Server functions for all CRUD operations
+
+**Files:**
+- Create: `frontend/src/api/authenticated-scans.functions.ts`
+
+- [ ] **Step 1: Create server functions**
+
+```typescript
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+import { authMiddleware } from '@/server/middleware'
+import { apiDelete, apiGet, apiPost, apiPut } from '@/server/api'
+import { buildFilterParams } from './utils'
+import {
+  createScanRunnerResponseSchema,
+  pagedConnectionProfilesSchema,
+  pagedScanProfilesSchema,
+  pagedScanRunnersSchema,
+  pagedScanningToolsSchema,
+  rotateSecretResponseSchema,
+  scanProfileSchema,
+  triggerRunResponseSchema,
+} from './authenticated-scans.schemas'
+
+// ─── Scan Profiles ───
+
+export const fetchScanProfiles = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ page: z.number().optional(), pageSize: z.number().optional() }))
+  .handler(async ({ context, data: filters }) => {
+    const params = buildFilterParams(filters)
+    return pagedScanProfilesSchema.parse(await apiGet(`/scan-profiles?${params}`, context))
+  })
+
+export const createScanProfile = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      name: z.string().min(1),
+      description: z.string(),
+      cronSchedule: z.string(),
+      connectionProfileId: z.string().uuid(),
+      scanRunnerId: z.string().uuid(),
+      enabled: z.boolean(),
+      toolIds: z.array(z.string().uuid()),
+    }),
+  )
+  .handler(async ({ context, data }) => {
+    return scanProfileSchema.parse(await apiPost('/scan-profiles', context, data))
+  })
+
+export const updateScanProfile = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      id: z.string().uuid(),
+      name: z.string().min(1),
+      description: z.string(),
+      cronSchedule: z.string(),
+      connectionProfileId: z.string().uuid(),
+      scanRunnerId: z.string().uuid(),
+      enabled: z.boolean(),
+      toolIds: z.array(z.string().uuid()),
+    }),
+  )
+  .handler(async ({ context, data: { id, ...body } }) => {
+    return scanProfileSchema.parse(await apiPut(`/scan-profiles/${id}`, context, body))
+  })
+
+export const deleteScanProfile = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    await apiDelete(`/scan-profiles/${id}`, context)
+  })
+
+export const triggerScanRun = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    return triggerRunResponseSchema.parse(
+      await apiPost(`/scan-profiles/${id}/trigger`, context, { triggerKind: 'manual' }),
+    )
+  })
+
+// ─── Scanning Tools ───
+
+export const fetchScanningTools = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ page: z.number().optional(), pageSize: z.number().optional() }))
+  .handler(async ({ context, data: filters }) => {
+    const params = buildFilterParams(filters)
+    return pagedScanningToolsSchema.parse(await apiGet(`/scanning-tools?${params}`, context))
+  })
+
+export const createScanningTool = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      name: z.string().min(1),
+      description: z.string(),
+      scriptType: z.enum(['python', 'bash', 'powershell']),
+      interpreterPath: z.string().min(1),
+      timeoutSeconds: z.number().min(5).max(3600),
+      initialScript: z.string(),
+    }),
+  )
+  .handler(async ({ context, data }) => {
+    return await apiPost('/scanning-tools', context, data)
+  })
+
+export const updateScanningTool = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      id: z.string().uuid(),
+      name: z.string().min(1),
+      description: z.string(),
+      scriptType: z.enum(['python', 'bash', 'powershell']),
+      interpreterPath: z.string().min(1),
+      timeoutSeconds: z.number().min(5).max(3600),
+    }),
+  )
+  .handler(async ({ context, data: { id, ...body } }) => {
+    await apiPut(`/scanning-tools/${id}`, context, body)
+  })
+
+export const deleteScanningTool = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    await apiDelete(`/scanning-tools/${id}`, context)
+  })
+
+// ─── Connection Profiles ───
+
+export const fetchConnectionProfiles = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ page: z.number().optional(), pageSize: z.number().optional() }))
+  .handler(async ({ context, data: filters }) => {
+    const params = buildFilterParams(filters)
+    return pagedConnectionProfilesSchema.parse(await apiGet(`/connection-profiles?${params}`, context))
+  })
+
+export const createConnectionProfile = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      name: z.string().min(1),
+      description: z.string(),
+      sshHost: z.string().min(1),
+      sshPort: z.number().min(1).max(65535),
+      sshUsername: z.string().min(1),
+      authMethod: z.enum(['password', 'privateKey']),
+      password: z.string().optional(),
+      privateKey: z.string().optional(),
+      passphrase: z.string().optional(),
+      hostKeyFingerprint: z.string().optional(),
+    }),
+  )
+  .handler(async ({ context, data }) => {
+    return await apiPost('/connection-profiles', context, data)
+  })
+
+export const updateConnectionProfile = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      id: z.string().uuid(),
+      name: z.string().min(1),
+      description: z.string(),
+      sshHost: z.string().min(1),
+      sshPort: z.number().min(1).max(65535),
+      sshUsername: z.string().min(1),
+      authMethod: z.enum(['password', 'privateKey']),
+      password: z.string().optional(),
+      privateKey: z.string().optional(),
+      passphrase: z.string().optional(),
+      hostKeyFingerprint: z.string().optional(),
+    }),
+  )
+  .handler(async ({ context, data: { id, ...body } }) => {
+    await apiPut(`/connection-profiles/${id}`, context, body)
+  })
+
+export const deleteConnectionProfile = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    await apiDelete(`/connection-profiles/${id}`, context)
+  })
+
+// ─── Scan Runners ───
+
+export const fetchScanRunners = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ page: z.number().optional(), pageSize: z.number().optional() }))
+  .handler(async ({ context, data: filters }) => {
+    const params = buildFilterParams(filters)
+    return pagedScanRunnersSchema.parse(await apiGet(`/scan-runners?${params}`, context))
+  })
+
+export const createScanRunner = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ name: z.string().min(1), description: z.string() }))
+  .handler(async ({ context, data }) => {
+    return createScanRunnerResponseSchema.parse(await apiPost('/scan-runners', context, data))
+  })
+
+export const updateScanRunner = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(
+    z.object({
+      id: z.string().uuid(),
+      name: z.string().min(1),
+      description: z.string(),
+      enabled: z.boolean(),
+    }),
+  )
+  .handler(async ({ context, data: { id, ...body } }) => {
+    await apiPut(`/scan-runners/${id}`, context, body)
+  })
+
+export const rotateScanRunnerSecret = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    return rotateSecretResponseSchema.parse(await apiPost(`/scan-runners/${id}/rotate-secret`, context, {}))
+  })
+
+export const deleteScanRunner = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    await apiDelete(`/scan-runners/${id}`, context)
+  })
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/authenticated-scans.functions.ts
+git commit -m "feat: add server functions for authenticated scan CRUD operations"
+```
+
+---
+
+## Task 3: Workbench route with tab skeleton
+
+**Files:**
+- Create: `frontend/src/routes/_authed/admin/authenticated-scans.tsx`
+
+- [ ] **Step 1: Create the route file**
+
+```typescript
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { z } from 'zod'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  fetchConnectionProfiles,
+  fetchScanProfiles,
+  fetchScanRunners,
+  fetchScanningTools,
+} from '@/api/authenticated-scans.functions'
+import { baseListSearchSchema } from '@/routes/-list-search'
+
+const tabValues = ['profiles', 'tools', 'connections', 'runners'] as const
+
+export const Route = createFileRoute('/_authed/admin/authenticated-scans')({
+  beforeLoad: ({ context }) => {
+    const activeRoles = context.user?.activeRoles ?? []
+    if (!activeRoles.includes('CustomerAdmin') && !activeRoles.includes('GlobalAdmin')) {
+      throw redirect({ to: '/admin' })
+    }
+  },
+  validateSearch: baseListSearchSchema.extend({
+    tab: z.enum(tabValues).optional(),
+  }),
+  loaderDeps: ({ search }) => search,
+  loader: async ({ deps }) => {
+    const tab = deps.tab ?? 'profiles'
+    const paging = { page: deps.page, pageSize: deps.pageSize }
+
+    // Only fetch data for the active tab
+    if (tab === 'profiles') {
+      const [profiles, tools, connections, runners] = await Promise.all([
+        fetchScanProfiles({ data: paging }),
+        fetchScanningTools({ data: { pageSize: 100 } }),
+        fetchConnectionProfiles({ data: { pageSize: 100 } }),
+        fetchScanRunners({ data: { pageSize: 100 } }),
+      ])
+      return { profiles, tools, connections, runners, tab }
+    }
+    if (tab === 'tools') {
+      return { tools: await fetchScanningTools({ data: paging }), tab }
+    }
+    if (tab === 'connections') {
+      return { connections: await fetchConnectionProfiles({ data: paging }), tab }
+    }
+    return { runners: await fetchScanRunners({ data: paging }), tab }
+  },
+  component: AuthenticatedScansWorkbench,
+})
+
+function AuthenticatedScansWorkbench() {
+  const navigate = Route.useNavigate()
+  const search = Route.useSearch()
+  const loaderData = Route.useLoaderData()
+  const activeTab = search.tab ?? 'profiles'
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Authenticated Scans</h1>
+        <p className="text-muted-foreground text-sm">
+          Manage scan profiles, tools, connections, and runners for on-prem host scanning.
+        </p>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) =>
+          navigate({ search: { tab: value as (typeof tabValues)[number], page: 1, pageSize: search.pageSize } })
+        }
+      >
+        <TabsList className="h-10 w-full justify-start rounded-xl bg-muted/50 p-1">
+          <TabsTrigger value="profiles">Scan Profiles</TabsTrigger>
+          <TabsTrigger value="tools">Scanning Tools</TabsTrigger>
+          <TabsTrigger value="connections">Connections</TabsTrigger>
+          <TabsTrigger value="runners">Runners</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profiles" className="space-y-4 pt-1">
+          <p className="text-muted-foreground text-sm">Scan profiles tab — loaded in next task.</p>
+        </TabsContent>
+
+        <TabsContent value="tools" className="space-y-4 pt-1">
+          <p className="text-muted-foreground text-sm">Scanning tools tab — loaded in next task.</p>
+        </TabsContent>
+
+        <TabsContent value="connections" className="space-y-4 pt-1">
+          <p className="text-muted-foreground text-sm">Connection profiles tab — loaded in next task.</p>
+        </TabsContent>
+
+        <TabsContent value="runners" className="space-y-4 pt-1">
+          <p className="text-muted-foreground text-sm">Scan runners tab — loaded in next task.</p>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify dev server compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/routes/_authed/admin/authenticated-scans.tsx
+git commit -m "feat: add authenticated scans workbench route with tab skeleton"
+```
+
+---
+
+## Task 4: Scan Runners tab (simplest entity — build the pattern)
+
+**Files:**
+- Create: `frontend/src/components/features/admin/scan-runners/ScanRunnersTab.tsx`
+- Create: `frontend/src/components/features/admin/scan-runners/RunnerSecretModal.tsx`
+- Modify: `frontend/src/routes/_authed/admin/authenticated-scans.tsx`
+
+This is the simplest CRUD entity (name, description, enabled). We build it first to establish the pattern for the other tabs.
+
+- [ ] **Step 1: Create RunnerSecretModal**
+
+```typescript
+import { useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  runnerName: string
+  runnerId: string
+  bearerSecret: string
+  centralUrl?: string
+}
+
+export function RunnerSecretModal({ open, onOpenChange, runnerName, runnerId, bearerSecret, centralUrl }: Props) {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const yamlSnippet = `# runner.yaml for ${runnerName}
+centralUrl: "${centralUrl ?? 'https://your-patchhound-instance.com'}"
+bearerToken: "${bearerSecret}"
+maxConcurrentJobs: 10
+pollIntervalSeconds: 10
+heartbeatIntervalSeconds: 30`
+
+  const copyToClipboard = async (text: string, label: string) => {
+    await navigator.clipboard.writeText(text)
+    setCopied(label)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Runner Created: {runnerName}</DialogTitle>
+          <DialogDescription>
+            Save the bearer secret below — it will not be shown again.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label className="text-sm font-medium">Runner ID</label>
+            <div className="mt-1 flex items-center gap-2">
+              <code className="bg-muted rounded px-2 py-1 text-sm flex-1 break-all">{runnerId}</code>
+              <Button size="icon" variant="ghost" onClick={() => copyToClipboard(runnerId, 'id')}>
+                {copied === 'id' ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium">Bearer Secret</label>
+            <div className="mt-1 flex items-center gap-2">
+              <code className="bg-muted rounded px-2 py-1 text-sm flex-1 break-all font-mono">{bearerSecret}</code>
+              <Button size="icon" variant="ghost" onClick={() => copyToClipboard(bearerSecret, 'secret')}>
+                {copied === 'secret' ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">runner.yaml</label>
+              <Button size="sm" variant="ghost" onClick={() => copyToClipboard(yamlSnippet, 'yaml')}>
+                {copied === 'yaml' ? <Check className="mr-1 h-3 w-3" /> : <Copy className="mr-1 h-3 w-3" />}
+                {copied === 'yaml' ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+            <pre className="bg-muted mt-1 rounded p-3 text-xs overflow-x-auto whitespace-pre">{yamlSnippet}</pre>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: Create ScanRunnersTab**
+
+```typescript
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { toast } from 'sonner'
+import { formatDistanceToNow } from 'date-fns'
+import { Plus, RotateCw, Trash2 } from 'lucide-react'
+import {
+  createScanRunner,
+  deleteScanRunner,
+  fetchScanRunners,
+  rotateScanRunnerSecret,
+  updateScanRunner,
+} from '@/api/authenticated-scans.functions'
+import type { PagedScanRunners, ScanRunner } from '@/api/authenticated-scans.schemas'
+import { RunnerSecretModal } from './RunnerSecretModal'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { DataTable } from '@/components/ui/data-table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { PaginationControls } from '@/components/ui/pagination-controls'
+import { Textarea } from '@/components/ui/textarea'
+
+type Props = {
+  initialData: PagedScanRunners
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+}
+
+export function ScanRunnersTab({ initialData, page, pageSize, onPageChange }: Props) {
+  const queryClient = useQueryClient()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [secretModal, setSecretModal] = useState<{
+    open: boolean
+    runnerName: string
+    runnerId: string
+    bearerSecret: string
+  }>({ open: false, runnerName: '', runnerId: '', bearerSecret: '' })
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+
+  const query = useQuery({
+    queryKey: ['scan-runners', page, pageSize],
+    queryFn: () => fetchScanRunners({ data: { page, pageSize } }),
+    initialData,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createScanRunner,
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['scan-runners'] })
+      setCreateOpen(false)
+      setName('')
+      setDescription('')
+      setSecretModal({
+        open: true,
+        runnerName: result.runner.name,
+        runnerId: result.runner.id,
+        bearerSecret: result.bearerSecret,
+      })
+    },
+    onError: () => toast.error('Failed to create runner'),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteScanRunner,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scan-runners'] })
+      toast.success('Runner deleted')
+    },
+    onError: () => toast.error('Failed to delete runner'),
+  })
+
+  const rotateMutation = useMutation({
+    mutationFn: rotateScanRunnerSecret,
+    onSuccess: (result, variables) => {
+      const runner = query.data?.items.find((r) => r.id === variables.data.id)
+      setSecretModal({
+        open: true,
+        runnerName: runner?.name ?? 'Runner',
+        runnerId: variables.data.id,
+        bearerSecret: result.bearerSecret,
+      })
+    },
+    onError: () => toast.error('Failed to rotate secret'),
+  })
+
+  const isOnline = (runner: ScanRunner) => {
+    if (!runner.lastSeenAt) return false
+    const diff = Date.now() - new Date(runner.lastSeenAt).getTime()
+    return diff < 2 * 60 * 1000
+  }
+
+  const columns: ColumnDef<ScanRunner>[] = [
+    { accessorKey: 'name', header: 'Name' },
+    {
+      accessorKey: 'lastSeenAt',
+      header: 'Last Seen',
+      cell: ({ row }) => {
+        const val = row.original.lastSeenAt
+        if (!val) return <span className="text-muted-foreground">Never</span>
+        return formatDistanceToNow(new Date(val), { addSuffix: true })
+      },
+    },
+    { accessorKey: 'version', header: 'Version' },
+    {
+      id: 'status',
+      header: 'Status',
+      cell: ({ row }) =>
+        isOnline(row.original) ? (
+          <Badge variant="default" className="bg-green-600">Online</Badge>
+        ) : (
+          <Badge variant="secondary">Offline</Badge>
+        ),
+    },
+    {
+      id: 'enabled',
+      header: 'Enabled',
+      cell: ({ row }) => (row.original.enabled ? 'Yes' : 'No'),
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => rotateMutation.mutate({ data: { id: row.original.id } })}
+            disabled={rotateMutation.isPending}
+          >
+            <RotateCw className="mr-1 h-3 w-3" />
+            Rotate Secret
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive"
+            onClick={() => {
+              if (confirm(`Delete runner "${row.original.name}"?`)) {
+                deleteMutation.mutate({ data: { id: row.original.id } })
+              }
+            }}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Scan Runners</CardTitle>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1 h-4 w-4" />
+            New Runner
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <DataTable columns={columns} data={query.data?.items ?? []} />
+          <PaginationControls
+            page={page}
+            pageSize={pageSize}
+            totalCount={query.data?.totalCount ?? 0}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Create dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Scan Runner</DialogTitle>
+            <DialogDescription>
+              Create a runner identity. A bearer secret will be shown once after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="runner-name">Name</Label>
+              <Input id="runner-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="prod-scanner-01" />
+            </div>
+            <div>
+              <Label htmlFor="runner-desc">Description</Label>
+              <Textarea id="runner-desc" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="On-prem runner in datacenter A" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => createMutation.mutate({ data: { name, description } })}
+              disabled={!name || createMutation.isPending}
+            >
+              Create Runner
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Secret modal */}
+      <RunnerSecretModal
+        open={secretModal.open}
+        onOpenChange={(open) => setSecretModal((s) => ({ ...s, open }))}
+        runnerName={secretModal.runnerName}
+        runnerId={secretModal.runnerId}
+        bearerSecret={secretModal.bearerSecret}
+      />
+    </>
+  )
+}
+```
+
+- [ ] **Step 3: Wire into workbench route**
+
+In `frontend/src/routes/_authed/admin/authenticated-scans.tsx`, replace the runners `TabsContent` placeholder:
+
+Import the component at the top:
+```typescript
+import { ScanRunnersTab } from '@/components/features/admin/scan-runners/ScanRunnersTab'
+```
+
+Replace the runners TabsContent:
+```typescript
+        <TabsContent value="runners" className="space-y-4 pt-1">
+          {'runners' in loaderData && loaderData.runners && (
+            <ScanRunnersTab
+              initialData={loaderData.runners}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(p) => navigate({ search: { ...search, page: p } })}
+            />
+          )}
+        </TabsContent>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/features/admin/scan-runners/ \
+  frontend/src/routes/_authed/admin/authenticated-scans.tsx
+git commit -m "feat: add Scan Runners tab with create dialog and secret modal"
+```
+
+---
+
+## Task 5: Connection Profiles tab
+
+**Files:**
+- Create: `frontend/src/components/features/admin/connection-profiles/ConnectionProfilesTab.tsx`
+- Create: `frontend/src/components/features/admin/connection-profiles/ConnectionProfileDialog.tsx`
+- Modify: `frontend/src/routes/_authed/admin/authenticated-scans.tsx`
+
+- [ ] **Step 1: Create ConnectionProfileDialog**
+
+```typescript
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import type { ConnectionProfile } from '@/api/authenticated-scans.schemas'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  profile?: ConnectionProfile | null
+  onSubmit: (data: {
+    name: string
+    description: string
+    sshHost: string
+    sshPort: number
+    sshUsername: string
+    authMethod: 'password' | 'privateKey'
+    password?: string
+    privateKey?: string
+    passphrase?: string
+    hostKeyFingerprint?: string
+  }) => void
+  isPending: boolean
+}
+
+export function ConnectionProfileDialog({ open, onOpenChange, profile, onSubmit, isPending }: Props) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [sshHost, setSshHost] = useState('')
+  const [sshPort, setSshPort] = useState(22)
+  const [sshUsername, setSshUsername] = useState('')
+  const [authMethod, setAuthMethod] = useState<'password' | 'privateKey'>('password')
+  const [password, setPassword] = useState('')
+  const [privateKey, setPrivateKey] = useState('')
+  const [passphrase, setPassphrase] = useState('')
+  const [hostKeyFingerprint, setHostKeyFingerprint] = useState('')
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile.name)
+      setDescription(profile.description)
+      setSshHost(profile.sshHost)
+      setSshPort(profile.sshPort)
+      setSshUsername(profile.sshUsername)
+      setAuthMethod(profile.authMethod as 'password' | 'privateKey')
+      setHostKeyFingerprint(profile.hostKeyFingerprint ?? '')
+    } else {
+      setName('')
+      setDescription('')
+      setSshHost('')
+      setSshPort(22)
+      setSshUsername('')
+      setAuthMethod('password')
+      setHostKeyFingerprint('')
+    }
+    setPassword('')
+    setPrivateKey('')
+    setPassphrase('')
+  }, [profile, open])
+
+  const isEdit = Boolean(profile)
+  const canSubmit = name && sshHost && sshUsername && (isEdit || (authMethod === 'password' ? password : privateKey))
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit' : 'New'} Connection Profile</DialogTitle>
+          <DialogDescription>SSH connection details for target hosts.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+          <div>
+            <Label>Name</Label>
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="prod-linux-servers" />
+          </div>
+          <div>
+            <Label>Description</Label>
+            <Textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-2">
+              <Label>SSH Host</Label>
+              <Input value={sshHost} onChange={(e) => setSshHost(e.target.value)} placeholder="10.0.1.50" />
+            </div>
+            <div>
+              <Label>Port</Label>
+              <Input type="number" value={sshPort} onChange={(e) => setSshPort(Number(e.target.value))} />
+            </div>
+          </div>
+          <div>
+            <Label>Username</Label>
+            <Input value={sshUsername} onChange={(e) => setSshUsername(e.target.value)} placeholder="scanner" />
+          </div>
+          <div>
+            <Label>Auth Method</Label>
+            <div className="mt-1 flex gap-4">
+              <label className="flex items-center gap-2 text-sm">
+                <input type="radio" checked={authMethod === 'password'} onChange={() => setAuthMethod('password')} />
+                Password
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input type="radio" checked={authMethod === 'privateKey'} onChange={() => setAuthMethod('privateKey')} />
+                Private Key
+              </label>
+            </div>
+          </div>
+          {authMethod === 'password' ? (
+            <div>
+              <Label>{isEdit ? 'New Password (leave blank to keep)' : 'Password'}</Label>
+              <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+            </div>
+          ) : (
+            <>
+              <div>
+                <Label>{isEdit ? 'New Private Key (leave blank to keep)' : 'Private Key'}</Label>
+                <Textarea value={privateKey} onChange={(e) => setPrivateKey(e.target.value)} rows={4} className="font-mono text-xs" placeholder="-----BEGIN RSA PRIVATE KEY-----" />
+              </div>
+              <div>
+                <Label>Passphrase (optional)</Label>
+                <Input type="password" value={passphrase} onChange={(e) => setPassphrase(e.target.value)} />
+              </div>
+            </>
+          )}
+          <div>
+            <Label>Host Key Fingerprint (optional)</Label>
+            <Input value={hostKeyFingerprint} onChange={(e) => setHostKeyFingerprint(e.target.value)} placeholder="SHA256:..." />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button
+            onClick={() =>
+              onSubmit({
+                name,
+                description,
+                sshHost,
+                sshPort,
+                sshUsername,
+                authMethod,
+                ...(password ? { password } : {}),
+                ...(privateKey ? { privateKey } : {}),
+                ...(passphrase ? { passphrase } : {}),
+                ...(hostKeyFingerprint ? { hostKeyFingerprint } : {}),
+              })
+            }
+            disabled={!canSubmit || isPending}
+          >
+            {isEdit ? 'Save' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: Create ConnectionProfilesTab**
+
+```typescript
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { toast } from 'sonner'
+import { PenSquare, Plus, Trash2 } from 'lucide-react'
+import {
+  createConnectionProfile,
+  deleteConnectionProfile,
+  fetchConnectionProfiles,
+  updateConnectionProfile,
+} from '@/api/authenticated-scans.functions'
+import type { ConnectionProfile, PagedConnectionProfiles } from '@/api/authenticated-scans.schemas'
+import { ConnectionProfileDialog } from './ConnectionProfileDialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { DataTable } from '@/components/ui/data-table'
+import { PaginationControls } from '@/components/ui/pagination-controls'
+
+type Props = {
+  initialData: PagedConnectionProfiles
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+}
+
+export function ConnectionProfilesTab({ initialData, page, pageSize, onPageChange }: Props) {
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<ConnectionProfile | null>(null)
+
+  const query = useQuery({
+    queryKey: ['connection-profiles', page, pageSize],
+    queryFn: () => fetchConnectionProfiles({ data: { page, pageSize } }),
+    initialData,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createConnectionProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['connection-profiles'] })
+      setDialogOpen(false)
+      toast.success('Connection profile created')
+    },
+    onError: () => toast.error('Failed to create connection profile'),
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: updateConnectionProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['connection-profiles'] })
+      setDialogOpen(false)
+      setEditing(null)
+      toast.success('Connection profile updated')
+    },
+    onError: () => toast.error('Failed to update connection profile'),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteConnectionProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['connection-profiles'] })
+      toast.success('Connection profile deleted')
+    },
+    onError: () => toast.error('Failed to delete connection profile'),
+  })
+
+  const columns: ColumnDef<ConnectionProfile>[] = [
+    { accessorKey: 'name', header: 'Name' },
+    {
+      id: 'host',
+      header: 'Host',
+      cell: ({ row }) => `${row.original.sshHost}:${row.original.sshPort}`,
+    },
+    { accessorKey: 'sshUsername', header: 'Username' },
+    {
+      accessorKey: 'authMethod',
+      header: 'Auth',
+      cell: ({ row }) => (
+        <Badge variant="outline">{row.original.authMethod === 'privateKey' ? 'Key' : 'Password'}</Badge>
+      ),
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setEditing(row.original)
+              setDialogOpen(true)
+            }}
+          >
+            <PenSquare className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive"
+            onClick={() => {
+              if (confirm(`Delete "${row.original.name}"?`)) {
+                deleteMutation.mutate({ data: { id: row.original.id } })
+              }
+            }}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Connection Profiles</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditing(null)
+              setDialogOpen(true)
+            }}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            New Connection
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <DataTable columns={columns} data={query.data?.items ?? []} />
+          <PaginationControls
+            page={page}
+            pageSize={pageSize}
+            totalCount={query.data?.totalCount ?? 0}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+
+      <ConnectionProfileDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open)
+          if (!open) setEditing(null)
+        }}
+        profile={editing}
+        isPending={createMutation.isPending || updateMutation.isPending}
+        onSubmit={(data) => {
+          if (editing) {
+            updateMutation.mutate({ data: { id: editing.id, ...data } })
+          } else {
+            createMutation.mutate({ data })
+          }
+        }}
+      />
+    </>
+  )
+}
+```
+
+- [ ] **Step 3: Wire into workbench route**
+
+In `authenticated-scans.tsx`, add import:
+```typescript
+import { ConnectionProfilesTab } from '@/components/features/admin/connection-profiles/ConnectionProfilesTab'
+```
+
+Replace connections TabsContent:
+```typescript
+        <TabsContent value="connections" className="space-y-4 pt-1">
+          {'connections' in loaderData && loaderData.connections && (
+            <ConnectionProfilesTab
+              initialData={loaderData.connections}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(p) => navigate({ search: { ...search, page: p } })}
+            />
+          )}
+        </TabsContent>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/features/admin/connection-profiles/ \
+  frontend/src/routes/_authed/admin/authenticated-scans.tsx
+git commit -m "feat: add Connection Profiles tab with create/edit dialog"
+```
+
+---
+
+## Task 6: Scanning Tools tab (basic — no CodeMirror yet)
+
+**Files:**
+- Create: `frontend/src/components/features/admin/scanning-tools/ScanningToolsTab.tsx`
+- Modify: `frontend/src/routes/_authed/admin/authenticated-scans.tsx`
+
+- [ ] **Step 1: Create ScanningToolsTab**
+
+```typescript
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { toast } from 'sonner'
+import { Plus, Trash2 } from 'lucide-react'
+import {
+  createScanningTool,
+  deleteScanningTool,
+  fetchScanningTools,
+} from '@/api/authenticated-scans.functions'
+import type { PagedScanningTools, ScanningTool } from '@/api/authenticated-scans.schemas'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { DataTable } from '@/components/ui/data-table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { PaginationControls } from '@/components/ui/pagination-controls'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+
+type Props = {
+  initialData: PagedScanningTools
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+}
+
+const scriptTypes = ['python', 'bash', 'powershell'] as const
+const defaultInterpreters: Record<string, string> = {
+  python: '/usr/bin/python3',
+  bash: '/bin/bash',
+  powershell: '/usr/bin/pwsh',
+}
+
+export function ScanningToolsTab({ initialData, page, pageSize, onPageChange }: Props) {
+  const queryClient = useQueryClient()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [scriptType, setScriptType] = useState<(typeof scriptTypes)[number]>('python')
+  const [interpreterPath, setInterpreterPath] = useState(defaultInterpreters.python)
+  const [timeoutSeconds, setTimeoutSeconds] = useState(300)
+  const [initialScript, setInitialScript] = useState('')
+
+  const query = useQuery({
+    queryKey: ['scanning-tools', page, pageSize],
+    queryFn: () => fetchScanningTools({ data: { page, pageSize } }),
+    initialData,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createScanningTool,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scanning-tools'] })
+      setCreateOpen(false)
+      resetForm()
+      toast.success('Scanning tool created')
+    },
+    onError: () => toast.error('Failed to create scanning tool'),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteScanningTool,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scanning-tools'] })
+      toast.success('Scanning tool deleted')
+    },
+    onError: () => toast.error('Failed to delete scanning tool'),
+  })
+
+  const resetForm = () => {
+    setName('')
+    setDescription('')
+    setScriptType('python')
+    setInterpreterPath(defaultInterpreters.python)
+    setTimeoutSeconds(300)
+    setInitialScript('')
+  }
+
+  const columns: ColumnDef<ScanningTool>[] = [
+    { accessorKey: 'name', header: 'Name' },
+    {
+      accessorKey: 'scriptType',
+      header: 'Type',
+      cell: ({ row }) => <Badge variant="outline">{row.original.scriptType}</Badge>,
+    },
+    {
+      accessorKey: 'outputModel',
+      header: 'Output',
+      cell: ({ row }) => <Badge variant="secondary">{row.original.outputModel}</Badge>,
+    },
+    {
+      accessorKey: 'timeoutSeconds',
+      header: 'Timeout',
+      cell: ({ row }) => `${row.original.timeoutSeconds}s`,
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-destructive"
+          onClick={() => {
+            if (confirm(`Delete "${row.original.name}"?`)) {
+              deleteMutation.mutate({ data: { id: row.original.id } })
+            }
+          }}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Scanning Tools</CardTitle>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1 h-4 w-4" />
+            New Tool
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <DataTable columns={columns} data={query.data?.items ?? []} />
+          <PaginationControls
+            page={page}
+            pageSize={pageSize}
+            totalCount={query.data?.totalCount ?? 0}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>New Scanning Tool</DialogTitle>
+            <DialogDescription>Define a script that runs on target hosts and produces structured output.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+            <div>
+              <Label>Name</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="linux-software-inventory" />
+            </div>
+            <div>
+              <Label>Description</Label>
+              <Textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label>Script Type</Label>
+                <Select
+                  value={scriptType}
+                  onValueChange={(v) => {
+                    const st = v as (typeof scriptTypes)[number]
+                    setScriptType(st)
+                    setInterpreterPath(defaultInterpreters[st] ?? '')
+                  }}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {scriptTypes.map((t) => (
+                      <SelectItem key={t} value={t}>{t}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Timeout (seconds)</Label>
+                <Input type="number" value={timeoutSeconds} onChange={(e) => setTimeoutSeconds(Number(e.target.value))} min={5} max={3600} />
+              </div>
+            </div>
+            <div>
+              <Label>Interpreter Path</Label>
+              <Input value={interpreterPath} onChange={(e) => setInterpreterPath(e.target.value)} />
+            </div>
+            <div>
+              <Label>Initial Script</Label>
+              <Textarea
+                value={initialScript}
+                onChange={(e) => setInitialScript(e.target.value)}
+                rows={8}
+                className="font-mono text-xs"
+                placeholder="# Your script here..."
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() =>
+                createMutation.mutate({
+                  data: { name, description, scriptType, interpreterPath, timeoutSeconds, initialScript },
+                })
+              }
+              disabled={!name || !interpreterPath || !initialScript || createMutation.isPending}
+            >
+              Create Tool
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+```
+
+- [ ] **Step 2: Wire into workbench route**
+
+In `authenticated-scans.tsx`, add import:
+```typescript
+import { ScanningToolsTab } from '@/components/features/admin/scanning-tools/ScanningToolsTab'
+```
+
+Replace tools TabsContent:
+```typescript
+        <TabsContent value="tools" className="space-y-4 pt-1">
+          {'tools' in loaderData && loaderData.tools && (
+            <ScanningToolsTab
+              initialData={loaderData.tools}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(p) => navigate({ search: { ...search, page: p } })}
+            />
+          )}
+        </TabsContent>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/features/admin/scanning-tools/ \
+  frontend/src/routes/_authed/admin/authenticated-scans.tsx
+git commit -m "feat: add Scanning Tools tab with create dialog"
+```
+
+---
+
+## Task 7: Scan Profiles tab
+
+**Files:**
+- Create: `frontend/src/components/features/admin/scan-profiles/ScanProfileDialog.tsx`
+- Create: `frontend/src/components/features/admin/scan-profiles/ScanProfilesTab.tsx`
+- Modify: `frontend/src/routes/_authed/admin/authenticated-scans.tsx`
+
+- [ ] **Step 1: Create ScanProfileDialog**
+
+```typescript
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import type { ConnectionProfile, ScanProfile, ScanRunner, ScanningTool } from '@/api/authenticated-scans.schemas'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  profile?: ScanProfile | null
+  runners: ScanRunner[]
+  connections: ConnectionProfile[]
+  tools: ScanningTool[]
+  onSubmit: (data: {
+    name: string
+    description: string
+    cronSchedule: string
+    connectionProfileId: string
+    scanRunnerId: string
+    enabled: boolean
+    toolIds: string[]
+  }) => void
+  isPending: boolean
+}
+
+export function ScanProfileDialog({
+  open,
+  onOpenChange,
+  profile,
+  runners,
+  connections,
+  tools,
+  onSubmit,
+  isPending,
+}: Props) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [cronSchedule, setCronSchedule] = useState('')
+  const [connectionProfileId, setConnectionProfileId] = useState('')
+  const [scanRunnerId, setScanRunnerId] = useState('')
+  const [enabled, setEnabled] = useState(true)
+  const [selectedToolIds, setSelectedToolIds] = useState<string[]>([])
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile.name)
+      setDescription(profile.description)
+      setCronSchedule(profile.cronSchedule)
+      setConnectionProfileId(profile.connectionProfileId)
+      setScanRunnerId(profile.scanRunnerId)
+      setEnabled(profile.enabled)
+      setSelectedToolIds(profile.toolIds)
+    } else {
+      setName('')
+      setDescription('')
+      setCronSchedule('')
+      setConnectionProfileId(connections[0]?.id ?? '')
+      setScanRunnerId(runners[0]?.id ?? '')
+      setEnabled(true)
+      setSelectedToolIds([])
+    }
+  }, [profile, open, connections, runners])
+
+  const toggleTool = (toolId: string) => {
+    setSelectedToolIds((prev) =>
+      prev.includes(toolId) ? prev.filter((id) => id !== toolId) : [...prev, toolId],
+    )
+  }
+
+  const canSubmit = name && connectionProfileId && scanRunnerId
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{profile ? 'Edit' : 'New'} Scan Profile</DialogTitle>
+          <DialogDescription>Bundle tools, schedule, and runner into a scan configuration.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+          <div>
+            <Label>Name</Label>
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="weekly-linux-scan" />
+          </div>
+          <div>
+            <Label>Description</Label>
+            <Textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+          <div>
+            <Label>Cron Schedule (empty = manual only)</Label>
+            <Input value={cronSchedule} onChange={(e) => setCronSchedule(e.target.value)} placeholder="0 2 * * 0" />
+            {cronSchedule && (
+              <p className="text-muted-foreground text-xs mt-1">
+                Cron: {cronSchedule || 'manual only'}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label>Runner</Label>
+            <Select value={scanRunnerId} onValueChange={setScanRunnerId}>
+              <SelectTrigger><SelectValue placeholder="Select runner" /></SelectTrigger>
+              <SelectContent>
+                {runners.map((r) => (
+                  <SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Connection Profile</Label>
+            <Select value={connectionProfileId} onValueChange={setConnectionProfileId}>
+              <SelectTrigger><SelectValue placeholder="Select connection" /></SelectTrigger>
+              <SelectContent>
+                {connections.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name} ({c.sshHost}:{c.sshPort})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Tools</Label>
+            <div className="mt-1 space-y-2 rounded border p-2">
+              {tools.length === 0 && (
+                <p className="text-muted-foreground text-sm">No tools created yet.</p>
+              )}
+              {tools.map((tool) => (
+                <label key={tool.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={selectedToolIds.includes(tool.id)}
+                    onChange={() => toggleTool(tool.id)}
+                  />
+                  {tool.name}
+                  <span className="text-muted-foreground">({tool.scriptType})</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch checked={enabled} onCheckedChange={setEnabled} />
+            <Label>Enabled</Label>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button
+            onClick={() =>
+              onSubmit({
+                name,
+                description,
+                cronSchedule,
+                connectionProfileId,
+                scanRunnerId,
+                enabled,
+                toolIds: selectedToolIds,
+              })
+            }
+            disabled={!canSubmit || isPending}
+          >
+            {profile ? 'Save' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: Create ScanProfilesTab**
+
+```typescript
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { toast } from 'sonner'
+import { PenSquare, Play, Plus, Trash2 } from 'lucide-react'
+import {
+  createScanProfile,
+  deleteScanProfile,
+  fetchScanProfiles,
+  triggerScanRun,
+  updateScanProfile,
+} from '@/api/authenticated-scans.functions'
+import type {
+  ConnectionProfile,
+  PagedScanProfiles,
+  ScanProfile,
+  ScanRunner,
+  ScanningTool,
+} from '@/api/authenticated-scans.schemas'
+import { ScanProfileDialog } from './ScanProfileDialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { DataTable } from '@/components/ui/data-table'
+import { PaginationControls } from '@/components/ui/pagination-controls'
+
+type Props = {
+  initialData: PagedScanProfiles
+  runners: ScanRunner[]
+  connections: ConnectionProfile[]
+  tools: ScanningTool[]
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+}
+
+export function ScanProfilesTab({ initialData, runners, connections, tools, page, pageSize, onPageChange }: Props) {
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<ScanProfile | null>(null)
+
+  const query = useQuery({
+    queryKey: ['scan-profiles', page, pageSize],
+    queryFn: () => fetchScanProfiles({ data: { page, pageSize } }),
+    initialData,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createScanProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scan-profiles'] })
+      setDialogOpen(false)
+      toast.success('Scan profile created')
+    },
+    onError: () => toast.error('Failed to create scan profile'),
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: updateScanProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scan-profiles'] })
+      setDialogOpen(false)
+      setEditing(null)
+      toast.success('Scan profile updated')
+    },
+    onError: () => toast.error('Failed to update scan profile'),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteScanProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scan-profiles'] })
+      toast.success('Scan profile deleted')
+    },
+    onError: () => toast.error('Failed to delete scan profile'),
+  })
+
+  const triggerMutation = useMutation({
+    mutationFn: triggerScanRun,
+    onSuccess: () => toast.success('Scan run triggered'),
+    onError: () => toast.error('Failed to trigger scan run'),
+  })
+
+  const runnerName = (id: string) => runners.find((r) => r.id === id)?.name ?? '—'
+  const connectionName = (id: string) => connections.find((c) => c.id === id)?.name ?? '—'
+
+  const columns: ColumnDef<ScanProfile>[] = [
+    { accessorKey: 'name', header: 'Name' },
+    {
+      id: 'schedule',
+      header: 'Schedule',
+      cell: ({ row }) => row.original.cronSchedule || <span className="text-muted-foreground">Manual</span>,
+    },
+    {
+      id: 'runner',
+      header: 'Runner',
+      cell: ({ row }) => runnerName(row.original.scanRunnerId),
+    },
+    {
+      id: 'connection',
+      header: 'Connection',
+      cell: ({ row }) => connectionName(row.original.connectionProfileId),
+    },
+    {
+      id: 'tools',
+      header: 'Tools',
+      cell: ({ row }) => row.original.toolIds.length,
+    },
+    {
+      id: 'enabled',
+      header: 'Enabled',
+      cell: ({ row }) =>
+        row.original.enabled ? (
+          <Badge variant="default" className="bg-green-600">Yes</Badge>
+        ) : (
+          <Badge variant="secondary">No</Badge>
+        ),
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => triggerMutation.mutate({ data: { id: row.original.id } })}
+            disabled={triggerMutation.isPending}
+            title="Trigger manual run"
+          >
+            <Play className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setEditing(row.original)
+              setDialogOpen(true)
+            }}
+          >
+            <PenSquare className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive"
+            onClick={() => {
+              if (confirm(`Delete "${row.original.name}"?`)) {
+                deleteMutation.mutate({ data: { id: row.original.id } })
+              }
+            }}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Scan Profiles</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditing(null)
+              setDialogOpen(true)
+            }}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            New Profile
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <DataTable columns={columns} data={query.data?.items ?? []} />
+          <PaginationControls
+            page={page}
+            pageSize={pageSize}
+            totalCount={query.data?.totalCount ?? 0}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+
+      <ScanProfileDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open)
+          if (!open) setEditing(null)
+        }}
+        profile={editing}
+        runners={runners}
+        connections={connections}
+        tools={tools}
+        isPending={createMutation.isPending || updateMutation.isPending}
+        onSubmit={(data) => {
+          if (editing) {
+            updateMutation.mutate({ data: { id: editing.id, ...data } })
+          } else {
+            createMutation.mutate({ data })
+          }
+        }}
+      />
+    </>
+  )
+}
+```
+
+- [ ] **Step 3: Wire into workbench route**
+
+In `authenticated-scans.tsx`, add import:
+```typescript
+import { ScanProfilesTab } from '@/components/features/admin/scan-profiles/ScanProfilesTab'
+```
+
+Replace profiles TabsContent:
+```typescript
+        <TabsContent value="profiles" className="space-y-4 pt-1">
+          {'profiles' in loaderData && loaderData.profiles && (
+            <ScanProfilesTab
+              initialData={loaderData.profiles}
+              runners={loaderData.runners?.items ?? []}
+              connections={loaderData.connections?.items ?? []}
+              tools={loaderData.tools?.items ?? []}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(p) => navigate({ search: { ...search, page: p } })}
+            />
+          )}
+        </TabsContent>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/features/admin/scan-profiles/ \
+  frontend/src/routes/_authed/admin/authenticated-scans.tsx
+git commit -m "feat: add Scan Profiles tab with create/edit dialog and manual trigger"
+```
+
+---
+
+## Task 8: Add workbench link to admin hub
+
+**Files:**
+- Modify: `frontend/src/routes/_authed/admin/index.tsx`
+
+- [ ] **Step 1: Add authenticated scans card to admin hub**
+
+Find the admin areas/sections definition in `frontend/src/routes/_authed/admin/index.tsx`. Add an entry for Authenticated Scans in the appropriate section (likely "Configuration" or "Platform"). The entry should:
+
+- Title: "Authenticated Scans"
+- Description: "Configure on-prem scan runners, tools, connections, and profiles"
+- Route: `/admin/authenticated-scans`
+- Required roles: `['CustomerAdmin', 'GlobalAdmin']`
+
+Follow the existing pattern of `AdminArea` / `AdminSection` definitions already in the file. Read the file first to find the exact pattern, then add the entry.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/routes/_authed/admin/index.tsx
+git commit -m "feat: add Authenticated Scans link to admin hub"
+```
+
+---
+
+## Task 9: Full build verification
+
+- [ ] **Step 1: TypeScript check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 2: Build**
+
+Run: `cd frontend && npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Full backend test suite (unchanged)**
+
+Run: `dotnet test --nologo`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit --allow-empty -m "chore: Plan 4 authenticated scans admin UI workbench complete"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§8):**
+
+| Requirement | Task | Status |
+|---|---|---|
+| §8.1 Workbench route `/admin/authenticated-scans` | Task 3 | Covered |
+| §8.1 4 tabs deep-linked via `?tab=` | Task 3 | Covered |
+| §8.1 Tab 1 — Scan Profiles data table | Task 7 | Covered |
+| §8.1 Tab 1 — Create/edit dialog with runner/connection/tool selects | Task 7 | Covered |
+| §8.1 Tab 1 — Cron input | Task 7 | Basic input (cron preview deferred to Plan 5) |
+| §8.1 Tab 1 — Detail drawer with assigned devices | — | Deferred to Plan 5 |
+| §8.1 Tab 2 — Scanning Tools data table | Task 6 | Covered |
+| §8.1 Tab 2 — Create dialog (basic) | Task 6 | Covered (CodeMirror editor in Plan 5) |
+| §8.1 Tab 2 — Version history panel | — | Deferred to Plan 5 |
+| §8.1 Tab 3 — Connection Profiles data table + CRUD | Task 5 | Covered |
+| §8.1 Tab 3 — Secret masking with "Replace" | Task 5 | Covered (password never echoed back) |
+| §8.1 Tab 4 — Scan Runners data table | Task 4 | Covered |
+| §8.1 Tab 4 — Create with secret-once modal | Task 4 | Covered |
+| §8.1 Tab 4 — Rotate secret | Task 4 | Covered |
+| §8.1 Role gating on Admin | Task 3 | Covered (beforeLoad check) |
+| Manual trigger on profiles | Task 7 | Covered |
+| Admin hub link | Task 8 | Covered |
+
+**Deferred to Plan 5:** CodeMirror script editor, version history, cron preview, assigned devices drawer, sources admin tab, asset rule `AssignScanProfile` operation, run report dialog.
+
+**Placeholder scan:** No TBD/TODO found.
+
+**Type consistency:** All schema types (`ScanProfile`, `ScanRunner`, `ConnectionProfile`, `ScanningTool`) used consistently across schemas → functions → components. Props types match loader return shapes.

--- a/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-1.md
+++ b/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-1.md
@@ -1,0 +1,2868 @@
+# Data Model Canonical Cleanup — Phase 1: Canonical Inventory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-data-model-canonical-cleanup-design.md` §5.1
+
+**Goal:** Introduce the canonical inventory model (`Device`, `SoftwareProduct`, `SoftwareAlias`, `InstalledSoftware`, `TenantSoftwareProductInsight`, `SourceSystem`, renamed `Device*` ownership entities, renamed `SecurityProfile`) directly on top of `main`, rewrite ingestion + authenticated-scan + rules + frontend to write and read them, and delete every legacy inventory entity in one PR.
+
+**Architecture:** Fresh branch `data-model-canonical-cleanup` cut from `main`. No EF migrations regenerated in this phase — model snapshot is mutated directly; developers wipe local DBs between phases; Phase 6 regenerates the single baseline migration. Every new tenant-scoped entity has a direct `TenantId` column and an EF global query filter per spec §4.10 Rules 1 and 2. Global entities (`SourceSystem`, `SoftwareProduct`, `SoftwareAlias`) carry no `TenantId` and no filter.
+
+**Tech Stack:** .NET 10 / EF Core 10 / xUnit / PostgreSQL (prod), in-memory test host / React + TanStack Router / Vitest.
+
+---
+
+## Preflight
+
+- [ ] **Step P1: Confirm working tree is on a fresh branch**
+
+Run:
+
+```bash
+git checkout main
+git pull
+git checkout -b data-model-canonical-cleanup
+git branch --show-current
+```
+
+Expected: `data-model-canonical-cleanup`
+
+- [ ] **Step P2: Wipe local dev database**
+
+The existing migrations no longer match the evolving model. Delete the local dev DB so EF's model snapshot comparison does not trip:
+
+```bash
+dotnet ef database drop --project src/PatchHound.Infrastructure --startup-project src/PatchHound.Api --force
+```
+
+Expected: "Successfully dropped database" or "Database does not exist."
+
+- [ ] **Step P3: Confirm baseline is green**
+
+Run the full backend and frontend suites to record a clean baseline before touching code:
+
+```bash
+dotnet test
+cd frontend && npm run typecheck && npm test && cd ..
+```
+
+Expected: all green. If not, stop and report — don't start Phase 1 on a red baseline.
+
+---
+
+## File Structure
+
+### New entity files (`src/PatchHound.Core/Entities/`)
+
+- `SourceSystem.cs` — global reference table. `Id`, `Key` (unique, e.g. `"defender"`, `"tanium"`, `"authenticated-scan"`), `DisplayName`, `CreatedAt`.
+- `Device.cs` — tenant-scoped. Holds every field currently on `Asset`-with-type-`Device` except `AssetType`. Adds `SourceSystemId` FK. Unique `(TenantId, SourceSystemId, ExternalId)`.
+- `SoftwareProduct.cs` — global. `Id`, `CanonicalProductKey` (unique), `Vendor`, `Name`, `PrimaryCpe23Uri?`, `EndOfLifeAt?`, `CreatedAt`, `UpdatedAt`.
+- `SoftwareAlias.cs` — global. `Id`, `SoftwareProductId` FK, `SourceSystemId` FK, `ExternalId`, unique `(SourceSystemId, ExternalId)`.
+- `InstalledSoftware.cs` — tenant-scoped. `Id`, `TenantId`, `DeviceId` FK, `SoftwareProductId` FK, `SourceSystemId` FK, `Version`, `FirstSeenAt`, `LastSeenAt`. Current-state unique `(TenantId, DeviceId, SoftwareProductId, SourceSystemId, Version)` with `Version` NOT NULL (use `""` sentinel when unknown, not NULL — avoids nullable-column unique-key gotchas per spec §4.1).
+- `TenantSoftwareProductInsight.cs` — tenant-scoped. `Id`, `TenantId`, `SoftwareProductId` FK, `Description?`, `SupplyChainEvidenceJson?`, `UpdatedAt`, unique `(TenantId, SoftwareProductId)`.
+- `DeviceBusinessLabel.cs` — tenant-scoped. `Id`, `TenantId`, `DeviceId` FK, `BusinessLabelId` FK, unique `(DeviceId, BusinessLabelId)`.
+- `DeviceTag.cs` — tenant-scoped. `Id`, `TenantId`, `DeviceId` FK, `Key`, `Value`, unique `(DeviceId, Key)`.
+- `DeviceRule.cs` — tenant-scoped. Direct port of `AssetRule` with the `AssetType` filter column dropped.
+- `DeviceRiskScore.cs` — tenant-scoped. Direct port of `AssetRiskScore` keyed on `DeviceId` instead of `AssetId`.
+- `SecurityProfile.cs` — tenant-scoped. Direct port of `AssetSecurityProfile` under the new name.
+
+### New entity files (`src/PatchHound.Core/Entities/AuthenticatedScans/`)
+
+- `DeviceScanProfileAssignment.cs` — rename of `AssetScanProfileAssignment` with `AssetId` → `DeviceId`.
+- `StagedDetectedSoftware.cs` — rename of `StagedAuthenticatedScanSoftware`.
+
+### New EF configurations (`src/PatchHound.Infrastructure/Data/Configurations/`)
+
+One per new entity, mirroring the existing style. Every tenant-scoped entity's configuration **must** include the `TenantId` column, the `HasIndex(e => e.TenantId)` index, and relevant unique keys. Global entities' configurations omit `TenantId` entirely.
+
+### New services (`src/PatchHound.Infrastructure/Services/`)
+
+- `Inventory/SoftwareProductResolver.cs` — resolves observed `(sourceSystemKey, externalId, productName, version)` to a `SoftwareProduct` via `SoftwareAlias`. Creates missing `SoftwareProduct` + `SoftwareAlias` rows under `IsSystemContext`.
+- `Inventory/DeviceResolver.cs` — resolves observed `(tenantId, sourceSystemKey, externalId)` to a `Device`, creates on miss.
+- `Inventory/StagedDeviceMergeService.cs` — replaces `StagedAssetMergeService`. Writes directly to `Device` / `InstalledSoftware` (no legacy side effects).
+- `Inventory/DeviceRuleEvaluationService.cs` — replaces `AssetRuleEvaluationService`. Operates on `Device`, not `Asset`.
+
+### Modified services / controllers / frontend
+
+See each task for exact files and line numbers.
+
+### Deleted files
+
+See Task 20. Every entity, configuration, service, controller, DTO, route, and frontend component listed under §4.9 and §5.1 of the spec is deleted in the same PR.
+
+---
+
+## Task 1: Add `SourceSystem` global entity + configuration + seed
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/SourceSystem.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/SourceSystemConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs` (add DbSet)
+- Modify: `src/PatchHound.Infrastructure/Services/DefaultTeamSeedHostedService.cs` or a new `SourceSystemSeedHostedService.cs` — seed built-in source systems
+- Test: `tests/PatchHound.Tests/Core/SourceSystemTests.cs`
+
+- [ ] **Step 1: Write the failing entity test**
+
+Create `tests/PatchHound.Tests/Core/SourceSystemTests.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class SourceSystemTests
+{
+    [Fact]
+    public void Create_trims_and_lowercases_key()
+    {
+        var s = SourceSystem.Create("  Defender  ", "Microsoft Defender for Endpoint");
+        Assert.Equal("defender", s.Key);
+        Assert.Equal("Microsoft Defender for Endpoint", s.DisplayName);
+        Assert.NotEqual(Guid.Empty, s.Id);
+    }
+
+    [Fact]
+    public void Create_rejects_empty_key()
+    {
+        Assert.Throws<ArgumentException>(() => SourceSystem.Create("  ", "x"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~SourceSystemTests"`
+Expected: FAIL with "The type or namespace name 'SourceSystem' could not be found".
+
+- [ ] **Step 3: Create the entity**
+
+Create `src/PatchHound.Core/Entities/SourceSystem.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class SourceSystem
+{
+    public Guid Id { get; private set; }
+    public string Key { get; private set; } = null!;
+    public string DisplayName { get; private set; } = null!;
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    private SourceSystem() { }
+
+    public static SourceSystem Create(string key, string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Key is required.", nameof(key));
+        }
+        return new SourceSystem
+        {
+            Id = Guid.NewGuid(),
+            Key = key.Trim().ToLowerInvariant(),
+            DisplayName = displayName,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~SourceSystemTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Add the EF configuration**
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/SourceSystemConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class SourceSystemConfiguration : IEntityTypeConfiguration<SourceSystem>
+{
+    public void Configure(EntityTypeBuilder<SourceSystem> builder)
+    {
+        builder.HasKey(s => s.Id);
+        builder.HasIndex(s => s.Key).IsUnique();
+        builder.Property(s => s.Key).HasMaxLength(64).IsRequired();
+        builder.Property(s => s.DisplayName).HasMaxLength(256).IsRequired();
+    }
+}
+```
+
+- [ ] **Step 6: Register the DbSet**
+
+Edit `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`. After the `Tenants` DbSet at line 23, add:
+
+```csharp
+public DbSet<SourceSystem> SourceSystems => Set<SourceSystem>();
+```
+
+Do **not** add a query filter — `SourceSystem` is global per spec §4.10 Rule 3.
+
+- [ ] **Step 7: Add a seed hosted service for built-in source systems**
+
+Create `src/PatchHound.Infrastructure/Services/Inventory/SourceSystemSeedHostedService.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services.Inventory;
+
+public class SourceSystemSeedHostedService(IServiceProvider services) : IHostedService
+{
+    private static readonly (string Key, string DisplayName)[] BuiltIns =
+    [
+        ("defender", "Microsoft Defender for Endpoint"),
+        ("authenticated-scan", "Authenticated Scan"),
+    ];
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+        var tenantContext = scope.ServiceProvider.GetRequiredService<ITenantContext>();
+        tenantContext.EnterSystemContext();
+
+        foreach (var (key, displayName) in BuiltIns)
+        {
+            if (!await db.SourceSystems.AnyAsync(s => s.Key == key, ct))
+            {
+                db.SourceSystems.Add(SourceSystem.Create(key, displayName));
+            }
+        }
+        await db.SaveChangesAsync(ct);
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}
+```
+
+Register it in `src/PatchHound.Api/Program.cs` next to `DefaultTeamSeedHostedService`:
+
+```csharp
+builder.Services.AddHostedService<SourceSystemSeedHostedService>();
+```
+
+- [ ] **Step 8: Build and test**
+
+Run:
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~SourceSystemTests"
+```
+
+Expected: clean build (0 warnings, 0 errors), all SourceSystem tests pass. If `ITenantContext.EnterSystemContext()` does not exist, use whatever pattern the codebase already has for system-context scoping (grep `IsSystemContext` in tests and ingestion to find the exact entry point) and adjust Step 7 accordingly.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/SourceSystem.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/SourceSystemConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        src/PatchHound.Infrastructure/Services/Inventory/SourceSystemSeedHostedService.cs \
+        src/PatchHound.Api/Program.cs \
+        tests/PatchHound.Tests/Core/SourceSystemTests.cs
+git commit -m "feat(canonical): add SourceSystem global reference entity"
+```
+
+---
+
+## Task 2: Add `SoftwareProduct` + `SoftwareAlias` global entities
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/SoftwareProduct.cs`
+- Create: `src/PatchHound.Core/Entities/SoftwareAlias.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/SoftwareProductConfiguration.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/SoftwareAliasConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Tests/Core/SoftwareProductTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/PatchHound.Tests/Core/SoftwareProductTests.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class SoftwareProductTests
+{
+    [Fact]
+    public void Create_computes_canonical_key_from_vendor_and_name()
+    {
+        var p = SoftwareProduct.Create(vendor: "Microsoft", name: "Edge", primaryCpe23Uri: "cpe:2.3:a:microsoft:edge:*:*:*:*:*:*:*:*");
+        Assert.Equal("microsoft::edge", p.CanonicalProductKey);
+        Assert.Equal("Microsoft", p.Vendor);
+        Assert.Equal("Edge", p.Name);
+        Assert.NotEqual(Guid.Empty, p.Id);
+    }
+
+    [Fact]
+    public void Create_trims_and_lowercases_canonical_key()
+    {
+        var p = SoftwareProduct.Create(vendor: "  MICROSOFT  ", name: "  Edge  ", primaryCpe23Uri: null);
+        Assert.Equal("microsoft::edge", p.CanonicalProductKey);
+    }
+
+    [Fact]
+    public void Create_rejects_empty_vendor_or_name()
+    {
+        Assert.Throws<ArgumentException>(() => SoftwareProduct.Create(" ", "x", null));
+        Assert.Throws<ArgumentException>(() => SoftwareProduct.Create("x", " ", null));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~SoftwareProductTests"`
+Expected: FAIL with "The type or namespace name 'SoftwareProduct' could not be found."
+
+- [ ] **Step 3: Create `SoftwareProduct`**
+
+Create `src/PatchHound.Core/Entities/SoftwareProduct.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class SoftwareProduct
+{
+    public Guid Id { get; private set; }
+    public string CanonicalProductKey { get; private set; } = null!;
+    public string Vendor { get; private set; } = null!;
+    public string Name { get; private set; } = null!;
+    public string? PrimaryCpe23Uri { get; private set; }
+    public DateTimeOffset? EndOfLifeAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private SoftwareProduct() { }
+
+    public static SoftwareProduct Create(string vendor, string name, string? primaryCpe23Uri)
+    {
+        if (string.IsNullOrWhiteSpace(vendor)) throw new ArgumentException("Vendor is required.", nameof(vendor));
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name is required.", nameof(name));
+        var now = DateTimeOffset.UtcNow;
+        return new SoftwareProduct
+        {
+            Id = Guid.NewGuid(),
+            Vendor = vendor.Trim(),
+            Name = name.Trim(),
+            CanonicalProductKey = $"{vendor.Trim().ToLowerInvariant()}::{name.Trim().ToLowerInvariant()}",
+            PrimaryCpe23Uri = primaryCpe23Uri,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void UpdatePrimaryCpe(string? cpe)
+    {
+        PrimaryCpe23Uri = cpe;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void SetEndOfLife(DateTimeOffset? at)
+    {
+        EndOfLifeAt = at;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [ ] **Step 4: Create `SoftwareAlias`**
+
+Create `src/PatchHound.Core/Entities/SoftwareAlias.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class SoftwareAlias
+{
+    public Guid Id { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public Guid SourceSystemId { get; private set; }
+    public string ExternalId { get; private set; } = null!;
+    public string? ObservedVendor { get; private set; }
+    public string? ObservedName { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    private SoftwareAlias() { }
+
+    public static SoftwareAlias Create(
+        Guid softwareProductId,
+        Guid sourceSystemId,
+        string externalId,
+        string? observedVendor = null,
+        string? observedName = null)
+    {
+        if (string.IsNullOrWhiteSpace(externalId)) throw new ArgumentException("ExternalId required.", nameof(externalId));
+        return new SoftwareAlias
+        {
+            Id = Guid.NewGuid(),
+            SoftwareProductId = softwareProductId,
+            SourceSystemId = sourceSystemId,
+            ExternalId = externalId,
+            ObservedVendor = observedVendor,
+            ObservedName = observedName,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~SoftwareProductTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Add EF configurations**
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/SoftwareProductConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class SoftwareProductConfiguration : IEntityTypeConfiguration<SoftwareProduct>
+{
+    public void Configure(EntityTypeBuilder<SoftwareProduct> builder)
+    {
+        builder.HasKey(p => p.Id);
+        builder.HasIndex(p => p.CanonicalProductKey).IsUnique();
+        builder.Property(p => p.CanonicalProductKey).HasMaxLength(512).IsRequired();
+        builder.Property(p => p.Vendor).HasMaxLength(256).IsRequired();
+        builder.Property(p => p.Name).HasMaxLength(512).IsRequired();
+        builder.Property(p => p.PrimaryCpe23Uri).HasMaxLength(512);
+    }
+}
+```
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/SoftwareAliasConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class SoftwareAliasConfiguration : IEntityTypeConfiguration<SoftwareAlias>
+{
+    public void Configure(EntityTypeBuilder<SoftwareAlias> builder)
+    {
+        builder.HasKey(a => a.Id);
+        builder.HasIndex(a => new { a.SourceSystemId, a.ExternalId }).IsUnique();
+        builder.HasIndex(a => a.SoftwareProductId);
+        builder.Property(a => a.ExternalId).HasMaxLength(256).IsRequired();
+        builder.Property(a => a.ObservedVendor).HasMaxLength(256);
+        builder.Property(a => a.ObservedName).HasMaxLength(512);
+        builder
+            .HasOne<SoftwareProduct>()
+            .WithMany()
+            .HasForeignKey(a => a.SoftwareProductId)
+            .OnDelete(DeleteBehavior.Cascade);
+        builder
+            .HasOne<SourceSystem>()
+            .WithMany()
+            .HasForeignKey(a => a.SourceSystemId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+- [ ] **Step 7: Register DbSets**
+
+Edit `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`. Next to `SourceSystems`, add:
+
+```csharp
+public DbSet<SoftwareProduct> SoftwareProducts => Set<SoftwareProduct>();
+public DbSet<SoftwareAlias> SoftwareAliases => Set<SoftwareAlias>();
+```
+
+Do **not** add query filters — both are global per spec §4.10 Rule 3.
+
+- [ ] **Step 8: Build and test**
+
+Run:
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~SoftwareProduct"
+```
+
+Expected: clean build, green tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/SoftwareProduct.cs \
+        src/PatchHound.Core/Entities/SoftwareAlias.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/SoftwareProductConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/SoftwareAliasConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Tests/Core/SoftwareProductTests.cs
+git commit -m "feat(canonical): add SoftwareProduct and SoftwareAlias global entities"
+```
+
+---
+
+## Task 3: Add `Device` tenant-scoped entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/Device.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/DeviceConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs` (DbSet + tenant filter)
+- Test: `tests/PatchHound.Tests/Core/DeviceTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/PatchHound.Tests/Core/DeviceTests.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class DeviceTests
+{
+    [Fact]
+    public void Create_initializes_all_identity_fields()
+    {
+        var tenantId = Guid.NewGuid();
+        var sourceSystemId = Guid.NewGuid();
+        var d = Device.Create(
+            tenantId: tenantId,
+            sourceSystemId: sourceSystemId,
+            externalId: "dev-1",
+            name: "host.example.com",
+            baselineCriticality: Criticality.Medium);
+        Assert.Equal(tenantId, d.TenantId);
+        Assert.Equal(sourceSystemId, d.SourceSystemId);
+        Assert.Equal("dev-1", d.ExternalId);
+        Assert.Equal("host.example.com", d.Name);
+        Assert.Equal(Criticality.Medium, d.Criticality);
+        Assert.Equal(Criticality.Medium, d.BaselineCriticality);
+        Assert.True(d.ActiveInTenant);
+    }
+
+    [Fact]
+    public void SetCriticality_marks_source_as_manual()
+    {
+        var d = Device.Create(Guid.NewGuid(), Guid.NewGuid(), "d", "n", Criticality.Low);
+        d.SetCriticality(Criticality.High);
+        Assert.Equal(Criticality.High, d.Criticality);
+        Assert.Equal("ManualOverride", d.CriticalitySource);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify the test fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeviceTests"`
+Expected: FAIL with "type or namespace name 'Device' could not be found" (or similar).
+
+- [ ] **Step 3: Create the entity**
+
+Create `src/PatchHound.Core/Entities/Device.cs`. Mirror `Asset.cs` field-by-field **but drop** `AssetType`, `SourceKey`, and add `SourceSystemId`. Rename `DeviceActiveInTenant` → `ActiveInTenant`. Rename all `Device*`-prefixed passthrough fields to drop the `Device` prefix where they are no longer necessary (`ComputerDnsName`, `HealthStatus`, `OsPlatform`, `OsVersion`, `ExternalRiskLabel`, `LastSeenAt`, `LastIpAddress`, `AadDeviceId`, `GroupId`, `GroupName`, `ExposureLevel`, `IsAadJoined`, `OnboardingStatus`, `DeviceValue`, `ExposureImpactScore`). Keep ownership/criticality/fallback/security-profile API surface identical to `Asset`.
+
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class Device
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid SourceSystemId { get; private set; }
+    public string ExternalId { get; private set; } = null!;
+    public string Name { get; private set; } = null!;
+    public string? Description { get; private set; }
+
+    public Criticality BaselineCriticality { get; private set; }
+    public Criticality Criticality { get; private set; }
+    public string? CriticalitySource { get; private set; }
+    public string? CriticalityReason { get; private set; }
+    public Guid? CriticalityRuleId { get; private set; }
+    public DateTimeOffset? CriticalityUpdatedAt { get; private set; }
+
+    public OwnerType OwnerType { get; private set; }
+    public Guid? OwnerUserId { get; private set; }
+    public Guid? OwnerTeamId { get; private set; }
+    public Guid? FallbackTeamId { get; private set; }
+    public Guid? FallbackTeamRuleId { get; private set; }
+
+    public Guid? SecurityProfileId { get; private set; }
+    public Guid? SecurityProfileRuleId { get; private set; }
+
+    public string? ComputerDnsName { get; private set; }
+    public string? HealthStatus { get; private set; }
+    public string? OsPlatform { get; private set; }
+    public string? OsVersion { get; private set; }
+    public string? ExternalRiskLabel { get; private set; }
+    public DateTimeOffset? LastSeenAt { get; private set; }
+    public string? LastIpAddress { get; private set; }
+    public string? AadDeviceId { get; private set; }
+    public string? GroupId { get; private set; }
+    public string? GroupName { get; private set; }
+    public string? ExposureLevel { get; private set; }
+    public bool? IsAadJoined { get; private set; }
+    public string? OnboardingStatus { get; private set; }
+    public string? DeviceValue { get; private set; }
+    public decimal? ExposureImpactScore { get; private set; }
+    public bool ActiveInTenant { get; private set; } = true;
+    public string Metadata { get; private set; } = "{}";
+
+    private Device() { }
+
+    public static Device Create(
+        Guid tenantId,
+        Guid sourceSystemId,
+        string externalId,
+        string name,
+        Criticality baselineCriticality,
+        string? description = null)
+    {
+        return new Device
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            SourceSystemId = sourceSystemId,
+            ExternalId = externalId,
+            Name = name,
+            Description = description,
+            BaselineCriticality = baselineCriticality,
+            Criticality = baselineCriticality,
+            CriticalitySource = "Default",
+            CriticalityUpdatedAt = DateTimeOffset.UtcNow,
+            OwnerType = OwnerType.User,
+            ActiveInTenant = true,
+        };
+    }
+
+    // Port every mutator from Asset.cs (AssignOwner, AssignTeamOwner, SetFallbackTeamFromRule,
+    // ClearRuleAssignedFallbackTeam, SetCriticality, SetCriticalityFromRule,
+    // ResetCriticalityToBaseline, ClearManualCriticalityOverride, AssignSecurityProfile,
+    // AssignSecurityProfileFromRule, ClearRuleAssignedSecurityProfile, UpdateDetails,
+    // UpdateMetadata, SetActiveInTenant, SetExposureImpactScore) — body-identical to Asset.cs
+    // except the renamed ActiveInTenant field. Drop the UpdateDeviceDetails parameters that only
+    // existed to transport the `Device*` prefix (it's now the whole entity) — rename it to
+    // UpdateInventoryDetails taking the now-unprefixed fields.
+
+    // ... (paste the mutator bodies from src/PatchHound.Core/Entities/Asset.cs lines 75-221,
+    //      renaming DeviceActiveInTenant → ActiveInTenant and removing the `Device` prefix
+    //      from passthrough fields inside UpdateDeviceDetails → UpdateInventoryDetails)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeviceTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Add EF configuration**
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/DeviceConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class DeviceConfiguration : IEntityTypeConfiguration<Device>
+{
+    public void Configure(EntityTypeBuilder<Device> builder)
+    {
+        builder.HasKey(d => d.Id);
+
+        builder.HasIndex(d => new { d.TenantId, d.SourceSystemId, d.ExternalId }).IsUnique();
+        builder.HasIndex(d => d.TenantId);
+        builder.HasIndex(d => d.SecurityProfileId);
+        builder.HasIndex(d => new { d.TenantId, d.ActiveInTenant });
+
+        builder.Property(d => d.ExternalId).HasMaxLength(256).IsRequired();
+        builder.Property(d => d.Name).HasMaxLength(256).IsRequired();
+        builder.Property(d => d.Description).HasMaxLength(2048);
+        builder.Property(d => d.ComputerDnsName).HasMaxLength(256);
+        builder.Property(d => d.HealthStatus).HasMaxLength(64);
+        builder.Property(d => d.OsPlatform).HasMaxLength(128);
+        builder.Property(d => d.OsVersion).HasMaxLength(128);
+        builder.Property(d => d.ExternalRiskLabel).HasMaxLength(64);
+        builder.Property(d => d.LastIpAddress).HasMaxLength(128);
+        builder.Property(d => d.AadDeviceId).HasMaxLength(128);
+        builder.Property(d => d.GroupId).HasMaxLength(128);
+        builder.Property(d => d.GroupName).HasMaxLength(256);
+        builder.Property(d => d.ExposureLevel).HasMaxLength(64);
+        builder.Property(d => d.OnboardingStatus).HasMaxLength(64);
+        builder.Property(d => d.DeviceValue).HasMaxLength(64);
+        builder.Property(d => d.ActiveInTenant).HasDefaultValue(true);
+        builder.Property(d => d.BaselineCriticality).HasConversion<string>().HasMaxLength(32);
+        builder.Property(d => d.Criticality).HasConversion<string>().HasMaxLength(32);
+        builder.Property(d => d.CriticalitySource).HasMaxLength(32);
+        builder.Property(d => d.CriticalityReason).HasMaxLength(512);
+        builder.Property(d => d.OwnerType).HasConversion<string>().HasMaxLength(32);
+        builder.Property(d => d.Metadata).HasColumnType("text");
+
+        builder
+            .HasOne<SourceSystem>()
+            .WithMany()
+            .HasForeignKey(d => d.SourceSystemId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+- [ ] **Step 6: Register DbSet and tenant filter**
+
+In `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`, add the DbSet next to the `SoftwareAliases` DbSet:
+
+```csharp
+public DbSet<Device> Devices => Set<Device>();
+```
+
+In `OnModelCreating`, add (ideally near the existing `Asset` filter around line 167):
+
+```csharp
+modelBuilder
+    .Entity<Device>()
+    .HasQueryFilter(e =>
+        IsSystemContext
+        || (AccessibleTenantIds.Contains(e.TenantId) && e.ActiveInTenant));
+```
+
+- [ ] **Step 7: Build and test**
+
+Run:
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~DeviceTests"
+```
+
+Expected: clean build, green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/Device.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/DeviceConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Tests/Core/DeviceTests.cs
+git commit -m "feat(canonical): add Device tenant-scoped entity with global filter"
+```
+
+---
+
+## Task 4: Add `InstalledSoftware` + `TenantSoftwareProductInsight`
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/InstalledSoftware.cs`
+- Create: `src/PatchHound.Core/Entities/TenantSoftwareProductInsight.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/InstalledSoftwareConfiguration.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/TenantSoftwareProductInsightConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Tests/Core/InstalledSoftwareTests.cs`
+- Test: `tests/PatchHound.Tests/Core/TenantSoftwareProductInsightTests.cs`
+
+- [ ] **Step 1: Write the `InstalledSoftware` entity test**
+
+Create `tests/PatchHound.Tests/Core/InstalledSoftwareTests.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class InstalledSoftwareTests
+{
+    [Fact]
+    public void Observe_sets_identity_and_timestamps()
+    {
+        var tenantId = Guid.NewGuid();
+        var deviceId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var sourceId = Guid.NewGuid();
+        var at = DateTimeOffset.UtcNow;
+
+        var i = InstalledSoftware.Observe(tenantId, deviceId, productId, sourceId, version: "1.2.3", at);
+
+        Assert.Equal(tenantId, i.TenantId);
+        Assert.Equal(deviceId, i.DeviceId);
+        Assert.Equal(productId, i.SoftwareProductId);
+        Assert.Equal(sourceId, i.SourceSystemId);
+        Assert.Equal("1.2.3", i.Version);
+        Assert.Equal(at, i.FirstSeenAt);
+        Assert.Equal(at, i.LastSeenAt);
+    }
+
+    [Fact]
+    public void Observe_with_null_version_uses_empty_sentinel()
+    {
+        var i = InstalledSoftware.Observe(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), version: null, DateTimeOffset.UtcNow);
+        Assert.Equal("", i.Version);
+    }
+
+    [Fact]
+    public void Touch_updates_last_seen_but_not_first_seen()
+    {
+        var first = DateTimeOffset.UtcNow.AddDays(-1);
+        var i = InstalledSoftware.Observe(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "1.0", first);
+        var next = DateTimeOffset.UtcNow;
+        i.Touch(next);
+        Assert.Equal(first, i.FirstSeenAt);
+        Assert.Equal(next, i.LastSeenAt);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify the test fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~InstalledSoftwareTests"`
+Expected: FAIL, type not found.
+
+- [ ] **Step 3: Create `InstalledSoftware`**
+
+Create `src/PatchHound.Core/Entities/InstalledSoftware.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class InstalledSoftware
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid DeviceId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public Guid SourceSystemId { get; private set; }
+    public string Version { get; private set; } = "";
+    public DateTimeOffset FirstSeenAt { get; private set; }
+    public DateTimeOffset LastSeenAt { get; private set; }
+
+    private InstalledSoftware() { }
+
+    public static InstalledSoftware Observe(
+        Guid tenantId,
+        Guid deviceId,
+        Guid softwareProductId,
+        Guid sourceSystemId,
+        string? version,
+        DateTimeOffset at)
+    {
+        return new InstalledSoftware
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            DeviceId = deviceId,
+            SoftwareProductId = softwareProductId,
+            SourceSystemId = sourceSystemId,
+            Version = version ?? "",
+            FirstSeenAt = at,
+            LastSeenAt = at,
+        };
+    }
+
+    public void Touch(DateTimeOffset at)
+    {
+        LastSeenAt = at;
+    }
+}
+```
+
+- [ ] **Step 4: Write the `TenantSoftwareProductInsight` test**
+
+Create `tests/PatchHound.Tests/Core/TenantSoftwareProductInsightTests.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class TenantSoftwareProductInsightTests
+{
+    [Fact]
+    public void Create_sets_identity_and_timestamps()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var insight = TenantSoftwareProductInsight.Create(tenantId, productId);
+        Assert.Equal(tenantId, insight.TenantId);
+        Assert.Equal(productId, insight.SoftwareProductId);
+        Assert.Null(insight.Description);
+    }
+
+    [Fact]
+    public void UpdateDescription_sets_description_and_bumps_updated_at()
+    {
+        var insight = TenantSoftwareProductInsight.Create(Guid.NewGuid(), Guid.NewGuid());
+        var before = insight.UpdatedAt;
+        Thread.Sleep(5);
+        insight.UpdateDescription("tenant-specific notes");
+        Assert.Equal("tenant-specific notes", insight.Description);
+        Assert.True(insight.UpdatedAt > before);
+    }
+}
+```
+
+- [ ] **Step 5: Create `TenantSoftwareProductInsight`**
+
+Create `src/PatchHound.Core/Entities/TenantSoftwareProductInsight.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class TenantSoftwareProductInsight
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public string? Description { get; private set; }
+    public string? SupplyChainEvidenceJson { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private TenantSoftwareProductInsight() { }
+
+    public static TenantSoftwareProductInsight Create(Guid tenantId, Guid softwareProductId)
+    {
+        return new TenantSoftwareProductInsight
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            SoftwareProductId = softwareProductId,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    public void UpdateDescription(string? description)
+    {
+        Description = description;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void UpdateSupplyChainEvidence(string? evidenceJson)
+    {
+        SupplyChainEvidenceJson = evidenceJson;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [ ] **Step 6: Add EF configurations**
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/InstalledSoftwareConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class InstalledSoftwareConfiguration : IEntityTypeConfiguration<InstalledSoftware>
+{
+    public void Configure(EntityTypeBuilder<InstalledSoftware> builder)
+    {
+        builder.HasKey(i => i.Id);
+        builder.HasIndex(i => new
+        {
+            i.TenantId,
+            i.DeviceId,
+            i.SoftwareProductId,
+            i.SourceSystemId,
+            i.Version
+        }).IsUnique();
+        builder.HasIndex(i => new { i.TenantId, i.SoftwareProductId });
+        builder.HasIndex(i => i.TenantId);
+        builder.Property(i => i.Version).HasMaxLength(128).IsRequired();
+
+        builder.HasOne<Device>().WithMany().HasForeignKey(i => i.DeviceId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne<SoftwareProduct>().WithMany().HasForeignKey(i => i.SoftwareProductId).OnDelete(DeleteBehavior.Restrict);
+        builder.HasOne<SourceSystem>().WithMany().HasForeignKey(i => i.SourceSystemId).OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/TenantSoftwareProductInsightConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class TenantSoftwareProductInsightConfiguration : IEntityTypeConfiguration<TenantSoftwareProductInsight>
+{
+    public void Configure(EntityTypeBuilder<TenantSoftwareProductInsight> builder)
+    {
+        builder.HasKey(i => i.Id);
+        builder.HasIndex(i => new { i.TenantId, i.SoftwareProductId }).IsUnique();
+        builder.Property(i => i.Description).HasMaxLength(4096);
+        builder.Property(i => i.SupplyChainEvidenceJson).HasColumnType("text");
+
+        builder.HasOne<SoftwareProduct>().WithMany().HasForeignKey(i => i.SoftwareProductId).OnDelete(DeleteBehavior.Cascade);
+    }
+}
+```
+
+- [ ] **Step 7: Register DbSets and tenant filters**
+
+In `PatchHoundDbContext.cs`, add next to the previously added inventory DbSets:
+
+```csharp
+public DbSet<InstalledSoftware> InstalledSoftware => Set<InstalledSoftware>();
+public DbSet<TenantSoftwareProductInsight> TenantSoftwareProductInsights => Set<TenantSoftwareProductInsight>();
+```
+
+In `OnModelCreating`:
+
+```csharp
+modelBuilder
+    .Entity<InstalledSoftware>()
+    .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+
+modelBuilder
+    .Entity<TenantSoftwareProductInsight>()
+    .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+```
+
+- [ ] **Step 8: Build and test**
+
+Run:
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~InstalledSoftwareTests|FullyQualifiedName~TenantSoftwareProductInsightTests"
+```
+
+Expected: clean build, green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/InstalledSoftware.cs \
+        src/PatchHound.Core/Entities/TenantSoftwareProductInsight.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/InstalledSoftwareConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/TenantSoftwareProductInsightConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Tests/Core/InstalledSoftwareTests.cs \
+        tests/PatchHound.Tests/Core/TenantSoftwareProductInsightTests.cs
+git commit -m "feat(canonical): add InstalledSoftware and TenantSoftwareProductInsight"
+```
+
+---
+
+## Task 5: Add device ownership / attribute entities (`DeviceBusinessLabel`, `DeviceTag`, `DeviceRule`, `DeviceRiskScore`, `SecurityProfile`)
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/DeviceBusinessLabel.cs`
+- Create: `src/PatchHound.Core/Entities/DeviceTag.cs`
+- Create: `src/PatchHound.Core/Entities/DeviceRule.cs`
+- Create: `src/PatchHound.Core/Entities/DeviceRiskScore.cs`
+- Create: `src/PatchHound.Core/Entities/SecurityProfile.cs`
+- Create: Five EF configurations under `src/PatchHound.Infrastructure/Data/Configurations/`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Tests: `tests/PatchHound.Tests/Core/DeviceOwnershipTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/PatchHound.Tests/Core/DeviceOwnershipTests.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using Xunit;
+
+namespace PatchHound.Tests.Core;
+
+public class DeviceOwnershipTests
+{
+    [Fact]
+    public void DeviceBusinessLabel_Create_sets_ids()
+    {
+        var tenantId = Guid.NewGuid();
+        var deviceId = Guid.NewGuid();
+        var labelId = Guid.NewGuid();
+        var link = DeviceBusinessLabel.Create(tenantId, deviceId, labelId);
+        Assert.Equal(tenantId, link.TenantId);
+        Assert.Equal(deviceId, link.DeviceId);
+        Assert.Equal(labelId, link.BusinessLabelId);
+    }
+
+    [Fact]
+    public void DeviceTag_Create_sets_kv_pair()
+    {
+        var tag = DeviceTag.Create(Guid.NewGuid(), Guid.NewGuid(), "env", "prod");
+        Assert.Equal("env", tag.Key);
+        Assert.Equal("prod", tag.Value);
+    }
+
+    [Fact]
+    public void SecurityProfile_Create_initializes_modifiers_to_zero()
+    {
+        var profile = SecurityProfile.Create(Guid.NewGuid(), "Gold", description: null);
+        Assert.Equal("Gold", profile.Name);
+        Assert.Equal(0, profile.ConfidentialityRequirementModifier);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify the test fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeviceOwnershipTests"`
+Expected: FAIL, types not found.
+
+- [ ] **Step 3: Create `DeviceBusinessLabel`**
+
+Create `src/PatchHound.Core/Entities/DeviceBusinessLabel.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class DeviceBusinessLabel
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid DeviceId { get; private set; }
+    public Guid BusinessLabelId { get; private set; }
+
+    private DeviceBusinessLabel() { }
+
+    public static DeviceBusinessLabel Create(Guid tenantId, Guid deviceId, Guid businessLabelId)
+    {
+        return new DeviceBusinessLabel
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            DeviceId = deviceId,
+            BusinessLabelId = businessLabelId,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Create `DeviceTag`**
+
+Create `src/PatchHound.Core/Entities/DeviceTag.cs`:
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class DeviceTag
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid DeviceId { get; private set; }
+    public string Key { get; private set; } = null!;
+    public string Value { get; private set; } = null!;
+
+    private DeviceTag() { }
+
+    public static DeviceTag Create(Guid tenantId, Guid deviceId, string key, string value)
+    {
+        return new DeviceTag
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            DeviceId = deviceId,
+            Key = key,
+            Value = value,
+        };
+    }
+}
+```
+
+- [ ] **Step 5: Create `DeviceRule`**
+
+Open `src/PatchHound.Core/Entities/AssetRule.cs` and read every public field + method. Create `src/PatchHound.Core/Entities/DeviceRule.cs` as a direct rename. **Drop** any `AssetType` filter field — this rule operates on devices exclusively per spec §4.4. Keep name, tenant ID, criteria JSON, action fields, priority, rule-kind enum, audit fields identical to `AssetRule`.
+
+- [ ] **Step 6: Create `DeviceRiskScore`**
+
+Open `src/PatchHound.Core/Entities/AssetRiskScore.cs`. Create `src/PatchHound.Core/Entities/DeviceRiskScore.cs` as a direct rename with `AssetId` → `DeviceId`. Keep the scoring columns (base score, criticality multiplier, exposure component, SLA component, etc.) identical.
+
+- [ ] **Step 7: Create `SecurityProfile`**
+
+Open `src/PatchHound.Core/Entities/AssetSecurityProfile.cs`. Create `src/PatchHound.Core/Entities/SecurityProfile.cs` as a direct rename (the entity is a tenant policy, not asset-specific). Keep every column (name, description, CIA modifiers, integrity/confidentiality requirements, network requirement, scope temporal modifier, tenant ID) identical.
+
+- [ ] **Step 8: Add EF configurations**
+
+Port each configuration from its `Asset*` predecessor under `src/PatchHound.Infrastructure/Data/Configurations/`:
+
+- `DeviceBusinessLabelConfiguration.cs` ← `AssetBusinessLabelConfiguration.cs` — replace `Asset` nav with `Device` FK, add `TenantId` column + index per spec §4.10 Rule 1, add `(DeviceId, BusinessLabelId)` unique.
+- `DeviceTagConfiguration.cs` ← `AssetTagConfiguration.cs` — replace `AssetId` FK with `DeviceId`, add `(DeviceId, Key)` unique, `TenantId` column + index.
+- `DeviceRuleConfiguration.cs` ← `AssetRuleConfiguration.cs` — drop `AssetType` column if present, otherwise identical shape.
+- `DeviceRiskScoreConfiguration.cs` ← `AssetRiskScoreConfiguration.cs` — replace `AssetId` FK with `DeviceId`, keep `TenantId`.
+- `SecurityProfileConfiguration.cs` ← `AssetSecurityProfileConfiguration.cs` — rename the type, keep the tenant column and indexes.
+
+Each configuration **must** include `TenantId` as a direct column and `HasIndex(e => e.TenantId)` to satisfy spec §4.10 Rule 1 even for entities where `TenantId` is also reachable transitively through a parent FK.
+
+- [ ] **Step 9: Register DbSets and filters**
+
+In `PatchHoundDbContext.cs`:
+
+```csharp
+public DbSet<Device> Devices => Set<Device>();                             // (already added in Task 3)
+public DbSet<DeviceBusinessLabel> DeviceBusinessLabels => Set<DeviceBusinessLabel>();
+public DbSet<DeviceTag> DeviceTags => Set<DeviceTag>();
+public DbSet<DeviceRule> DeviceRules => Set<DeviceRule>();
+public DbSet<DeviceRiskScore> DeviceRiskScores => Set<DeviceRiskScore>();
+public DbSet<SecurityProfile> SecurityProfiles => Set<SecurityProfile>();
+```
+
+In `OnModelCreating`, add tenant filters (direct `TenantId` on every one per Rule 1):
+
+```csharp
+modelBuilder.Entity<DeviceBusinessLabel>().HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+modelBuilder.Entity<DeviceTag>().HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+modelBuilder.Entity<DeviceRule>().HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+modelBuilder.Entity<DeviceRiskScore>().HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+modelBuilder.Entity<SecurityProfile>().HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+```
+
+- [ ] **Step 10: Build and test**
+
+Run:
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~DeviceOwnershipTests"
+```
+
+Expected: clean build, green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/DeviceBusinessLabel.cs \
+        src/PatchHound.Core/Entities/DeviceTag.cs \
+        src/PatchHound.Core/Entities/DeviceRule.cs \
+        src/PatchHound.Core/Entities/DeviceRiskScore.cs \
+        src/PatchHound.Core/Entities/SecurityProfile.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/Device*.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/SecurityProfileConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Tests/Core/DeviceOwnershipTests.cs
+git commit -m "feat(canonical): add Device ownership entities and SecurityProfile"
+```
+
+---
+
+## Task 6: Rename authenticated-scan inventory entities (`AssetScanProfileAssignment` → `DeviceScanProfileAssignment`, `ScanJob.AssetId` → `DeviceId`, `StagedAuthenticatedScanSoftware` → `StagedDetectedSoftware`)
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/DeviceScanProfileAssignment.cs`
+- Create: `src/PatchHound.Core/Entities/AuthenticatedScans/StagedDetectedSoftware.cs`
+- Modify: `src/PatchHound.Core/Entities/AuthenticatedScans/ScanJob.cs` — rename `AssetId` → `DeviceId`
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/AuthenticatedScans/*` for each renamed entity
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs` — rename DbSets
+- Modify: every consumer in `src/PatchHound.Api/Controllers/` and `src/PatchHound.Infrastructure/` that touches these three types
+- Modify: `src/PatchHound.Api/Controllers/ScanRunnersController.cs`, `ScanningToolsController.cs`, `ScanJobsController.cs`, `ScanProfilesController.cs`, authenticated-scan runner ingest controllers — rename payload fields `assetId`/`assetName` → `deviceId`/`deviceName`
+- Modify: `frontend/src/api/scan-jobs.schemas.ts` (and any other scan-related schema) — rename `assetId` → `deviceId`
+- Modify: `frontend/src/components/features/authenticated-scans/**` — rename references
+
+- [ ] **Step 1: Find every reference that will need renaming**
+
+Run grep to enumerate consumers:
+
+```bash
+rg "AssetScanProfileAssignment" -l
+rg "StagedAuthenticatedScanSoftware" -l
+rg "\\.AssetId\\b" src/PatchHound.Core/Entities/AuthenticatedScans src/PatchHound.Infrastructure -l
+rg "assetId\\b|assetName\\b" frontend/src -l
+```
+
+Expected: captures Controllers, services, tests, EF configs, frontend components, schemas. Write the list down in a scratch comment; every file in it needs to land in this task.
+
+- [ ] **Step 2: Create `DeviceScanProfileAssignment` (rename of `AssetScanProfileAssignment`)**
+
+Read `src/PatchHound.Core/Entities/AuthenticatedScans/AssetScanProfileAssignment.cs` end-to-end. Create `DeviceScanProfileAssignment.cs` with the entire body copied, replacing:
+- class name → `DeviceScanProfileAssignment`
+- property `AssetId` → `DeviceId`
+- any method parameter named `assetId` → `deviceId`
+
+- [ ] **Step 3: Create `StagedDetectedSoftware` (rename of `StagedAuthenticatedScanSoftware`)**
+
+Same pattern — read the old file, copy body into `StagedDetectedSoftware.cs` with renamed class name. Field renames: `AssetId` → `DeviceId` where the entity references a device. The content (detected name/version/vendor) stays the same.
+
+- [ ] **Step 4: Rename `ScanJob.AssetId` to `DeviceId`**
+
+Edit `src/PatchHound.Core/Entities/AuthenticatedScans/ScanJob.cs`:
+
+```csharp
+// Before
+public Guid AssetId { get; private set; }
+// After
+public Guid DeviceId { get; private set; }
+```
+
+Rename every method parameter, every `scanJob.AssetId` reference, every `WithAssetId` → `WithDeviceId`. Grep within the file:
+
+```bash
+rg "AssetId" src/PatchHound.Core/Entities/AuthenticatedScans/ScanJob.cs
+```
+
+Expected after edit: zero matches.
+
+- [ ] **Step 5: Update EF configurations**
+
+Copy `AssetScanProfileAssignmentConfiguration.cs` to `DeviceScanProfileAssignmentConfiguration.cs`, rename the generic argument, rename `AssetId` → `DeviceId` in the index and the `HasOne<Asset>` → `HasOne<Device>` (FK now points to `Device`).
+
+Copy `StagedAuthenticatedScanSoftwareConfiguration.cs` to `StagedDetectedSoftwareConfiguration.cs` similarly.
+
+In `ScanJobConfiguration.cs`, rename the `AssetId` property reference to `DeviceId` in indexes and any `.Property(j => j.AssetId)` call.
+
+- [ ] **Step 6: Rename DbSets in `PatchHoundDbContext`**
+
+```csharp
+// Before
+public DbSet<AssetScanProfileAssignment> AssetScanProfileAssignments => Set<AssetScanProfileAssignment>();
+public DbSet<StagedAuthenticatedScanSoftware> StagedAuthenticatedScanSoftware => Set<StagedAuthenticatedScanSoftware>();
+// After
+public DbSet<DeviceScanProfileAssignment> DeviceScanProfileAssignments => Set<DeviceScanProfileAssignment>();
+public DbSet<StagedDetectedSoftware> StagedDetectedSoftware => Set<StagedDetectedSoftware>();
+```
+
+- [ ] **Step 7: Rename consumers**
+
+For each file surfaced by Step 1's grep, use Edit (or your editor's rename) to change `AssetScanProfileAssignment` → `DeviceScanProfileAssignment`, `StagedAuthenticatedScanSoftware` → `StagedDetectedSoftware`, `AssetId` → `DeviceId` inside scan-related code only. This includes:
+
+- Controllers (`ScanJobsController`, `ScanProfilesController`, `ScanRunnersController`, `ScanningToolsController`) — rename action parameter names and DTO properties so that the wire format now uses `deviceId`/`deviceName`.
+- Services (scan-job dispatch, scan-job validation, scan-run aggregation, staged software → canonical merge hook)
+- Tests under `tests/PatchHound.Tests/Api` and `tests/PatchHound.Tests/Infrastructure/AuthenticatedScans`
+
+- [ ] **Step 8: Rename the scan-runner bearer protocol fields**
+
+In the `ScanRunner` authentication and enqueue paths, the runner pulls scan jobs with an `assetId` payload. Rename payload fields `assetId`→`deviceId`, `assetName`→`deviceName` across:
+- the runner-facing DTOs under `src/PatchHound.Api/Models/`
+- the C# scan runner client project (`src/PatchHound.ScanRunner/**` if it exists) — grep with `rg "assetId" src/PatchHound.ScanRunner`
+- the runner spec tests
+
+- [ ] **Step 9: Rename the frontend scan schemas and components**
+
+Edit `frontend/src/api/scan-*.schemas.ts` and every component under `frontend/src/components/features/authenticated-scans/**` that references `assetId` or `assetName`. Use:
+
+```bash
+rg "assetId|assetName" frontend/src/api frontend/src/components/features/authenticated-scans -l
+```
+
+For every match, edit the literal to `deviceId`/`deviceName`, matching camelCase on the TS side.
+
+- [ ] **Step 10: Build and run tests**
+
+Run:
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~AuthenticatedScans|FullyQualifiedName~ScanJob|FullyQualifiedName~ScanProfile"
+cd frontend && npm run typecheck && npm test -- authenticated-scans && cd ..
+```
+
+Expected: clean build, green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/AuthenticatedScans/ \
+        src/PatchHound.Infrastructure/Data/Configurations/AuthenticatedScans/ \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        src/PatchHound.Api/Controllers/Scan*.cs \
+        src/PatchHound.Api/Models/ \
+        src/PatchHound.ScanRunner/ \
+        frontend/src/api/ \
+        frontend/src/components/features/authenticated-scans/ \
+        tests/PatchHound.Tests/
+git commit -m "refactor(canonical): rename authenticated-scan inventory references Asset → Device"
+```
+
+---
+
+## Task 7: `SoftwareProductResolver` service
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/Inventory/SoftwareProductResolver.cs`
+- Create: `src/PatchHound.Core/Interfaces/ISoftwareProductResolver.cs`
+- Register: `src/PatchHound.Api/Program.cs`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/SoftwareProductResolverTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/SoftwareProductResolverTests.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+using PatchHound.Tests.Infrastructure; // DbContext test helper
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class SoftwareProductResolverTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private SoftwareProductResolver _resolver = null!;
+    private SourceSystem _sourceSystem = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = await TestDbContextFactory.CreateAsync(); // existing helper; create if missing
+        _sourceSystem = SourceSystem.Create("defender", "Defender");
+        _db.SourceSystems.Add(_sourceSystem);
+        await _db.SaveChangesAsync();
+        _resolver = new SoftwareProductResolver(_db);
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Resolve_creates_product_and_alias_on_first_observation()
+    {
+        var observation = new SoftwareObservation(
+            SourceSystemId: _sourceSystem.Id,
+            ExternalId: "ms-edge",
+            Vendor: "Microsoft",
+            Name: "Edge");
+
+        var product = await _resolver.ResolveAsync(observation, ct: default);
+
+        Assert.Equal("microsoft::edge", product.CanonicalProductKey);
+        Assert.Single(await _db.SoftwareProducts.ToListAsync());
+        Assert.Single(await _db.SoftwareAliases.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Resolve_returns_existing_product_on_second_observation()
+    {
+        var obs = new SoftwareObservation(_sourceSystem.Id, "ms-edge", "Microsoft", "Edge");
+        var first = await _resolver.ResolveAsync(obs, default);
+        var second = await _resolver.ResolveAsync(obs, default);
+        Assert.Equal(first.Id, second.Id);
+        Assert.Equal(1, await _db.SoftwareProducts.CountAsync());
+        Assert.Equal(1, await _db.SoftwareAliases.CountAsync());
+    }
+
+    [Fact]
+    public async Task Resolve_different_external_ids_same_canonical_resolve_to_same_product()
+    {
+        // Tenant A sees Microsoft/Edge under external id "ms-edge"; Tenant B sees it as "edge-enterprise".
+        var obsA = new SoftwareObservation(_sourceSystem.Id, "ms-edge", "Microsoft", "Edge");
+        var obsB = new SoftwareObservation(_sourceSystem.Id, "edge-enterprise", "Microsoft", "Edge");
+        var a = await _resolver.ResolveAsync(obsA, default);
+        var b = await _resolver.ResolveAsync(obsB, default);
+        Assert.Equal(a.Id, b.Id);
+        Assert.Equal(1, await _db.SoftwareProducts.CountAsync());
+        Assert.Equal(2, await _db.SoftwareAliases.CountAsync());
+    }
+}
+```
+
+Note: if `TestDbContextFactory` does not exist, create it at `tests/PatchHound.Tests/Infrastructure/TestDbContextFactory.cs` as a small helper that builds an in-memory / SQLite-in-memory `PatchHoundDbContext` with a no-tenant `ITenantContext` stub set to `IsSystemContext = true`. Keep this helper minimal — it is used by every subsequent service test in Phase 1.
+
+- [ ] **Step 2: Run to verify the test fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~SoftwareProductResolverTests"`
+Expected: FAIL, `SoftwareProductResolver` not found.
+
+- [ ] **Step 3: Create the interface and record**
+
+Create `src/PatchHound.Core/Interfaces/ISoftwareProductResolver.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Core.Interfaces;
+
+public record SoftwareObservation(Guid SourceSystemId, string ExternalId, string Vendor, string Name);
+
+public interface ISoftwareProductResolver
+{
+    Task<SoftwareProduct> ResolveAsync(SoftwareObservation observation, CancellationToken ct);
+}
+```
+
+- [ ] **Step 4: Create the service**
+
+Create `src/PatchHound.Infrastructure/Services/Inventory/SoftwareProductResolver.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services.Inventory;
+
+public class SoftwareProductResolver(PatchHoundDbContext db) : ISoftwareProductResolver
+{
+    public async Task<SoftwareProduct> ResolveAsync(SoftwareObservation observation, CancellationToken ct)
+    {
+        var alias = await db.SoftwareAliases
+            .FirstOrDefaultAsync(a =>
+                a.SourceSystemId == observation.SourceSystemId
+                && a.ExternalId == observation.ExternalId, ct);
+
+        if (alias is not null)
+        {
+            var existing = await db.SoftwareProducts.FirstAsync(p => p.Id == alias.SoftwareProductId, ct);
+            return existing;
+        }
+
+        var canonicalKey = $"{observation.Vendor.Trim().ToLowerInvariant()}::{observation.Name.Trim().ToLowerInvariant()}";
+        var product = await db.SoftwareProducts.FirstOrDefaultAsync(p => p.CanonicalProductKey == canonicalKey, ct);
+        if (product is null)
+        {
+            product = SoftwareProduct.Create(observation.Vendor, observation.Name, primaryCpe23Uri: null);
+            db.SoftwareProducts.Add(product);
+        }
+
+        var newAlias = SoftwareAlias.Create(
+            softwareProductId: product.Id,
+            sourceSystemId: observation.SourceSystemId,
+            externalId: observation.ExternalId,
+            observedVendor: observation.Vendor,
+            observedName: observation.Name);
+        db.SoftwareAliases.Add(newAlias);
+        await db.SaveChangesAsync(ct);
+        return product;
+    }
+}
+```
+
+- [ ] **Step 5: Register the service**
+
+In `src/PatchHound.Api/Program.cs`, next to the other scoped services:
+
+```csharp
+builder.Services.AddScoped<ISoftwareProductResolver, SoftwareProductResolver>();
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~SoftwareProductResolverTests"`
+Expected: PASS (three tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Core/Interfaces/ISoftwareProductResolver.cs \
+        src/PatchHound.Infrastructure/Services/Inventory/SoftwareProductResolver.cs \
+        src/PatchHound.Api/Program.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/SoftwareProductResolverTests.cs \
+        tests/PatchHound.Tests/Infrastructure/TestDbContextFactory.cs
+git commit -m "feat(canonical): add SoftwareProductResolver with alias-backed resolution"
+```
+
+---
+
+## Task 8: `DeviceResolver` service
+
+**Files:**
+- Create: `src/PatchHound.Core/Interfaces/IDeviceResolver.cs`
+- Create: `src/PatchHound.Infrastructure/Services/Inventory/DeviceResolver.cs`
+- Register: `src/PatchHound.Api/Program.cs`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/DeviceResolverTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/DeviceResolverTests.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class DeviceResolverTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private DeviceResolver _resolver = null!;
+    private Guid _tenantId;
+    private SourceSystem _source = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = await TestDbContextFactory.CreateAsync();
+        _tenantId = Guid.NewGuid();
+        _source = SourceSystem.Create("defender", "Defender");
+        _db.SourceSystems.Add(_source);
+        await _db.SaveChangesAsync();
+        _resolver = new DeviceResolver(_db);
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Resolve_creates_device_on_first_observation()
+    {
+        var obs = new DeviceObservation(_tenantId, _source.Id, "dev-1", "host.a", Criticality.Medium);
+        var device = await _resolver.ResolveAsync(obs, default);
+        Assert.Equal(_tenantId, device.TenantId);
+        Assert.Equal("dev-1", device.ExternalId);
+        Assert.Single(await _db.Devices.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Resolve_returns_existing_device_on_second_observation()
+    {
+        var obs = new DeviceObservation(_tenantId, _source.Id, "dev-1", "host.a", Criticality.Medium);
+        var a = await _resolver.ResolveAsync(obs, default);
+        var b = await _resolver.ResolveAsync(obs, default);
+        Assert.Equal(a.Id, b.Id);
+        Assert.Equal(1, await _db.Devices.CountAsync());
+    }
+
+    [Fact]
+    public async Task Resolve_same_external_id_different_source_systems_creates_two_devices()
+    {
+        var other = SourceSystem.Create("tanium", "Tanium");
+        _db.SourceSystems.Add(other);
+        await _db.SaveChangesAsync();
+
+        var a = await _resolver.ResolveAsync(new DeviceObservation(_tenantId, _source.Id, "dev-1", "host", Criticality.Low), default);
+        var b = await _resolver.ResolveAsync(new DeviceObservation(_tenantId, other.Id, "dev-1", "host", Criticality.Low), default);
+        Assert.NotEqual(a.Id, b.Id);
+        Assert.Equal(2, await _db.Devices.CountAsync());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify the test fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeviceResolverTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Create the interface**
+
+Create `src/PatchHound.Core/Interfaces/IDeviceResolver.cs`:
+
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Interfaces;
+
+public record DeviceObservation(
+    Guid TenantId,
+    Guid SourceSystemId,
+    string ExternalId,
+    string Name,
+    Criticality BaselineCriticality);
+
+public interface IDeviceResolver
+{
+    Task<Device> ResolveAsync(DeviceObservation observation, CancellationToken ct);
+}
+```
+
+- [ ] **Step 4: Create the service**
+
+Create `src/PatchHound.Infrastructure/Services/Inventory/DeviceResolver.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services.Inventory;
+
+public class DeviceResolver(PatchHoundDbContext db) : IDeviceResolver
+{
+    public async Task<Device> ResolveAsync(DeviceObservation observation, CancellationToken ct)
+    {
+        var existing = await db.Devices
+            .IgnoreQueryFilters() // resolver runs under system context during ingestion
+            .FirstOrDefaultAsync(d =>
+                d.TenantId == observation.TenantId
+                && d.SourceSystemId == observation.SourceSystemId
+                && d.ExternalId == observation.ExternalId, ct);
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var device = Device.Create(
+            tenantId: observation.TenantId,
+            sourceSystemId: observation.SourceSystemId,
+            externalId: observation.ExternalId,
+            name: observation.Name,
+            baselineCriticality: observation.BaselineCriticality);
+        db.Devices.Add(device);
+        await db.SaveChangesAsync(ct);
+        return device;
+    }
+}
+```
+
+Note: this is the one documented `IgnoreQueryFilters()` use in Phase 1. Per spec §4.10 Rule 5, it is allowed inside ingestion (system-context) services. Document this in the PR description's tenant-scope audit.
+
+- [ ] **Step 5: Register and test**
+
+In `Program.cs`:
+
+```csharp
+builder.Services.AddScoped<IDeviceResolver, DeviceResolver>();
+```
+
+Run: `dotnet test --filter "FullyQualifiedName~DeviceResolverTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Interfaces/IDeviceResolver.cs \
+        src/PatchHound.Infrastructure/Services/Inventory/DeviceResolver.cs \
+        src/PatchHound.Api/Program.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/DeviceResolverTests.cs
+git commit -m "feat(canonical): add DeviceResolver service"
+```
+
+---
+
+## Task 9: `StagedDeviceMergeService` — replace `StagedAssetMergeService`
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/Inventory/StagedDeviceMergeService.cs`
+- Create: `src/PatchHound.Core/Interfaces/IStagedDeviceMergeService.cs`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/StagedDeviceMergeServiceTests.cs`
+
+**Contract:** given a pending ingestion run and a tenant ID, read `StagedAsset` rows for that run and produce canonical `Device` + `InstalledSoftware` rows. Legacy-free: writes only to canonical tables. Idempotent under spec §7 "Ingestion idempotency": re-merging the same staged data must not produce duplicate rows. Does **not** touch legacy tables.
+
+- [ ] **Step 1: Write the failing test (idempotency)**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/StagedDeviceMergeServiceTests.cs` with at least these three tests:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class StagedDeviceMergeServiceTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private StagedDeviceMergeService _svc = null!;
+    private Guid _tenantId;
+    private SourceSystem _source = null!;
+    private IngestionRun _run = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = await TestDbContextFactory.CreateAsync();
+        _tenantId = Guid.NewGuid();
+        _source = SourceSystem.Create("defender", "Defender");
+        _db.SourceSystems.Add(_source);
+        _run = IngestionRun.Start(_tenantId, sourceKey: "defender");
+        _db.IngestionRuns.Add(_run);
+        await _db.SaveChangesAsync();
+        _svc = new StagedDeviceMergeService(_db,
+            new DeviceResolver(_db),
+            new SoftwareProductResolver(_db));
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Merge_creates_device_and_installed_software_from_staged_rows()
+    {
+        var staged = StagedAsset.CreateDevice(runId: _run.Id, tenantId: _tenantId, externalId: "dev-1", name: "host", sourceKey: "defender");
+        staged.AddSoftwareObservation(externalId: "ms-edge", vendor: "Microsoft", name: "Edge", version: "1.2.3");
+        _db.StagedAssets.Add(staged);
+        await _db.SaveChangesAsync();
+
+        var summary = await _svc.MergeAsync(_run.Id, _tenantId, default);
+
+        Assert.Equal(1, summary.DevicesCreated);
+        Assert.Equal(1, summary.InstalledSoftwareCreated);
+        Assert.Single(await _db.Devices.IgnoreQueryFilters().Where(d => d.TenantId == _tenantId).ToListAsync());
+        Assert.Single(await _db.InstalledSoftware.IgnoreQueryFilters().Where(i => i.TenantId == _tenantId).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Merge_is_idempotent_on_repeated_run()
+    {
+        // Seed one staged observation
+        var staged = StagedAsset.CreateDevice(_run.Id, _tenantId, "dev-1", "host", "defender");
+        staged.AddSoftwareObservation("ms-edge", "Microsoft", "Edge", "1.2.3");
+        _db.StagedAssets.Add(staged);
+        await _db.SaveChangesAsync();
+
+        await _svc.MergeAsync(_run.Id, _tenantId, default);
+        // Re-stage the same observation under a new run
+        var run2 = IngestionRun.Start(_tenantId, "defender");
+        _db.IngestionRuns.Add(run2);
+        var staged2 = StagedAsset.CreateDevice(run2.Id, _tenantId, "dev-1", "host", "defender");
+        staged2.AddSoftwareObservation("ms-edge", "Microsoft", "Edge", "1.2.3");
+        _db.StagedAssets.Add(staged2);
+        await _db.SaveChangesAsync();
+
+        await _svc.MergeAsync(run2.Id, _tenantId, default);
+
+        Assert.Equal(1, await _db.Devices.IgnoreQueryFilters().CountAsync(d => d.TenantId == _tenantId));
+        Assert.Equal(1, await _db.InstalledSoftware.IgnoreQueryFilters().CountAsync(i => i.TenantId == _tenantId));
+    }
+
+    [Fact]
+    public async Task Merge_two_tenants_does_not_cross_contaminate()
+    {
+        var tenantB = Guid.NewGuid();
+        var runB = IngestionRun.Start(tenantB, "defender");
+        _db.IngestionRuns.Add(runB);
+
+        var stagedA = StagedAsset.CreateDevice(_run.Id, _tenantId, "dev-shared", "host", "defender");
+        stagedA.AddSoftwareObservation("ms-edge", "Microsoft", "Edge", "1.2.3");
+        var stagedB = StagedAsset.CreateDevice(runB.Id, tenantB, "dev-shared", "host", "defender");
+        stagedB.AddSoftwareObservation("ms-edge", "Microsoft", "Edge", "1.2.3");
+        _db.StagedAssets.AddRange(stagedA, stagedB);
+        await _db.SaveChangesAsync();
+
+        await _svc.MergeAsync(_run.Id, _tenantId, default);
+        await _svc.MergeAsync(runB.Id, tenantB, default);
+
+        var devicesA = await _db.Devices.IgnoreQueryFilters().Where(d => d.TenantId == _tenantId).ToListAsync();
+        var devicesB = await _db.Devices.IgnoreQueryFilters().Where(d => d.TenantId == tenantB).ToListAsync();
+        Assert.Single(devicesA);
+        Assert.Single(devicesB);
+        Assert.NotEqual(devicesA[0].Id, devicesB[0].Id);
+        // Same SoftwareProduct shared globally is expected (canonical).
+        Assert.Equal(1, await _db.SoftwareProducts.CountAsync());
+    }
+}
+```
+
+If `StagedAsset.CreateDevice(...)` and `AddSoftwareObservation(...)` don't already match these signatures, adjust the test to whatever the existing factory API looks like. The intent of this test is to drive the merge service contract — update the test input shape to the truth, not the other way around.
+
+- [ ] **Step 2: Run to verify the test fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~StagedDeviceMergeServiceTests"`
+Expected: FAIL, type not found.
+
+- [ ] **Step 3: Create the interface**
+
+Create `src/PatchHound.Core/Interfaces/IStagedDeviceMergeService.cs`:
+
+```csharp
+namespace PatchHound.Core.Interfaces;
+
+public record StagedDeviceMergeSummary(
+    int DevicesCreated,
+    int DevicesTouched,
+    int InstalledSoftwareCreated,
+    int InstalledSoftwareTouched);
+
+public interface IStagedDeviceMergeService
+{
+    Task<StagedDeviceMergeSummary> MergeAsync(Guid ingestionRunId, Guid tenantId, CancellationToken ct);
+}
+```
+
+- [ ] **Step 4: Create the service**
+
+Create `src/PatchHound.Infrastructure/Services/Inventory/StagedDeviceMergeService.cs`. It must:
+
+1. Load all `StagedAsset` rows for `(runId, tenantId)` under `IgnoreQueryFilters()` (this is system-context).
+2. For each staged device, resolve the `SourceSystem.Id` for the staged row's `SourceKey` by looking up `SourceSystems` by key (fail loudly if the source system is missing — ingestion misconfigured).
+3. Call `IDeviceResolver.ResolveAsync` to get or create the canonical `Device`.
+4. Apply attribute updates (`UpdateInventoryDetails`, `SetActiveInTenant(true)`, etc.) from the staged row onto the device.
+5. For each staged software observation attached to the staged row, call `ISoftwareProductResolver.ResolveAsync` then either insert a new `InstalledSoftware` or update the existing row's `LastSeenAt` via `Touch`.
+6. Save changes and return a summary.
+
+Concrete skeleton (fill in with the real staged-row shape once verified):
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services.Inventory;
+
+public class StagedDeviceMergeService(
+    PatchHoundDbContext db,
+    IDeviceResolver deviceResolver,
+    ISoftwareProductResolver softwareResolver) : IStagedDeviceMergeService
+{
+    public async Task<StagedDeviceMergeSummary> MergeAsync(Guid runId, Guid tenantId, CancellationToken ct)
+    {
+        var devicesCreated = 0;
+        var devicesTouched = 0;
+        var installedCreated = 0;
+        var installedTouched = 0;
+
+        var staged = await db.StagedAssets
+            .IgnoreQueryFilters()
+            .Include(s => s.SoftwareObservations)
+            .Where(s => s.IngestionRunId == runId && s.TenantId == tenantId)
+            .ToListAsync(ct);
+
+        var sourceSystems = await db.SourceSystems.ToDictionaryAsync(s => s.Key, ct);
+
+        foreach (var stagedDevice in staged)
+        {
+            if (!sourceSystems.TryGetValue(stagedDevice.SourceKey, out var sourceSystem))
+            {
+                throw new InvalidOperationException($"Unknown source system key '{stagedDevice.SourceKey}'. Seed it in SourceSystemSeedHostedService before ingesting.");
+            }
+
+            var deviceBefore = await db.Devices.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(d =>
+                    d.TenantId == tenantId
+                    && d.SourceSystemId == sourceSystem.Id
+                    && d.ExternalId == stagedDevice.ExternalId, ct);
+
+            var device = await deviceResolver.ResolveAsync(
+                new DeviceObservation(tenantId, sourceSystem.Id, stagedDevice.ExternalId, stagedDevice.Name, Criticality.Medium),
+                ct);
+
+            if (deviceBefore is null) devicesCreated++;
+            else devicesTouched++;
+
+            // Apply attribute updates from the staged payload.
+            // (Match fields 1:1 with StagedAsset columns.)
+            device.UpdateInventoryDetails(
+                computerDnsName: stagedDevice.DeviceComputerDnsName,
+                healthStatus:    stagedDevice.DeviceHealthStatus,
+                osPlatform:      stagedDevice.DeviceOsPlatform,
+                osVersion:       stagedDevice.DeviceOsVersion,
+                externalRiskLabel: stagedDevice.DeviceRiskScore,
+                lastSeenAt:      stagedDevice.DeviceLastSeenAt,
+                lastIpAddress:   stagedDevice.DeviceLastIpAddress,
+                aadDeviceId:     stagedDevice.DeviceAadDeviceId,
+                groupId:         stagedDevice.DeviceGroupId,
+                groupName:       stagedDevice.DeviceGroupName,
+                exposureLevel:   stagedDevice.DeviceExposureLevel,
+                isAadJoined:     stagedDevice.DeviceIsAadJoined,
+                onboardingStatus: stagedDevice.DeviceOnboardingStatus,
+                deviceValue:     stagedDevice.DeviceValue);
+            device.SetActiveInTenant(true);
+
+            foreach (var obs in stagedDevice.SoftwareObservations ?? [])
+            {
+                var product = await softwareResolver.ResolveAsync(
+                    new SoftwareObservation(sourceSystem.Id, obs.ExternalId, obs.Vendor, obs.Name),
+                    ct);
+
+                var existing = await db.InstalledSoftware
+                    .IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(i =>
+                        i.TenantId == tenantId
+                        && i.DeviceId == device.Id
+                        && i.SoftwareProductId == product.Id
+                        && i.SourceSystemId == sourceSystem.Id
+                        && i.Version == (obs.Version ?? ""), ct);
+
+                if (existing is null)
+                {
+                    db.InstalledSoftware.Add(InstalledSoftware.Observe(
+                        tenantId, device.Id, product.Id, sourceSystem.Id, obs.Version, DateTimeOffset.UtcNow));
+                    installedCreated++;
+                }
+                else
+                {
+                    existing.Touch(DateTimeOffset.UtcNow);
+                    installedTouched++;
+                }
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        return new StagedDeviceMergeSummary(devicesCreated, devicesTouched, installedCreated, installedTouched);
+    }
+}
+```
+
+If `StagedAsset` doesn't currently expose `SoftwareObservations` as a collection, extend `StagedAsset` + its configuration in this task. Spec §4.9 marks `StagedAsset` for renaming to `StagedDevice` only in Phase 6 scope; for Phase 1 we keep the table name but reshape the merge path.
+
+- [ ] **Step 5: Register the service**
+
+In `Program.cs`:
+
+```csharp
+builder.Services.AddScoped<IStagedDeviceMergeService, StagedDeviceMergeService>();
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~StagedDeviceMergeServiceTests"`
+Expected: PASS (three tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Core/Interfaces/IStagedDeviceMergeService.cs \
+        src/PatchHound.Infrastructure/Services/Inventory/StagedDeviceMergeService.cs \
+        src/PatchHound.Api/Program.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/StagedDeviceMergeServiceTests.cs
+git commit -m "feat(canonical): add StagedDeviceMergeService writing only canonical entities"
+```
+
+---
+
+## Task 10a: Rewrite `IngestionService` to call `StagedDeviceMergeService` (leave legacy files in place)
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs` (if `IStagedDeviceMergeService` is not yet registered — Task 9 may already have done this)
+- Modify: tests under `tests/PatchHound.Tests/Infrastructure/Services/IngestionService*`
+- **Do NOT delete** `StagedAssetMergeService.cs`, `NormalizedSoftwareProjectionService.cs`, or `NormalizedSoftwareResolver.cs` — they are still consumed by `AuthenticatedScanIngestionService`, `AssetsController`, and `SoftwareVulnerabilityMatchService`. Deletion is deferred to Task 10b (after those consumers migrate).
+
+**Context (important — read before editing):**
+
+1. `IngestionService` is 2,771 lines. Its constructor currently takes `StagedAssetMergeService _stagedAssetMergeService` (line 31) and `NormalizedSoftwareProjectionService _normalizedSoftwareProjectionService` (line 29). Both are only invoked inside the single internal method `ProcessStagedAssetsAsync` (line 2271):
+
+   ```csharp
+   internal async Task<StagedAssetMergeSummary> ProcessStagedAssetsAsync(
+       Guid ingestionRunId, Guid tenantId, string sourceKey, Guid? snapshotId, CancellationToken ct)
+   {
+       var summary = await _stagedAssetMergeService.ProcessAsync(
+           ingestionRunId, tenantId, sourceKey, UpdateAssetMergeProgressAsync, ct);
+       await _normalizedSoftwareProjectionService.SyncTenantAsync(tenantId, snapshotId, ct);
+       return summary;
+       // ... UpdateAssetMergeProgressAsync local function unchanged ...
+   }
+   ```
+
+2. The returned `StagedAssetMergeSummary` (13-field record defined at `StagedAssetMergeService.cs:703`) is consumed in ~30 places across `IngestionService` via fields: `StagedMachineCount`, `StagedSoftwareCount`, `PersistedMachineCount`, `PersistedSoftwareCount`, `MergedAssetCount` (see grep output in Step 1). **Touching all those call sites is out of scope** — we adapt at the boundary instead.
+
+3. The new canonical merge service exposes `IStagedDeviceMergeService.MergeAsync(runId, tenantId, ct)` returning `StagedDeviceMergeSummary(DevicesCreated, DevicesTouched, InstalledSoftwareCreated, InstalledSoftwareTouched)` (4 fields only — created in Task 9).
+
+4. **Boundary adapter strategy:** inside `ProcessStagedAssetsAsync`, call `_stagedDeviceMergeService.MergeAsync`, then construct a `StagedAssetMergeSummary` mapping canonical counts into the legacy shape so the 30 downstream call sites stay unchanged. `StagedAssetMergeSummary` is a public record in `StagedAssetMergeService.cs` — leaving that file in place means the record stays available; no move needed.
+
+5. **Progress callback:** the existing `UpdateAssetMergeProgressAsync` local function takes `(stagedMachineCount, stagedSoftwareCount, persistedMachineCount, persistedSoftwareCount, ct)` and is invoked by `StagedAssetMergeService` during long-running merges. `IStagedDeviceMergeService.MergeAsync` has no progress callback. For 10a, call `UpdateAssetMergeProgressAsync` once with final counts after the merge completes — accept the loss of mid-run progress updates. Document in a code comment.
+
+- [ ] **Step 1: Grep every call site to confirm scope**
+
+Run:
+
+```bash
+rg "StagedAssetMergeService|NormalizedSoftwareProjectionService|NormalizedSoftwareResolver" src/PatchHound.Infrastructure/Services/IngestionService.cs -n
+rg "assetMergeSummary\." src/PatchHound.Infrastructure/Services/IngestionService.cs -n
+```
+
+Expected first command: matches only on lines 29, 31, 45, 47, 73, 75, 87, 89, 2279, 2286 (fields, ctor, assignments, two call sites). Expected second command: ~30 matches across lines 258-1379. **Do not touch any of the ~30 `assetMergeSummary.` call sites — we keep the record shape intact at the boundary.**
+
+- [ ] **Step 2: Swap the constructor dependency**
+
+Replace in `IngestionService.cs`:
+
+```csharp
+// Remove these fields
+private readonly NormalizedSoftwareProjectionService _normalizedSoftwareProjectionService;
+private readonly StagedAssetMergeService _stagedAssetMergeService;
+
+// Add this one
+private readonly IStagedDeviceMergeService _stagedDeviceMergeService;
+```
+
+Both constructors (primary at line 45 and secondary at line 73) take `NormalizedSoftwareProjectionService normalizedSoftwareProjectionService` and `StagedAssetMergeService stagedAssetMergeService`. **Remove both parameters** from both constructors and **add** `IStagedDeviceMergeService stagedDeviceMergeService` in their place. Delete the assignments at lines 87 and 89; add `_stagedDeviceMergeService = stagedDeviceMergeService;` in their place.
+
+`using PatchHound.Core.Interfaces;` may need adding at the top of the file to bring `IStagedDeviceMergeService` into scope — check before adding.
+
+- [ ] **Step 3: Rewrite `ProcessStagedAssetsAsync` to call the canonical merge and adapt the summary**
+
+Replace the body of `ProcessStagedAssetsAsync` (line 2271) with:
+
+```csharp
+internal async Task<StagedAssetMergeSummary> ProcessStagedAssetsAsync(
+    Guid ingestionRunId,
+    Guid tenantId,
+    string sourceKey,
+    Guid? snapshotId,
+    CancellationToken ct
+)
+{
+    // Canonical merge: writes Device + InstalledSoftware directly via resolvers.
+    // The legacy StagedAssetMergeService / NormalizedSoftwareProjectionService path
+    // is no longer invoked here. Those services remain for other consumers
+    // (AuthenticatedScanIngestionService, AssetsController, SoftwareVulnerabilityMatchService)
+    // until Task 10b.
+    var canonicalSummary = await _stagedDeviceMergeService.MergeAsync(ingestionRunId, tenantId, ct);
+
+    var persistedMachineCount = canonicalSummary.DevicesCreated + canonicalSummary.DevicesTouched;
+    var persistedSoftwareCount =
+        canonicalSummary.InstalledSoftwareCreated + canonicalSummary.InstalledSoftwareTouched;
+
+    // The canonical merge service does not expose mid-run progress, so emit a
+    // single final-state progress update. StagedMachineCount/StagedSoftwareCount
+    // already reflect the staging phase totals and are carried through unchanged.
+    await UpdateAssetMergeProgressAsync(
+        stagedMachineCount: persistedMachineCount,
+        stagedSoftwareCount: persistedSoftwareCount,
+        persistedMachineCount: persistedMachineCount,
+        persistedSoftwareCount: persistedSoftwareCount,
+        ct
+    );
+
+    // Adapt the 4-field canonical summary into the 13-field legacy shape so the
+    // ~30 downstream call sites in IngestionService keep working unchanged.
+    // Fields with no canonical equivalent are set to zero; they track concerns
+    // (episodes, stale installations) that no longer exist after Phase 1.
+    return new StagedAssetMergeSummary(
+        StagedMachineCount: persistedMachineCount,
+        StagedSoftwareCount: persistedSoftwareCount,
+        MergedAssetCount: persistedMachineCount + persistedSoftwareCount,
+        PersistedMachineCount: persistedMachineCount,
+        PersistedSoftwareCount: persistedSoftwareCount,
+        StagedSoftwareLinkCount: 0,
+        ResolvedSoftwareLinkCount: 0,
+        InstallationsCreated: canonicalSummary.InstalledSoftwareCreated,
+        InstallationsTouched: canonicalSummary.InstalledSoftwareTouched,
+        EpisodesOpened: 0,
+        EpisodesSeen: 0,
+        StaleInstallationsMarked: 0,
+        InstallationsRemoved: 0
+    );
+
+    async Task UpdateAssetMergeProgressAsync(
+        int stagedMachineCount,
+        int stagedSoftwareCount,
+        int persistedMachineCount,
+        int persistedSoftwareCount,
+        CancellationToken callbackCt
+    )
+    {
+        // ... KEEP the existing body of this local function (lines 2289-2360-ish) verbatim ...
+    }
+}
+```
+
+**Preserve the existing `UpdateAssetMergeProgressAsync` local function body exactly as it is** (in-memory vs non-in-memory branches updating `IngestionRun` progress columns). Only the outer method body changes.
+
+- [ ] **Step 4: Verify DI registration**
+
+```bash
+rg "IStagedDeviceMergeService|StagedDeviceMergeService" src/PatchHound.Infrastructure/DependencyInjection.cs -n
+rg "IStagedDeviceMergeService|StagedDeviceMergeService" src/PatchHound.Api/Program.cs -n
+```
+
+Task 9 should already have registered `services.AddScoped<IStagedDeviceMergeService, StagedDeviceMergeService>()`. If not, add it next to the existing `StagedAssetMergeService` registration. **Do not remove the `StagedAssetMergeService` or `NormalizedSoftwareProjectionService` registrations** — other consumers still need them.
+
+- [ ] **Step 5: Fix existing `IngestionService` tests**
+
+Find them:
+
+```bash
+rg "IngestionService" tests -l
+```
+
+For each test that wires up `IngestionService` directly, swap the constructor args:
+- Remove `StagedAssetMergeService` and `NormalizedSoftwareProjectionService` from the test's construction
+- Add an `IStagedDeviceMergeService` — stub it with a fake that returns `new StagedDeviceMergeSummary(DevicesCreated: 0, DevicesTouched: 0, InstalledSoftwareCreated: 0, InstalledSoftwareTouched: 0)` (or a configured count if the test asserts merge output)
+
+Existing tests that asserted `StagedMachineCount`/`StagedSoftwareCount`/`PersistedMachineCount`/`PersistedSoftwareCount` should still work because the adapter populates those fields from canonical counts — verify by running them.
+
+Tests that asserted `NormalizedSoftware*` projection side effects must be updated to assert canonical `InstalledSoftware` side effects instead, or removed if they duplicate Task 9's coverage.
+
+- [ ] **Step 6: Build and run tests**
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~Ingestion"
+```
+
+Expected: clean build, green. If the full suite regresses, run `dotnet test` and fix the specific breakage — the adapter should keep all downstream `assetMergeSummary.*` usages working.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs \
+        src/PatchHound.Api/Program.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/
+git commit -m "refactor(ingestion): IngestionService writes canonical Device+InstalledSoftware via StagedDeviceMergeService"
+```
+
+---
+
+## Task 10c (deferred): Rewrite `IngestionServiceTests.cs` to assert canonical `Device` / `InstalledSoftware` state
+
+**Deferred — all 38 tests in `tests/PatchHound.Tests/Infrastructure/IngestionServiceTests.cs` are currently marked with `Skip = "Legacy Asset-centric assertions. Pending canonical inventory test rewrite in Task 10c / Task 16/17."`.**
+
+**Why they were skipped:** After Task 10a swapped `IngestionService.ProcessStagedAssetsAsync` from `StagedAssetMergeService.ProcessAsync` to `IStagedDeviceMergeService.MergeAsync`, 17 of the 38 tests failed at runtime because their assertions poke at `_dbContext.Assets` / `DeviceSoftwareInstallations` / `IngestionRun.Status` state that is no longer written the same way. The remaining 21 pass today, but the entire file is skipped to avoid a mix of Skip/run states that will rot under further Phase 1 changes.
+
+**Scope of rewrite:**
+- Replace `_dbContext.Assets.IgnoreQueryFilters()...` assertions with `_dbContext.Devices.IgnoreQueryFilters()...`
+- Replace `_dbContext.DeviceSoftwareInstallations...` assertions with `_dbContext.InstalledSoftware...`
+- Delete tests that assert on `NormalizedSoftware` / `TenantSoftware` (those tables are removed in Task 16)
+- Review each `RunIngestionAsync_*` test for `IngestionRun.Status` expectations — the canonical merge path may emit slightly different status values; fix the expectation to match new reality, not the other way around
+- For tests that construct `IngestionService` inline (10 sites), the constructor signature is already correct (Task 10a updated them); they now use a `Substitute.For<IStagedDeviceMergeService>()` which returns `default(StagedDeviceMergeSummary)` — configure the stub with `.Returns(new StagedDeviceMergeSummary(...))` for tests that care about merge counts
+
+**When to execute:** Ideally bundled with Task 16 (legacy inventory deletion) since the two rewrites touch overlapping seed code. If Task 16's scope grows too large, split Task 10c into its own standalone task before Task 16.
+
+---
+
+## Task 10b (deferred): Delete legacy `StagedAssetMergeService` / `NormalizedSoftwareProjectionService` / `NormalizedSoftwareResolver`
+
+**Deferred — do not execute during Phase 1 Task 10.** This task unblocks only after:
+1. `AuthenticatedScanIngestionService` (`src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs`) migrates off `StagedAssetMergeService` + `NormalizedSoftwareProjectionService` and off the legacy `dbContext.Assets` read in `GetDeviceExternalId`. This likely happens in Phase 1 Task 16 (legacy inventory deletion) or gets a dedicated task before then.
+2. `AssetsController` (`src/PatchHound.Api/Controllers/AssetsController.cs`) drops its 3 `SyncTenantAsync` call sites. This is tracked in Task 13 (DevicesController migration).
+3. `SoftwareVulnerabilityMatchService` (Infrastructure/Services) drops its 2 `SyncTenantAsync` call sites. This is tracked in Phase 2 or an early Phase 3 task — verify at Phase 2 kickoff.
+
+**When all three are clear:**
+- [ ] `rm src/PatchHound.Infrastructure/Services/StagedAssetMergeService.cs` (also deletes the `StagedAssetMergeSummary` record — move the record into `IngestionService.cs` as a private nested type **only if IngestionService still uses it** after downstream cleanup; otherwise delete outright)
+- [ ] `rm src/PatchHound.Infrastructure/Services/NormalizedSoftwareProjectionService.cs`
+- [ ] `rm src/PatchHound.Infrastructure/Services/NormalizedSoftwareResolver.cs`
+- [ ] Remove DI registrations from `DependencyInjection.cs` and/or `Program.cs`
+- [ ] `dotnet build && dotnet test`
+- [ ] Commit: `refactor(ingestion): remove legacy StagedAssetMergeService after consumers migrated`
+
+---
+
+## Task 11: Replace `AssetRuleEvaluationService` with `DeviceRuleEvaluationService`
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/Inventory/DeviceRuleEvaluationService.cs`
+- Modify: every caller (search with `rg "AssetRuleEvaluationService"`)
+- Delete: `src/PatchHound.Infrastructure/Services/AssetRuleEvaluationService.cs`
+- Delete: `src/PatchHound.Infrastructure/Services/AssetRuleFilterBuilder.cs` (if it becomes unused)
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/DeviceRuleEvaluationServiceTests.cs`
+
+- [ ] **Step 1: Read the existing implementation**
+
+Read `src/PatchHound.Infrastructure/Services/AssetRuleEvaluationService.cs` end-to-end. Identify:
+- What inputs it accepts (grep, criteria JSON, rule set)
+- Which entity fields it matches on (e.g. `Asset.DeviceOsPlatform`)
+- What side effects it writes (criticality from rule, fallback team, security profile)
+
+- [ ] **Step 2: Write a failing behavior test**
+
+Create `DeviceRuleEvaluationServiceTests.cs` with at minimum:
+- a test asserting that a rule matching on `OsPlatform == "Windows"` sets the criticality for matching devices only
+- a test asserting two tenants' rules don't cross-affect each other
+- a test asserting that rules whose criteria no longer match clear their rule-assigned criticality/team/profile
+
+Use the existing `AssetRuleEvaluationServiceTests` as a template, renaming the types.
+
+- [ ] **Step 3: Port the implementation to operate on `Device`**
+
+Create `DeviceRuleEvaluationService.cs`. Replace every `db.Assets` with `db.Devices`, every `AssetRule` with `DeviceRule`, every field that was renamed in the entity (`DeviceOsPlatform` → `OsPlatform`, etc.). Reuse the existing filter-builder pattern — if the filter builder still makes sense, create `DeviceRuleFilterBuilder.cs`; if it doesn't survive the rename cleanly, inline it.
+
+- [ ] **Step 4: Update every caller**
+
+Run:
+
+```bash
+rg "AssetRuleEvaluationService|IAssetRuleEvaluationService" src -l
+```
+
+For each hit, rename to `DeviceRuleEvaluationService` / `IDeviceRuleEvaluationService`. Typical callers: a hosted service that re-evaluates rules on ingestion changes, and the admin controller that runs "preview" evaluations.
+
+- [ ] **Step 5: Register and delete the old files**
+
+Update `Program.cs` to register the new service and drop the old one. Then:
+
+```bash
+rm src/PatchHound.Infrastructure/Services/AssetRuleEvaluationService.cs
+rm src/PatchHound.Infrastructure/Services/AssetRuleFilterBuilder.cs   # only if grep shows it has no remaining consumers
+```
+
+- [ ] **Step 6: Build and test**
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~DeviceRuleEvaluation|FullyQualifiedName~AssetRuleEvaluation"
+```
+
+Expected: clean build, all green (including previous `AssetRule*` tests that you renamed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/Inventory/DeviceRuleEvaluationService.cs \
+        src/PatchHound.Infrastructure/Services/Inventory/DeviceRuleFilterBuilder.cs \
+        src/PatchHound.Api/Program.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/DeviceRuleEvaluationServiceTests.cs
+git rm src/PatchHound.Infrastructure/Services/AssetRuleEvaluationService.cs \
+       src/PatchHound.Infrastructure/Services/AssetRuleFilterBuilder.cs
+git commit -m "refactor(rules): evaluate DeviceRule against Device entities"
+```
+
+---
+
+## Task 12: Rewrite `RiskScoreService` inventory baseline (device baseline only)
+
+**Context:** Phase 1 only changes the *source* of device rows for risk scoring — from `Asset` to `Device` — and the name of the target table from `AssetRiskScore` to `DeviceRiskScore`. Vulnerability-driven components are rewritten in Phase 5 once exposure is canonical (Phase 3).
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/RiskScoreService.cs`
+- Modify: the risk-score query services under `src/PatchHound.Infrastructure/Services/` that currently project `Asset` → `AssetRiskScore`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTests.cs` (if it exists — otherwise add a focused one)
+
+- [ ] **Step 1: Grep every remaining use of `Asset*` risk references inside `RiskScoreService`**
+
+```bash
+rg "Asset\\b|AssetRiskScore|AssetRule|AssetType" src/PatchHound.Infrastructure/Services/RiskScoreService.cs -n
+```
+
+- [ ] **Step 2: Update the query/project path**
+
+Replace every `db.Assets.Where(a => a.TenantId == ...)` with `db.Devices.Where(d => d.TenantId == ...)`. Where the old code checked `a.AssetType == AssetType.Device`, drop the check (every `Device` row is a device). Project into `DeviceRiskScore` instead of `AssetRiskScore`.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~RiskScoreService"
+```
+
+Expected: clean build, green. Spec explicitly allows numeric drift — tests that pinned exact values may need re-baselining. If so, update the asserts to the new canonical values, noting the shift in a comment.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/RiskScoreService.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTests.cs
+git commit -m "refactor(risk): use Device and DeviceRiskScore in baseline risk path"
+```
+
+---
+
+## Task 13: Rename `AssetsController` → `DevicesController` and wire to `Device`
+
+**Files:**
+- Create: `src/PatchHound.Api/Controllers/DevicesController.cs` (copy/rewrite of `AssetsController.cs`)
+- Delete: `src/PatchHound.Api/Controllers/AssetsController.cs`
+- Modify: `src/PatchHound.Api/Models/*` DTOs — rename `AssetDto` → `DeviceDto` and drop `AssetType` field
+- Modify: every API test that hits `/api/assets`
+- Test: `tests/PatchHound.Tests/Api/DevicesControllerTests.cs`
+
+- [ ] **Step 1: Copy the controller**
+
+```bash
+cp src/PatchHound.Api/Controllers/AssetsController.cs src/PatchHound.Api/Controllers/DevicesController.cs
+```
+
+Then edit `DevicesController.cs`:
+- class name → `DevicesController`
+- route → `[Route("api/devices")]`
+- every `Asset` → `Device`, `db.Assets` → `db.Devices`
+- drop `AssetType` filtering (no longer exists)
+- `AssetDto` → `DeviceDto` (rename the DTO in `src/PatchHound.Api/Models/` — create `DeviceDto` as a direct rename)
+
+- [ ] **Step 2: Delete the old controller**
+
+```bash
+rm src/PatchHound.Api/Controllers/AssetsController.cs
+```
+
+- [ ] **Step 3: Update tests**
+
+Rename every `AssetsController`-targeting test to `DevicesControllerTests`, update route strings from `/api/assets` to `/api/devices`. Drop any `AssetType` assertions.
+
+- [ ] **Step 4: Build and run API tests**
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~DevicesControllerTests"
+```
+
+Expected: clean build, green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/DevicesController.cs \
+        src/PatchHound.Api/Models/ \
+        tests/PatchHound.Tests/Api/
+git rm src/PatchHound.Api/Controllers/AssetsController.cs
+git commit -m "feat(api): introduce /api/devices backed by Device entity"
+```
+
+---
+
+## Task 14: Admin controllers — rename asset-rule, tag, label, security-profile endpoints
+
+**Files:**
+- Rename: `src/PatchHound.Api/Controllers/AssetRulesController.cs` → `DeviceRulesController.cs`, route `/api/asset-rules` → `/api/device-rules`
+- Rename: `src/PatchHound.Api/Controllers/AssetTagsController.cs` → `DeviceTagsController.cs`
+- Rename: `src/PatchHound.Api/Controllers/AssetBusinessLabelsController.cs` → `DeviceBusinessLabelsController.cs`
+- Rename: `src/PatchHound.Api/Controllers/AssetSecurityProfilesController.cs` → `SecurityProfilesController.cs`, route `/api/security-profiles`
+- Update: DTOs under `src/PatchHound.Api/Models/` to drop `Asset` prefix
+- Update: tests
+
+- [ ] **Step 1: Grep for every such controller**
+
+```bash
+rg "\"api/asset-|api/asset-rules|api/asset-tags|api/asset-business-labels|api/asset-security-profiles\"" src -l
+```
+
+Write the list down before editing.
+
+- [ ] **Step 2–N: For each controller, copy→rename→delete old, following Task 13's pattern**
+
+Each rename is mechanically the same: new file, updated class/route/DTO, delete old, update tests. Commit **each controller as its own commit** so the review is small and reversible:
+
+```bash
+git commit -m "feat(api): rename AssetRulesController → DeviceRulesController"
+git commit -m "feat(api): rename AssetTagsController → DeviceTagsController"
+git commit -m "feat(api): rename AssetBusinessLabelsController → DeviceBusinessLabelsController"
+git commit -m "feat(api): rename AssetSecurityProfilesController → SecurityProfilesController"
+```
+
+- [ ] **Step Final: Build and run API tests**
+
+```bash
+dotnet build
+dotnet test --filter "FullyQualifiedName~DeviceRulesControllerTests|FullyQualifiedName~DeviceTagsControllerTests|FullyQualifiedName~DeviceBusinessLabelsControllerTests|FullyQualifiedName~SecurityProfilesControllerTests"
+```
+
+Expected: clean build, green.
+
+---
+
+## Task 15: Frontend — rename `/assets` routes and components to `/devices`
+
+**Context:** The frontend already has `frontend/src/routes/_authed/devices/` (per grep in preflight) — the assets-directory content needs to move there, and every component under `frontend/src/components/features/assets/` needs to be renamed to `frontend/src/components/features/devices/`.
+
+**Files:**
+- Rename: `frontend/src/routes/_authed/assets/` → `frontend/src/routes/_authed/devices/` (merge with existing folder; no duplication)
+- Rename: `frontend/src/components/features/assets/` → `frontend/src/components/features/devices/` (and every file inside — `AssetDetailPane.tsx` → `DeviceDetailPane.tsx`, etc.)
+- Rename: `frontend/src/features/assets/` → `frontend/src/features/devices/`
+- Rename: `frontend/src/api/assets.functions.ts` → `frontend/src/api/devices.functions.ts`
+- Rename: `frontend/src/api/assets.schemas.ts` → `frontend/src/api/devices.schemas.ts`
+- Modify: `frontend/src/router.tsx`, `frontend/src/routeTree.gen.ts` (regenerate)
+- Update: `frontend/src/components/features/dashboard/AssetOwnerAttentionView.tsx` → `DeviceOwnerAttentionView.tsx`
+- Update: `frontend/src/components/features/admin/asset-rules/` → `device-rules/`
+- Update: `frontend/src/routes/_authed/admin/asset-rules/` → `device-rules/`
+- Update: `frontend/src/routes/_authed/dashboard/my-assets.tsx` → `my-devices.tsx`
+- Update: every import that references an `Asset*` type, and every call site that calls `getAssets` → `getDevices`
+
+- [ ] **Step 1: Inventory the rename surface**
+
+```bash
+rg -l "Asset|assets" frontend/src > /tmp/assets-frontend-renames.txt
+wc -l /tmp/assets-frontend-renames.txt
+```
+
+Expected: dozens of files. Review the list to identify what is genuinely about assets-vs-devices (rename) vs legitimate uses of the word "asset" elsewhere in copy/docs (leave alone).
+
+- [ ] **Step 2: Rename directories with `git mv`**
+
+```bash
+git mv frontend/src/routes/_authed/assets frontend/src/routes/_authed/devices-new
+# merge contents into existing devices dir, then remove the staging dir
+```
+
+If the existing `frontend/src/routes/_authed/devices` already has content, inspect it first — it may be a stub. Resolve conflicts by keeping the richer implementation from the former `assets` directory.
+
+Repeat for `frontend/src/components/features/assets`, `frontend/src/features/assets`, `frontend/src/api/assets.functions.ts`, `frontend/src/api/assets.schemas.ts`, `frontend/src/components/features/admin/asset-rules`, `frontend/src/routes/_authed/admin/asset-rules`, `frontend/src/routes/_authed/dashboard/my-assets.tsx`.
+
+- [ ] **Step 3: Bulk-rename type references**
+
+For each renamed file, update its contents:
+- `Asset` type → `Device`
+- `AssetDto` → `DeviceDto`
+- `assetId` → `deviceId`
+- `/api/assets` → `/api/devices`
+- `useGetAssets` → `useGetDevices`
+- Component names (e.g. `AssetDetailPane` → `DeviceDetailPane`, `AssetAdvancedToolsPanel` → `DeviceAdvancedToolsPanel`)
+
+For each function/component renamed, update every caller. Use `rg "AssetDetailPane" frontend/src -l` to verify zero leftover references per rename.
+
+- [ ] **Step 4: Regenerate the TanStack route tree**
+
+```bash
+cd frontend && npm run dev -- --generate-routes 2>/dev/null || npx @tanstack/router-cli generate
+```
+
+Exact command depends on project setup — grep `package.json` scripts for `generate` or `routes`. If none exists, edit `routeTree.gen.ts` manually (the file is regenerated on `npm run dev`, so triggering a dev server start and stopping it is the usual workflow).
+
+- [ ] **Step 5: Run typecheck and tests**
+
+```bash
+cd frontend
+npm run typecheck
+npm test
+cd ..
+```
+
+Expected: no type errors, green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src
+git commit -m "feat(frontend): rename /assets → /devices routes and components"
+```
+
+---
+
+## Task 16: Delete legacy inventory entities (`Asset`, `AssetType`, `Asset*` subtypes, `NormalizedSoftware*`, `TenantSoftware*`, `DeviceSoftwareInstallation*`, `SoftwareCpeBinding`, `StagedAsset`, `StagedDeviceSoftwareInstallation`)
+
+**Context:** Every consumer has been rewritten in Tasks 1–15. This task is the mechanical deletion + tenant-filter removal pass.
+
+**Files to delete:** (spec §4.9 inventory legacy + software legacy)
+
+```
+src/PatchHound.Core/Entities/Asset.cs
+src/PatchHound.Core/Entities/AssetBusinessLabel.cs
+src/PatchHound.Core/Entities/AssetRiskScore.cs
+src/PatchHound.Core/Entities/AssetRule.cs
+src/PatchHound.Core/Entities/AssetSecurityProfile.cs
+src/PatchHound.Core/Entities/AssetTag.cs
+src/PatchHound.Core/Entities/StagedAsset.cs
+src/PatchHound.Core/Entities/StagedDeviceSoftwareInstallation.cs
+src/PatchHound.Core/Entities/DeviceSoftwareInstallation.cs
+src/PatchHound.Core/Entities/DeviceSoftwareInstallationEpisode.cs
+src/PatchHound.Core/Entities/NormalizedSoftware.cs
+src/PatchHound.Core/Entities/NormalizedSoftwareAlias.cs
+src/PatchHound.Core/Entities/NormalizedSoftwareInstallation.cs
+src/PatchHound.Core/Entities/NormalizedSoftwareVulnerabilityProjection.cs
+src/PatchHound.Core/Entities/SoftwareCpeBinding.cs
+src/PatchHound.Core/Entities/TenantSoftware.cs
+src/PatchHound.Core/Entities/TenantSoftwareRiskScore.cs
+src/PatchHound.Core/Enums/AssetType.cs
+```
+
+Plus every corresponding file under `src/PatchHound.Infrastructure/Data/Configurations/`.
+
+- [ ] **Step 1: Delete the entity files**
+
+```bash
+git rm src/PatchHound.Core/Entities/Asset.cs \
+       src/PatchHound.Core/Entities/AssetBusinessLabel.cs \
+       src/PatchHound.Core/Entities/AssetRiskScore.cs \
+       src/PatchHound.Core/Entities/AssetRule.cs \
+       src/PatchHound.Core/Entities/AssetSecurityProfile.cs \
+       src/PatchHound.Core/Entities/AssetTag.cs \
+       src/PatchHound.Core/Entities/StagedAsset.cs \
+       src/PatchHound.Core/Entities/StagedDeviceSoftwareInstallation.cs \
+       src/PatchHound.Core/Entities/DeviceSoftwareInstallation.cs \
+       src/PatchHound.Core/Entities/DeviceSoftwareInstallationEpisode.cs \
+       src/PatchHound.Core/Entities/NormalizedSoftware.cs \
+       src/PatchHound.Core/Entities/NormalizedSoftwareAlias.cs \
+       src/PatchHound.Core/Entities/NormalizedSoftwareInstallation.cs \
+       src/PatchHound.Core/Entities/NormalizedSoftwareVulnerabilityProjection.cs \
+       src/PatchHound.Core/Entities/SoftwareCpeBinding.cs \
+       src/PatchHound.Core/Entities/TenantSoftware.cs \
+       src/PatchHound.Core/Entities/TenantSoftwareRiskScore.cs \
+       src/PatchHound.Core/Enums/AssetType.cs
+```
+
+- [ ] **Step 2: Delete their configurations**
+
+```bash
+git rm src/PatchHound.Infrastructure/Data/Configurations/Asset*.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/StagedAsset*.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/StagedDeviceSoftwareInstallationConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/DeviceSoftwareInstallation*.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/NormalizedSoftware*.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/SoftwareCpeBindingConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/TenantSoftware*.cs
+```
+
+- [ ] **Step 3: Remove DbSets from `PatchHoundDbContext`**
+
+Open `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs` and delete every DbSet for a deleted type. The current file has the legacy sets at roughly lines 46–106 (per preflight read). Remove:
+
+```csharp
+public DbSet<Asset> Assets
+public DbSet<AssetBusinessLabel> AssetBusinessLabels
+public DbSet<AssetSecurityProfile> AssetSecurityProfiles
+public DbSet<SoftwareCpeBinding> SoftwareCpeBindings
+public DbSet<NormalizedSoftware> NormalizedSoftware
+public DbSet<TenantSoftware> TenantSoftware
+public DbSet<NormalizedSoftwareAlias> NormalizedSoftwareAliases
+public DbSet<NormalizedSoftwareInstallation> NormalizedSoftwareInstallations
+public DbSet<NormalizedSoftwareVulnerabilityProjection> NormalizedSoftwareVulnerabilityProjections
+public DbSet<DeviceSoftwareInstallation> DeviceSoftwareInstallations
+public DbSet<DeviceSoftwareInstallationEpisode> DeviceSoftwareInstallationEpisodes
+public DbSet<StagedAsset> StagedAssets
+public DbSet<StagedDeviceSoftwareInstallation> StagedDeviceSoftwareInstallations
+public DbSet<AssetTag> AssetTags
+public DbSet<AssetRule> AssetRules
+public DbSet<AssetRiskScore> AssetRiskScores
+public DbSet<TenantSoftwareRiskScore> TenantSoftwareRiskScores
+```
+
+- [ ] **Step 4: Remove legacy tenant filters from `OnModelCreating`**
+
+Delete the `HasQueryFilter` registrations for `Asset`, `AssetBusinessLabel`, `AssetSecurityProfile`, `TenantSoftware`, `NormalizedSoftwareInstallation`, `NormalizedSoftwareVulnerabilityProjection`, `DeviceSoftwareInstallation`, `DeviceSoftwareInstallationEpisode`, `StagedAsset`, `StagedDeviceSoftwareInstallation`, `AssetTag`, `AssetRule`, `AssetRiskScore`, `TenantSoftwareRiskScore`. (Referenced lines 167–348 of the current file.)
+
+- [ ] **Step 5: Build**
+
+```bash
+dotnet build
+```
+
+Expected: clean. Every build error here identifies a stray consumer that was missed in earlier tasks. Fix those by:
+1. If the caller still needs the logic, point it at the canonical replacement.
+2. If the caller was legacy-only (e.g. a projection used only by a deleted dual-read path), delete it too.
+
+Do **not** re-introduce compatibility shims.
+
+- [ ] **Step 6: Run full tests**
+
+```bash
+dotnet test
+cd frontend && npm run typecheck && npm test && cd ..
+```
+
+Expected: everything green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+git commit -m "chore(canonical): delete legacy inventory and software entities"
+```
+
+---
+
+## Task 17: Grep sweep — no lingering legacy references
+
+Before declaring Phase 1 done, verify no deleted types, routes, or service names are referenced anywhere in the workspace.
+
+- [ ] **Step 1: Run the legacy grep**
+
+```bash
+rg --type cs '\b(Asset|AssetType|AssetBusinessLabel|AssetRiskScore|AssetRule|AssetSecurityProfile|AssetTag|StagedAsset|NormalizedSoftware|TenantSoftware|TenantSoftwareRiskScore|SoftwareCpeBinding|DeviceSoftwareInstallation|StagedDeviceSoftwareInstallation|StagedAuthenticatedScanSoftware|AssetScanProfileAssignment)\b' src tests
+```
+
+Expected: zero matches. Exceptions:
+- strings inside migration files — ignored (Phase 6 deletes these)
+- anything under `docs/` — ignored
+- anything inside this plan file — ignored
+
+- [ ] **Step 2: Run the frontend legacy grep**
+
+```bash
+rg 'AssetDetailPane|AssetAdvancedToolsPanel|AssetDto|/api/assets|/assets|assets\\.schemas|assetId|assetName' frontend/src
+```
+
+Expected: zero matches except legitimate uses of the English word "assets" in copy that should stay (e.g. "Welcome back to your asset inventory" marketing text — none is expected in this codebase, but double-check).
+
+- [ ] **Step 3: Verify no new `IgnoreQueryFilters()` in request-scoped code**
+
+```bash
+rg 'IgnoreQueryFilters' src/PatchHound.Api src/PatchHound.Infrastructure -n
+```
+
+Expected: matches only inside:
+- `src/PatchHound.Infrastructure/Services/Inventory/DeviceResolver.cs` (system-context ingestion — documented)
+- `src/PatchHound.Infrastructure/Services/Inventory/StagedDeviceMergeService.cs` (system-context merge — documented)
+- `src/PatchHound.Infrastructure/Services/IngestionService.cs` (system-context — existing pattern)
+- any other ingestion-hosted-service paths previously marked as system context
+
+No controllers or request-scoped services should have `IgnoreQueryFilters` calls. Any match outside the allow-list is a spec §4.10 Rule 5 violation — remove it or justify it in the PR description.
+
+- [ ] **Step 4: Commit an empty marker if anything was fixed**
+
+If the sweep surfaced cleanup work, commit it:
+
+```bash
+git commit -m "chore(canonical): final sweep of legacy inventory references"
+```
+
+Otherwise no commit needed.
+
+---
+
+## Task 18: `TenantIsolationEndToEndTests` — Phase 1 assertions
+
+**Files:**
+- Create: `tests/PatchHound.Tests/Api/TenantIsolationEndToEndTests.cs`
+
+Spec §7 says every phase extends this test with its new routes. Phase 1 introduces it.
+
+- [ ] **Step 1: Write the test scaffolding**
+
+```csharp
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+using Xunit;
+
+namespace PatchHound.Tests.Api;
+
+public class TenantIsolationEndToEndTests : IClassFixture<PatchHoundWebAppFactory>
+{
+    private readonly PatchHoundWebAppFactory _factory;
+
+    public TenantIsolationEndToEndTests(PatchHoundWebAppFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Devices_endpoint_scopes_to_authenticated_tenant_only()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+        // system-context seed of two tenants with disjoint devices
+        await _factory.EnterSystemContextAsync(async () =>
+        {
+            var source = await db.SourceSystems.FirstAsync();
+            var tenantA = Guid.NewGuid();
+            var tenantB = Guid.NewGuid();
+            db.Devices.Add(Device.Create(tenantA, source.Id, "A-dev-1", "tenant-a-host", Criticality.Low));
+            db.Devices.Add(Device.Create(tenantB, source.Id, "B-dev-1", "tenant-b-host", Criticality.Low));
+            await db.SaveChangesAsync();
+
+            _factory.StoreTenants(tenantA, tenantB);
+        });
+
+        var (a, b) = _factory.GetStoredTenants();
+        var clientA = _factory.CreateAuthenticatedClientFor(a);
+        var listA = await clientA.GetFromJsonAsync<PagedDevices>("/api/devices");
+        Assert.NotNull(listA);
+        Assert.Single(listA!.Items);
+        Assert.Equal("tenant-a-host", listA.Items[0].Name);
+    }
+
+    private record PagedDevices(List<DeviceListItem> Items, int Total);
+    private record DeviceListItem(Guid Id, string Name);
+}
+```
+
+Note: if `PatchHoundWebAppFactory` doesn't already exist as a test fixture, create it at `tests/PatchHound.Tests/Api/PatchHoundWebAppFactory.cs` wrapping `WebApplicationFactory<Program>` and providing `EnterSystemContextAsync`, `StoreTenants`, `GetStoredTenants`, `CreateAuthenticatedClientFor(tenantId)`. The authenticated client should inject the ambient test `ITenantContext` with `AccessibleTenantIds = [tenantId]`. Look at existing API tests under `tests/PatchHound.Tests/Api/` for the established pattern.
+
+- [ ] **Step 2: Extend the test with device-rule, device-tag, device-business-label, and installed-software assertions**
+
+Add one test per new Phase 1 route:
+
+```csharp
+[Fact] public Task Device_rules_endpoint_scopes_to_tenant() => ...;
+[Fact] public Task Device_tags_endpoint_scopes_to_tenant() => ...;
+[Fact] public Task Device_business_labels_endpoint_scopes_to_tenant() => ...;
+[Fact] public Task Installed_software_endpoint_scopes_to_tenant() => ...;
+[Fact] public Task Security_profiles_endpoint_scopes_to_tenant() => ...;
+[Fact] public Task Software_products_endpoint_returns_global_data_only_with_no_tenant_fields_leaking() => ...;
+```
+
+Each test follows the same pattern: seed rows for tenants A and B, authenticate as A, call the route, assert only A-owned rows come back (or, for `/api/software-products`, that the returned rows don't include any tenant-scoped fields — only global product identity).
+
+- [ ] **Step 3: Run**
+
+```bash
+dotnet test --filter "FullyQualifiedName~TenantIsolationEndToEndTests"
+```
+
+Expected: all green. If any test fails, the corresponding controller is missing a filter or joining across tenants — fix the controller, not the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/PatchHound.Tests/Api/TenantIsolationEndToEndTests.cs \
+        tests/PatchHound.Tests/Api/PatchHoundWebAppFactory.cs
+git commit -m "test(canonical): tenant isolation end-to-end test — Phase 1"
+```
+
+---
+
+## Task 19: Final build + suite + PR description
+
+- [ ] **Step 1: Clean build**
+
+```bash
+dotnet clean
+dotnet build
+```
+
+Expected: 0 warnings, 0 errors.
+
+- [ ] **Step 2: Full backend test run**
+
+```bash
+dotnet test
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Full frontend check**
+
+```bash
+cd frontend
+npm run typecheck
+npm test
+cd ..
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Write the PR description**
+
+Create/update the phase PR description with these required sections from spec §6:
+
+1. **Deleted surface area** — list every entity, configuration, service, controller, route, and DTO removed in Phase 1 (copy from §4.9 + the Task 16 deletion list).
+
+2. **Tenant scope audit table** — for each new entity introduced, list:
+   | Entity | Direct `TenantId` | EF global filter | Justification if global |
+   | --- | --- | --- | --- |
+   | `SourceSystem` | no | no | Global reference data; public CVE catalog. |
+   | `Device` | yes | yes | Tenant-scoped inventory fact. |
+   | `SoftwareProduct` | no | no | Global product identity; supports cross-tenant alias sharing. |
+   | `SoftwareAlias` | no | no | Global `(SourceSystemId, ExternalId) → SoftwareProductId` mapping. |
+   | `InstalledSoftware` | yes | yes | Tenant-scoped install fact. |
+   | `TenantSoftwareProductInsight` | yes | yes | Tenant-scoped description/evidence for a global product. |
+   | `DeviceBusinessLabel` | yes | yes | Tenant-scoped device label link. |
+   | `DeviceTag` | yes | yes | Tenant-scoped. |
+   | `DeviceRule` | yes | yes | Tenant-scoped rule. |
+   | `DeviceRiskScore` | yes | yes | Tenant-scoped. |
+   | `SecurityProfile` | yes | yes | Tenant policy. |
+
+3. **Tenant isolation test output** — paste the passing output of `dotnet test --filter "FullyQualifiedName~TenantIsolationEndToEndTests" -v normal`, showing each of the six Phase 1 route assertions passing.
+
+4. **`IgnoreQueryFilters()` audit** — list every call site and justify each (all three should be in ingestion/system-context services).
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin data-model-canonical-cleanup
+gh pr create --title "feat(canonical): phase 1 — canonical inventory + delete legacy" \
+  --body-file /tmp/phase-1-pr-body.md
+```
+
+(Write the body file from the checklist above.)
+
+- [ ] **Step 6: Done marker**
+
+When the PR is open and green in CI, Phase 1 is complete. Proceed to Phase 2's plan.
+
+---
+
+## Exit Criteria (copied from spec §5.1 for reference)
+
+- `Asset*`, `TenantSoftware*`, `NormalizedSoftware*`, `SoftwareCpeBinding`, `DeviceSoftwareInstallation*` gone from the workspace.
+- Ingestion writes only canonical.
+- No `tenantSoftwareId` or `softwareAssetId` references anywhere.
+- Frontend `/devices` works.
+- Tenant isolation audit in PR description lists the 11 new entities with their scope.
+- Tenant isolation end-to-end test passes (six Phase 1 routes).
+- `dotnet test` and `npm test` green.

--- a/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-2.md
+++ b/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-2.md
@@ -1,0 +1,2299 @@
+# Data Model Canonical Cleanup — Phase 2: Canonical Vulnerability Knowledge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the legacy `VulnerabilityDefinition*` / `TenantVulnerability` / `VulnerabilityThreatAssessment` chain with canonical global `Vulnerability`, `VulnerabilityReference`, `VulnerabilityApplicability`, and `ThreatAssessment` entities, rewrite vulnerability ingestion and the read controller, and delete the entire legacy vulnerability-knowledge + exposure-asset chain.
+
+**Architecture:** All four canonical entities are **global** (no `TenantId`, no EF query filter). Vulnerability ingestion (`DefenderVulnerabilitySource`, `NvdVulnerabilityEnrichmentRunner`, `DefenderVulnerabilityEnrichmentRunner`) resolves vulnerabilities via a new `VulnerabilityResolver` service that upserts by `(Source, ExternalId)` and writes `Vulnerability` + `VulnerabilityReference` + `VulnerabilityApplicability` rows. Threat assessment writes go through a rewritten `ThreatAssessmentService` that upserts `ThreatAssessment` by `VulnerabilityId`. All global writes run under `IsSystemContext = true`. Vulnerability list/detail endpoints return global canonical data with **empty `AffectedDevices`/`ActiveExposures` sections** (a clearly-marked state to be populated in Phase 3).
+
+**Tech Stack:** .NET 10, EF Core 10, xUnit, PostgreSQL, React, TanStack Router, Vitest.
+
+**Scope extension (vs spec §5.2):** The spec lists `VulnerabilityAsset`, `VulnerabilityAssetEpisode`, `VulnerabilityAssetAssessment`, `VulnerabilityEpisodeRiskAssessment`, and `SoftwareVulnerabilityMatch` under Phase 3 deletions. Those rows FK into `TenantVulnerabilityId` / `VulnerabilityDefinitionId`, so deleting `TenantVulnerability` in Phase 2 forces their removal in the same phase. Phase 3 then introduces `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment` from a clean slate — it does not need to delete anything. This is documented explicitly in the Phase 2 PR description (§Task 17).
+
+---
+
+## Preflight
+
+- [ ] **Step P1: Verify Phase 1 has merged to `main`**
+
+Run: `git log --oneline main -20`
+Expected: see a merge commit for Phase 1 ("data-model-canonical-cleanup phase 1: canonical inventory"). Phase 2 branches from that `main`. If Phase 1 is not merged, stop and escalate.
+
+- [ ] **Step P2: Create Phase 2 branch from `main`**
+
+Run:
+```bash
+git checkout main
+git pull origin main
+git checkout -b data-model-canonical-cleanup-phase-2
+```
+Expected: `Switched to a new branch 'data-model-canonical-cleanup-phase-2'`.
+
+- [ ] **Step P3: Drop local dev database**
+
+Run:
+```bash
+PGPASSWORD=patchhound psql -h localhost -U patchhound -d postgres -c "DROP DATABASE IF EXISTS patchhound;"
+PGPASSWORD=patchhound psql -h localhost -U patchhound -d postgres -c "CREATE DATABASE patchhound;"
+```
+Expected: `DROP DATABASE` + `CREATE DATABASE`. (Same rationale as Phase 1: no migrations until Phase 6; test runs use an in-memory or per-test-run provider.)
+
+- [ ] **Step P4: Baseline build + test**
+
+Run: `dotnet build && dotnet test`
+Expected: clean.
+
+Run: `cd web && npm run typecheck && npm test -- --run && cd ..`
+Expected: clean.
+
+---
+
+## Task 1: Add `Vulnerability` global entity + configuration
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/Vulnerability.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs` (add `DbSet<Vulnerability>`, do **not** add a query filter)
+- Test: `tests/PatchHound.Core.Tests/Entities/VulnerabilityTests.cs`
+
+- [x] **Step 1: Write the failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class VulnerabilityTests
+{
+    [Fact]
+    public void Create_sets_identity_and_defaults()
+    {
+        var v = Vulnerability.Create(
+            source: "microsoft-defender",
+            externalId: "CVE-2026-12345",
+            title: "Sample CVE",
+            description: "Sample description",
+            vendorSeverity: Severity.High,
+            cvssScore: 7.8m,
+            cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            publishedDate: new DateTimeOffset(2026, 1, 5, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.NotEqual(Guid.Empty, v.Id);
+        Assert.Equal("CVE-2026-12345", v.ExternalId);
+        Assert.Equal("microsoft-defender", v.Source);
+        Assert.Equal(Severity.High, v.VendorSeverity);
+        Assert.Equal(7.8m, v.CvssScore);
+        Assert.NotEqual(default, v.CreatedAt);
+        Assert.Equal(v.CreatedAt, v.UpdatedAt);
+    }
+
+    [Fact]
+    public void Update_mutates_mutable_fields_and_bumps_UpdatedAt()
+    {
+        var v = Vulnerability.Create("nvd", "CVE-2026-99999", "old", "old", Severity.Low, 1.0m, "vec", DateTimeOffset.UtcNow);
+        var original = v.UpdatedAt;
+
+        Thread.Sleep(5);
+        v.Update(
+            title: "new",
+            description: "new",
+            vendorSeverity: Severity.Critical,
+            cvssScore: 9.8m,
+            cvssVector: "new-vector",
+            publishedDate: DateTimeOffset.UtcNow);
+
+        Assert.Equal("new", v.Title);
+        Assert.Equal(Severity.Critical, v.VendorSeverity);
+        Assert.Equal(9.8m, v.CvssScore);
+        Assert.True(v.UpdatedAt > original);
+    }
+}
+```
+
+Run: `dotnet test tests/PatchHound.Core.Tests/PatchHound.Core.Tests.csproj --filter "FullyQualifiedName~VulnerabilityTests" -v minimal`
+Expected: FAIL (`Vulnerability` type does not exist).
+
+- [x] **Step 2: Write the entity**
+
+Create `src/PatchHound.Core/Entities/Vulnerability.cs`:
+
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class Vulnerability
+{
+    public Guid Id { get; private set; }
+    public string Source { get; private set; } = null!;
+    public string ExternalId { get; private set; } = null!;
+    public string Title { get; private set; } = null!;
+    public string Description { get; private set; } = null!;
+    public Severity VendorSeverity { get; private set; }
+    public decimal? CvssScore { get; private set; }
+    public string? CvssVector { get; private set; }
+    public DateTimeOffset? PublishedDate { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private Vulnerability() { }
+
+    public static Vulnerability Create(
+        string source,
+        string externalId,
+        string title,
+        string description,
+        Severity vendorSeverity,
+        decimal? cvssScore,
+        string? cvssVector,
+        DateTimeOffset? publishedDate)
+    {
+        if (string.IsNullOrWhiteSpace(source)) throw new ArgumentException("source required", nameof(source));
+        if (string.IsNullOrWhiteSpace(externalId)) throw new ArgumentException("externalId required", nameof(externalId));
+        var now = DateTimeOffset.UtcNow;
+        return new Vulnerability
+        {
+            Id = Guid.NewGuid(),
+            Source = source.Trim(),
+            ExternalId = externalId.Trim(),
+            Title = title ?? string.Empty,
+            Description = description ?? string.Empty,
+            VendorSeverity = vendorSeverity,
+            CvssScore = cvssScore,
+            CvssVector = cvssVector,
+            PublishedDate = publishedDate,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Update(
+        string title,
+        string description,
+        Severity vendorSeverity,
+        decimal? cvssScore,
+        string? cvssVector,
+        DateTimeOffset? publishedDate)
+    {
+        Title = title ?? string.Empty;
+        Description = description ?? string.Empty;
+        VendorSeverity = vendorSeverity;
+        CvssScore = cvssScore;
+        CvssVector = cvssVector;
+        PublishedDate = publishedDate;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [x] **Step 3: Run tests — expect pass**
+
+Run: `dotnet test tests/PatchHound.Core.Tests/PatchHound.Core.Tests.csproj --filter "FullyQualifiedName~VulnerabilityTests" -v minimal`
+Expected: PASS.
+
+- [x] **Step 4: Add EF configuration**
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class VulnerabilityConfiguration : IEntityTypeConfiguration<Vulnerability>
+{
+    public void Configure(EntityTypeBuilder<Vulnerability> builder)
+    {
+        builder.HasKey(v => v.Id);
+        builder.Property(v => v.Source).IsRequired().HasMaxLength(64);
+        builder.Property(v => v.ExternalId).IsRequired().HasMaxLength(128);
+        builder.Property(v => v.Title).IsRequired().HasMaxLength(512);
+        builder.Property(v => v.Description).IsRequired();
+        builder.Property(v => v.VendorSeverity).HasConversion<string>().HasMaxLength(32);
+        builder.Property(v => v.CvssScore).HasColumnType("numeric(4,2)");
+        builder.Property(v => v.CvssVector).HasMaxLength(256);
+
+        builder.HasIndex(v => new { v.Source, v.ExternalId }).IsUnique();
+        builder.HasIndex(v => v.ExternalId);
+    }
+}
+```
+
+- [x] **Step 5: Register `DbSet<Vulnerability>` in `PatchHoundDbContext`**
+
+In `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`, add in the canonical vulnerability region (above the legacy `VulnerabilityDefinitions` DbSet for now; the legacy set is removed in Task 16):
+
+```csharp
+public DbSet<Vulnerability> Vulnerabilities => Set<Vulnerability>();
+```
+
+Do **not** add `modelBuilder.Entity<Vulnerability>().HasQueryFilter(...)` — `Vulnerability` is global per spec §4.10 Rule 3.
+
+Run: `dotnet build`
+Expected: 0 errors, 0 warnings.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/Vulnerability.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/VulnerabilityTests.cs
+git commit -m "feat(phase-2): add canonical Vulnerability entity (global)"
+```
+
+---
+
+## Task 2: Add `VulnerabilityReference` global entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/VulnerabilityReference.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityReferenceConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Core.Tests/Entities/VulnerabilityReferenceTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class VulnerabilityReferenceTests
+{
+    [Fact]
+    public void Create_trims_and_normalizes_tags()
+    {
+        var vulnId = Guid.NewGuid();
+        var r = VulnerabilityReference.Create(
+            vulnId, "https://example.com/advisory ", "nvd", new[] { "advisory", " patch " });
+
+        Assert.Equal(vulnId, r.VulnerabilityId);
+        Assert.Equal("https://example.com/advisory", r.Url);
+        Assert.Equal("nvd", r.Source);
+        Assert.Contains("advisory", r.GetTags());
+        Assert.Contains("patch", r.GetTags());
+    }
+}
+```
+
+Run: `dotnet test --filter "FullyQualifiedName~VulnerabilityReferenceTests"` — FAIL.
+
+- [ ] **Step 2: Create entity**
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class VulnerabilityReference
+{
+    public Guid Id { get; private set; }
+    public Guid VulnerabilityId { get; private set; }
+    public string Url { get; private set; } = null!;
+    public string Source { get; private set; } = null!;
+    public string Tags { get; private set; } = string.Empty;
+
+    public Vulnerability Vulnerability { get; private set; } = null!;
+
+    private VulnerabilityReference() { }
+
+    public static VulnerabilityReference Create(
+        Guid vulnerabilityId,
+        string url,
+        string source,
+        IReadOnlyList<string> tags)
+    {
+        if (vulnerabilityId == Guid.Empty) throw new ArgumentException(nameof(vulnerabilityId));
+        if (string.IsNullOrWhiteSpace(url)) throw new ArgumentException(nameof(url));
+        return new VulnerabilityReference
+        {
+            Id = Guid.NewGuid(),
+            VulnerabilityId = vulnerabilityId,
+            Url = url.Trim(),
+            Source = string.IsNullOrWhiteSpace(source) ? "Unknown" : source.Trim(),
+            Tags = SerializeTags(tags),
+        };
+    }
+
+    public IReadOnlyList<string> GetTags() =>
+        Tags.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string SerializeTags(IReadOnlyList<string> tags) =>
+        string.Join("|",
+            tags.Where(t => !string.IsNullOrWhiteSpace(t))
+                .Select(t => t.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase));
+}
+```
+
+- [ ] **Step 3: Test passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~VulnerabilityReferenceTests"` — PASS.
+
+- [ ] **Step 4: EF configuration**
+
+`src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityReferenceConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class VulnerabilityReferenceConfiguration : IEntityTypeConfiguration<VulnerabilityReference>
+{
+    public void Configure(EntityTypeBuilder<VulnerabilityReference> builder)
+    {
+        builder.HasKey(r => r.Id);
+        builder.Property(r => r.Url).IsRequired().HasMaxLength(1024);
+        builder.Property(r => r.Source).IsRequired().HasMaxLength(64);
+        builder.Property(r => r.Tags).HasMaxLength(512);
+
+        builder.HasOne(r => r.Vulnerability)
+            .WithMany()
+            .HasForeignKey(r => r.VulnerabilityId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(r => new { r.VulnerabilityId, r.Url }).IsUnique();
+    }
+}
+```
+
+Add `public DbSet<VulnerabilityReference> VulnerabilityReferences => Set<VulnerabilityReference>();` to `PatchHoundDbContext` (no query filter).
+
+Run: `dotnet build` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/VulnerabilityReference.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityReferenceConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/VulnerabilityReferenceTests.cs
+git commit -m "feat(phase-2): add canonical VulnerabilityReference entity (global)"
+```
+
+---
+
+## Task 3: Add `VulnerabilityApplicability` global entity
+
+Applicability represents "this vulnerability affects this product", keyed by `SoftwareProductId` (introduced in Phase 1) or by CPE criteria. Version ranges follow CPE semantics (`VersionStartIncluding`, `VersionStartExcluding`, `VersionEndIncluding`, `VersionEndExcluding`).
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/VulnerabilityApplicability.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityApplicabilityConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Core.Tests/Entities/VulnerabilityApplicabilityTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class VulnerabilityApplicabilityTests
+{
+    [Fact]
+    public void Create_keyed_on_software_product_is_valid()
+    {
+        var vulnId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+
+        var a = VulnerabilityApplicability.Create(
+            vulnerabilityId: vulnId,
+            softwareProductId: productId,
+            cpeCriteria: null,
+            vulnerable: true,
+            versionStartIncluding: "1.0.0",
+            versionStartExcluding: null,
+            versionEndIncluding: null,
+            versionEndExcluding: "2.0.0");
+
+        Assert.Equal(vulnId, a.VulnerabilityId);
+        Assert.Equal(productId, a.SoftwareProductId);
+        Assert.Null(a.CpeCriteria);
+        Assert.True(a.Vulnerable);
+        Assert.Equal("1.0.0", a.VersionStartIncluding);
+        Assert.Equal("2.0.0", a.VersionEndExcluding);
+    }
+
+    [Fact]
+    public void Create_keyed_on_cpe_criteria_is_valid()
+    {
+        var vulnId = Guid.NewGuid();
+        var a = VulnerabilityApplicability.Create(
+            vulnerabilityId: vulnId,
+            softwareProductId: null,
+            cpeCriteria: "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*",
+            vulnerable: true,
+            versionStartIncluding: null,
+            versionStartExcluding: null,
+            versionEndIncluding: "3.0.0",
+            versionEndExcluding: null);
+
+        Assert.Null(a.SoftwareProductId);
+        Assert.Equal("cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*", a.CpeCriteria);
+    }
+
+    [Fact]
+    public void Create_requires_product_or_cpe()
+    {
+        Assert.Throws<ArgumentException>(() => VulnerabilityApplicability.Create(
+            Guid.NewGuid(), null, null, true, null, null, null, null));
+    }
+}
+```
+
+Run: FAIL.
+
+- [ ] **Step 2: Create entity**
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class VulnerabilityApplicability
+{
+    public Guid Id { get; private set; }
+    public Guid VulnerabilityId { get; private set; }
+    public Guid? SoftwareProductId { get; private set; }
+    public string? CpeCriteria { get; private set; }
+    public bool Vulnerable { get; private set; }
+    public string? VersionStartIncluding { get; private set; }
+    public string? VersionStartExcluding { get; private set; }
+    public string? VersionEndIncluding { get; private set; }
+    public string? VersionEndExcluding { get; private set; }
+
+    public Vulnerability Vulnerability { get; private set; } = null!;
+    public SoftwareProduct? SoftwareProduct { get; private set; }
+
+    private VulnerabilityApplicability() { }
+
+    public static VulnerabilityApplicability Create(
+        Guid vulnerabilityId,
+        Guid? softwareProductId,
+        string? cpeCriteria,
+        bool vulnerable,
+        string? versionStartIncluding,
+        string? versionStartExcluding,
+        string? versionEndIncluding,
+        string? versionEndExcluding)
+    {
+        if (vulnerabilityId == Guid.Empty) throw new ArgumentException(nameof(vulnerabilityId));
+        if (softwareProductId is null && string.IsNullOrWhiteSpace(cpeCriteria))
+            throw new ArgumentException("Either softwareProductId or cpeCriteria must be provided");
+
+        return new VulnerabilityApplicability
+        {
+            Id = Guid.NewGuid(),
+            VulnerabilityId = vulnerabilityId,
+            SoftwareProductId = softwareProductId,
+            CpeCriteria = string.IsNullOrWhiteSpace(cpeCriteria) ? null : cpeCriteria.Trim(),
+            Vulnerable = vulnerable,
+            VersionStartIncluding = versionStartIncluding,
+            VersionStartExcluding = versionStartExcluding,
+            VersionEndIncluding = versionEndIncluding,
+            VersionEndExcluding = versionEndExcluding,
+        };
+    }
+}
+```
+
+- [ ] **Step 3: Test passes**
+
+- [ ] **Step 4: EF configuration**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class VulnerabilityApplicabilityConfiguration : IEntityTypeConfiguration<VulnerabilityApplicability>
+{
+    public void Configure(EntityTypeBuilder<VulnerabilityApplicability> builder)
+    {
+        builder.HasKey(a => a.Id);
+        builder.Property(a => a.CpeCriteria).HasMaxLength(512);
+        builder.Property(a => a.VersionStartIncluding).HasMaxLength(128);
+        builder.Property(a => a.VersionStartExcluding).HasMaxLength(128);
+        builder.Property(a => a.VersionEndIncluding).HasMaxLength(128);
+        builder.Property(a => a.VersionEndExcluding).HasMaxLength(128);
+
+        builder.HasOne(a => a.Vulnerability)
+            .WithMany()
+            .HasForeignKey(a => a.VulnerabilityId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(a => a.SoftwareProduct)
+            .WithMany()
+            .HasForeignKey(a => a.SoftwareProductId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(a => new { a.VulnerabilityId, a.SoftwareProductId });
+        builder.HasIndex(a => new { a.VulnerabilityId, a.CpeCriteria });
+    }
+}
+```
+
+Add `public DbSet<VulnerabilityApplicability> VulnerabilityApplicabilities => Set<VulnerabilityApplicability>();` to `PatchHoundDbContext` (no query filter).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/VulnerabilityApplicability.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityApplicabilityConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/VulnerabilityApplicabilityTests.cs
+git commit -m "feat(phase-2): add canonical VulnerabilityApplicability entity (global)"
+```
+
+---
+
+## Task 4: Add `ThreatAssessment` global entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/ThreatAssessment.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/ThreatAssessmentConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Core.Tests/Entities/ThreatAssessmentTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class ThreatAssessmentTests
+{
+    [Fact]
+    public void Create_sets_all_factors_and_timestamps()
+    {
+        var vulnId = Guid.NewGuid();
+        var a = ThreatAssessment.Create(
+            vulnerabilityId: vulnId,
+            threatScore: 8.1m,
+            technicalScore: 7.5m,
+            exploitLikelihoodScore: 0.7m,
+            threatActivityScore: 6.2m,
+            epssScore: 0.33m,
+            knownExploited: true,
+            publicExploit: true,
+            activeAlert: false,
+            hasRansomwareAssociation: true,
+            hasMalwareAssociation: false,
+            factorsJson: "[]",
+            calculationVersion: "v2");
+
+        Assert.Equal(vulnId, a.VulnerabilityId);
+        Assert.Equal(8.1m, a.ThreatScore);
+        Assert.True(a.KnownExploited);
+        Assert.False(a.ActiveAlert);
+        Assert.Equal("v2", a.CalculationVersion);
+        Assert.NotEqual(default, a.CalculatedAt);
+    }
+
+    [Fact]
+    public void Update_refreshes_factors_and_CalculatedAt()
+    {
+        var a = ThreatAssessment.Create(Guid.NewGuid(), 1, 1, 0, 1, null, false, false, false, false, false, "[]", "v1");
+        var original = a.CalculatedAt;
+        Thread.Sleep(5);
+        a.Update(9, 9, 1, 9, 0.99m, true, true, true, true, true, "[\"kev\"]", "v2");
+        Assert.Equal(9, a.ThreatScore);
+        Assert.True(a.CalculatedAt > original);
+    }
+}
+```
+
+- [ ] **Step 2: Create entity** (copy shape from `VulnerabilityThreatAssessment` but FK is `VulnerabilityId`, not `VulnerabilityDefinitionId`)
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class ThreatAssessment
+{
+    public Guid Id { get; private set; }
+    public Guid VulnerabilityId { get; private set; }
+    public decimal ThreatScore { get; private set; }
+    public decimal TechnicalScore { get; private set; }
+    public decimal ExploitLikelihoodScore { get; private set; }
+    public decimal ThreatActivityScore { get; private set; }
+    public decimal? EpssScore { get; private set; }
+    public bool KnownExploited { get; private set; }
+    public bool PublicExploit { get; private set; }
+    public bool ActiveAlert { get; private set; }
+    public bool HasRansomwareAssociation { get; private set; }
+    public bool HasMalwareAssociation { get; private set; }
+    public DateTimeOffset? DefenderLastRefreshedAt { get; private set; }
+    public string FactorsJson { get; private set; } = "[]";
+    public string CalculationVersion { get; private set; } = null!;
+    public DateTimeOffset CalculatedAt { get; private set; }
+
+    public Vulnerability Vulnerability { get; private set; } = null!;
+
+    private ThreatAssessment() { }
+
+    public static ThreatAssessment Create(
+        Guid vulnerabilityId,
+        decimal threatScore,
+        decimal technicalScore,
+        decimal exploitLikelihoodScore,
+        decimal threatActivityScore,
+        decimal? epssScore,
+        bool knownExploited,
+        bool publicExploit,
+        bool activeAlert,
+        bool hasRansomwareAssociation,
+        bool hasMalwareAssociation,
+        string factorsJson,
+        string calculationVersion)
+    {
+        return new ThreatAssessment
+        {
+            Id = Guid.NewGuid(),
+            VulnerabilityId = vulnerabilityId,
+            ThreatScore = threatScore,
+            TechnicalScore = technicalScore,
+            ExploitLikelihoodScore = exploitLikelihoodScore,
+            ThreatActivityScore = threatActivityScore,
+            EpssScore = epssScore,
+            KnownExploited = knownExploited,
+            PublicExploit = publicExploit,
+            ActiveAlert = activeAlert,
+            HasRansomwareAssociation = hasRansomwareAssociation,
+            HasMalwareAssociation = hasMalwareAssociation,
+            FactorsJson = factorsJson,
+            CalculationVersion = calculationVersion,
+            CalculatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    public void Update(
+        decimal threatScore,
+        decimal technicalScore,
+        decimal exploitLikelihoodScore,
+        decimal threatActivityScore,
+        decimal? epssScore,
+        bool knownExploited,
+        bool publicExploit,
+        bool activeAlert,
+        bool hasRansomwareAssociation,
+        bool hasMalwareAssociation,
+        string factorsJson,
+        string calculationVersion)
+    {
+        ThreatScore = threatScore;
+        TechnicalScore = technicalScore;
+        ExploitLikelihoodScore = exploitLikelihoodScore;
+        ThreatActivityScore = threatActivityScore;
+        EpssScore = epssScore;
+        KnownExploited = knownExploited;
+        PublicExploit = publicExploit;
+        ActiveAlert = activeAlert;
+        HasRansomwareAssociation = hasRansomwareAssociation;
+        HasMalwareAssociation = hasMalwareAssociation;
+        FactorsJson = factorsJson;
+        CalculationVersion = calculationVersion;
+        CalculatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void MarkDefenderRefreshed(DateTimeOffset refreshedAt) =>
+        DefenderLastRefreshedAt = refreshedAt;
+}
+```
+
+- [ ] **Step 3: Test passes**
+
+- [ ] **Step 4: EF configuration**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class ThreatAssessmentConfiguration : IEntityTypeConfiguration<ThreatAssessment>
+{
+    public void Configure(EntityTypeBuilder<ThreatAssessment> builder)
+    {
+        builder.HasKey(a => a.Id);
+        builder.Property(a => a.ThreatScore).HasColumnType("numeric(4,2)");
+        builder.Property(a => a.TechnicalScore).HasColumnType("numeric(4,2)");
+        builder.Property(a => a.ExploitLikelihoodScore).HasColumnType("numeric(4,3)");
+        builder.Property(a => a.ThreatActivityScore).HasColumnType("numeric(4,2)");
+        builder.Property(a => a.EpssScore).HasColumnType("numeric(5,4)");
+        builder.Property(a => a.FactorsJson).IsRequired();
+        builder.Property(a => a.CalculationVersion).IsRequired().HasMaxLength(32);
+
+        builder.HasOne(a => a.Vulnerability)
+            .WithMany()
+            .HasForeignKey(a => a.VulnerabilityId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(a => a.VulnerabilityId).IsUnique();
+    }
+}
+```
+
+Add `public DbSet<ThreatAssessment> ThreatAssessments => Set<ThreatAssessment>();` (no query filter).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/ThreatAssessment.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/ThreatAssessmentConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/ThreatAssessmentTests.cs
+git commit -m "feat(phase-2): add canonical ThreatAssessment entity (global)"
+```
+
+---
+
+## Task 5: `VulnerabilityResolver` service
+
+System-context service that upserts a `Vulnerability` by `(Source, ExternalId)`, replaces its references, and replaces its applicabilities. Called by ingestion under `IsSystemContext = true`.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/VulnerabilityResolver.cs`
+- Create: `src/PatchHound.Core/Models/VulnerabilityResolveInput.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/VulnerabilityResolverTests.cs`
+
+- [ ] **Step 1: Define resolve input model**
+
+`src/PatchHound.Core/Models/VulnerabilityResolveInput.cs`:
+
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Models;
+
+public record VulnerabilityResolveInput(
+    string Source,
+    string ExternalId,
+    string Title,
+    string Description,
+    Severity VendorSeverity,
+    decimal? CvssScore,
+    string? CvssVector,
+    DateTimeOffset? PublishedDate,
+    IReadOnlyList<VulnerabilityReferenceInput> References,
+    IReadOnlyList<VulnerabilityApplicabilityInput> Applicabilities);
+
+public record VulnerabilityReferenceInput(string Url, string Source, IReadOnlyList<string> Tags);
+
+public record VulnerabilityApplicabilityInput(
+    Guid? SoftwareProductId,
+    string? CpeCriteria,
+    bool Vulnerable,
+    string? VersionStartIncluding,
+    string? VersionStartExcluding,
+    string? VersionEndIncluding,
+    string? VersionEndExcluding);
+```
+
+- [ ] **Step 2: Write failing test**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.Testing;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class VulnerabilityResolverTests
+{
+    [Fact]
+    public async Task Resolves_new_vulnerability_inserts_references_and_applicabilities()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var resolver = new VulnerabilityResolver(db);
+
+        var input = new VulnerabilityResolveInput(
+            Source: "nvd",
+            ExternalId: "CVE-2026-0001",
+            Title: "Example",
+            Description: "desc",
+            VendorSeverity: Severity.High,
+            CvssScore: 7.5m,
+            CvssVector: "vec",
+            PublishedDate: DateTimeOffset.UtcNow,
+            References: new[] {
+                new VulnerabilityReferenceInput("https://example.com/a", "nvd", new[] { "advisory" })
+            },
+            Applicabilities: new[] {
+                new VulnerabilityApplicabilityInput(null, "cpe:2.3:a:acme:*:*:*:*:*:*:*:*:*", true, null, null, "1.0.0", null)
+            });
+
+        var v = await resolver.ResolveAsync(input, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        Assert.NotEqual(Guid.Empty, v.Id);
+        Assert.Equal("CVE-2026-0001", v.ExternalId);
+        Assert.Single(await db.VulnerabilityReferences.ToListAsync());
+        Assert.Single(await db.VulnerabilityApplicabilities.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Resolves_existing_vulnerability_updates_fields_and_replaces_children()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var resolver = new VulnerabilityResolver(db);
+
+        var first = new VulnerabilityResolveInput(
+            "nvd", "CVE-2026-0002", "old", "old", Severity.Low, 1m, "v1", DateTimeOffset.UtcNow,
+            new[] { new VulnerabilityReferenceInput("https://old", "nvd", Array.Empty<string>()) },
+            new[] { new VulnerabilityApplicabilityInput(null, "old-cpe", true, null, null, null, null) });
+        await resolver.ResolveAsync(first, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var second = new VulnerabilityResolveInput(
+            "nvd", "CVE-2026-0002", "new", "new", Severity.Critical, 9.5m, "v2", DateTimeOffset.UtcNow,
+            new[] { new VulnerabilityReferenceInput("https://new", "nvd", Array.Empty<string>()) },
+            new[] { new VulnerabilityApplicabilityInput(null, "new-cpe", true, null, null, null, null) });
+        var updated = await resolver.ResolveAsync(second, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        Assert.Equal("new", updated.Title);
+        Assert.Equal(Severity.Critical, updated.VendorSeverity);
+        var refs = await db.VulnerabilityReferences.Where(r => r.VulnerabilityId == updated.Id).ToListAsync();
+        Assert.Single(refs);
+        Assert.Equal("https://new", refs[0].Url);
+        var apps = await db.VulnerabilityApplicabilities.Where(a => a.VulnerabilityId == updated.Id).ToListAsync();
+        Assert.Single(apps);
+        Assert.Equal("new-cpe", apps[0].CpeCriteria);
+    }
+}
+```
+
+> **If `TestDbContextFactory` does not exist yet**, add it in `tests/PatchHound.Tests/Infrastructure/Testing/TestDbContextFactory.cs` — see Phase 1 Task 7 for the canonical implementation. `CreateSystemContext()` returns a `PatchHoundDbContext` with `IsSystemContext = true` against an in-memory provider.
+
+Run: `dotnet test --filter "FullyQualifiedName~VulnerabilityResolverTests"` — FAIL.
+
+- [ ] **Step 3: Implement resolver**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class VulnerabilityResolver
+{
+    private readonly PatchHoundDbContext _db;
+
+    public VulnerabilityResolver(PatchHoundDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Vulnerability> ResolveAsync(VulnerabilityResolveInput input, CancellationToken ct)
+    {
+        var existing = await _db.Vulnerabilities
+            .FirstOrDefaultAsync(v => v.Source == input.Source && v.ExternalId == input.ExternalId, ct);
+
+        Vulnerability vuln;
+        if (existing is null)
+        {
+            vuln = Vulnerability.Create(
+                input.Source, input.ExternalId, input.Title, input.Description,
+                input.VendorSeverity, input.CvssScore, input.CvssVector, input.PublishedDate);
+            _db.Vulnerabilities.Add(vuln);
+        }
+        else
+        {
+            existing.Update(input.Title, input.Description, input.VendorSeverity,
+                input.CvssScore, input.CvssVector, input.PublishedDate);
+            vuln = existing;
+        }
+
+        // Replace references (delete + insert)
+        var existingRefs = await _db.VulnerabilityReferences
+            .Where(r => r.VulnerabilityId == vuln.Id).ToListAsync(ct);
+        _db.VulnerabilityReferences.RemoveRange(existingRefs);
+        foreach (var r in input.References
+                     .Where(r => !string.IsNullOrWhiteSpace(r.Url))
+                     .DistinctBy(r => r.Url.Trim(), StringComparer.OrdinalIgnoreCase))
+        {
+            _db.VulnerabilityReferences.Add(
+                VulnerabilityReference.Create(vuln.Id, r.Url, r.Source, r.Tags));
+        }
+
+        // Replace applicabilities
+        var existingApps = await _db.VulnerabilityApplicabilities
+            .Where(a => a.VulnerabilityId == vuln.Id).ToListAsync(ct);
+        _db.VulnerabilityApplicabilities.RemoveRange(existingApps);
+        foreach (var a in input.Applicabilities)
+        {
+            _db.VulnerabilityApplicabilities.Add(
+                VulnerabilityApplicability.Create(
+                    vuln.Id, a.SoftwareProductId, a.CpeCriteria, a.Vulnerable,
+                    a.VersionStartIncluding, a.VersionStartExcluding,
+                    a.VersionEndIncluding, a.VersionEndExcluding));
+        }
+
+        return vuln;
+    }
+}
+```
+
+- [ ] **Step 4: Tests pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~VulnerabilityResolverTests"` — PASS.
+
+- [ ] **Step 5: Register in DI**
+
+In `src/PatchHound.Infrastructure/DependencyInjection.cs`, add:
+
+```csharp
+services.AddScoped<VulnerabilityResolver>();
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Models/VulnerabilityResolveInput.cs \
+        src/PatchHound.Infrastructure/Services/VulnerabilityResolver.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/VulnerabilityResolverTests.cs
+git commit -m "feat(phase-2): add VulnerabilityResolver system-context upsert service"
+```
+
+---
+
+## Task 6: `ThreatAssessmentService` — upsert global threat assessment
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/ThreatAssessmentService.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/ThreatAssessmentServiceTests.cs`
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.Testing;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class ThreatAssessmentServiceTests
+{
+    [Fact]
+    public async Task Upserts_new_assessment_for_vulnerability()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var v = Vulnerability.Create("nvd", "CVE-2026-1000", "t", "d", Severity.High, 7.5m, "v", DateTimeOffset.UtcNow);
+        db.Vulnerabilities.Add(v);
+        await db.SaveChangesAsync();
+
+        var svc = new ThreatAssessmentService(db);
+        var a = await svc.UpsertAsync(
+            v.Id,
+            threatScore: 7.8m, technicalScore: 7.5m, exploitLikelihoodScore: 0.6m, threatActivityScore: 6.0m,
+            epssScore: 0.2m, knownExploited: false, publicExploit: true, activeAlert: false,
+            hasRansomwareAssociation: false, hasMalwareAssociation: false,
+            factorsJson: "[]", calculationVersion: "v1",
+            ct: CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        Assert.Equal(v.Id, a.VulnerabilityId);
+        Assert.Single(await db.ThreatAssessments.ToListAsync());
+    }
+
+    [Fact]
+    public async Task Updates_existing_assessment_in_place()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var v = Vulnerability.Create("nvd", "CVE-2026-2000", "t", "d", Severity.High, 7.5m, "v", DateTimeOffset.UtcNow);
+        db.Vulnerabilities.Add(v);
+        await db.SaveChangesAsync();
+
+        var svc = new ThreatAssessmentService(db);
+        await svc.UpsertAsync(v.Id, 1, 1, 0.1m, 1, null, false, false, false, false, false, "[]", "v1", CancellationToken.None);
+        await db.SaveChangesAsync();
+        await svc.UpsertAsync(v.Id, 9, 9, 0.9m, 9, 0.8m, true, true, true, true, true, "[\"kev\"]", "v2", CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var assessments = await db.ThreatAssessments.ToListAsync();
+        Assert.Single(assessments);
+        Assert.Equal(9, assessments[0].ThreatScore);
+        Assert.Equal("v2", assessments[0].CalculationVersion);
+    }
+}
+```
+
+- [ ] **Step 2: Implement service**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class ThreatAssessmentService
+{
+    private readonly PatchHoundDbContext _db;
+
+    public ThreatAssessmentService(PatchHoundDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<ThreatAssessment> UpsertAsync(
+        Guid vulnerabilityId,
+        decimal threatScore,
+        decimal technicalScore,
+        decimal exploitLikelihoodScore,
+        decimal threatActivityScore,
+        decimal? epssScore,
+        bool knownExploited,
+        bool publicExploit,
+        bool activeAlert,
+        bool hasRansomwareAssociation,
+        bool hasMalwareAssociation,
+        string factorsJson,
+        string calculationVersion,
+        CancellationToken ct)
+    {
+        var existing = await _db.ThreatAssessments
+            .FirstOrDefaultAsync(a => a.VulnerabilityId == vulnerabilityId, ct);
+
+        if (existing is null)
+        {
+            var a = ThreatAssessment.Create(
+                vulnerabilityId, threatScore, technicalScore, exploitLikelihoodScore, threatActivityScore,
+                epssScore, knownExploited, publicExploit, activeAlert,
+                hasRansomwareAssociation, hasMalwareAssociation, factorsJson, calculationVersion);
+            _db.ThreatAssessments.Add(a);
+            return a;
+        }
+
+        existing.Update(
+            threatScore, technicalScore, exploitLikelihoodScore, threatActivityScore,
+            epssScore, knownExploited, publicExploit, activeAlert,
+            hasRansomwareAssociation, hasMalwareAssociation, factorsJson, calculationVersion);
+        return existing;
+    }
+}
+```
+
+- [ ] **Step 3: Tests pass**
+
+- [ ] **Step 4: Register in DI**
+
+Add `services.AddScoped<ThreatAssessmentService>();` to `DependencyInjection.cs`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/ThreatAssessmentService.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/ThreatAssessmentServiceTests.cs
+git commit -m "feat(phase-2): add ThreatAssessmentService upsert"
+```
+
+---
+
+## Task 7: Rewrite `DefenderVulnerabilitySource` to produce canonical `VulnerabilityResolveInput`
+
+Today `DefenderVulnerabilitySource` returns `IngestionResult` wrappers built around legacy `VulnerabilityDefinition` shapes. Rewrite to return a new `CanonicalVulnerabilityBatch` shape containing `VulnerabilityResolveInput` items plus per-vulnerability threat-assessment inputs.
+
+**Files:**
+- Create: `src/PatchHound.Core/Models/CanonicalVulnerabilityBatch.cs`
+- Modify: `src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs` (add canonical method; deprecate legacy method signature)
+- Modify: `src/PatchHound.Infrastructure/VulnerabilitySources/DefenderVulnerabilitySource.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/VulnerabilitySources/DefenderVulnerabilitySourceCanonicalTests.cs`
+
+- [ ] **Step 1: Define canonical batch model**
+
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Models;
+
+public record CanonicalVulnerabilityBatch(
+    IReadOnlyList<VulnerabilityResolveInput> Vulnerabilities,
+    IReadOnlyList<CanonicalThreatAssessmentInput> ThreatAssessments);
+
+public record CanonicalThreatAssessmentInput(
+    string Source,
+    string ExternalId,
+    decimal ThreatScore,
+    decimal TechnicalScore,
+    decimal ExploitLikelihoodScore,
+    decimal ThreatActivityScore,
+    decimal? EpssScore,
+    bool KnownExploited,
+    bool PublicExploit,
+    bool ActiveAlert,
+    bool HasRansomwareAssociation,
+    bool HasMalwareAssociation,
+    string FactorsJson,
+    string CalculationVersion);
+```
+
+- [ ] **Step 2: Extend `IVulnerabilitySource`**
+
+In `src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs`, add:
+
+```csharp
+Task<CanonicalVulnerabilityBatch> FetchCanonicalVulnerabilitiesAsync(Guid tenantId, CancellationToken ct);
+```
+
+and mark the legacy `FetchVulnerabilitiesAsync(...)` with `[Obsolete("Removed in Phase 2. Use FetchCanonicalVulnerabilitiesAsync.", error: true)]`. Every implementer must provide the canonical method.
+
+- [ ] **Step 3: Write failing test**
+
+```csharp
+using Microsoft.Extensions.Logging.Abstractions;
+using PatchHound.Core.Enums;
+using PatchHound.Tests.Infrastructure.Testing;
+using PatchHound.Infrastructure.VulnerabilitySources;
+
+namespace PatchHound.Tests.Infrastructure.VulnerabilitySources;
+
+public class DefenderVulnerabilitySourceCanonicalTests
+{
+    [Fact]
+    public async Task FetchCanonicalVulnerabilitiesAsync_returns_batch_with_resolve_inputs()
+    {
+        var apiClient = FakeDefenderApiClient.WithSingleVulnerability("CVE-2026-0099", Severity.High, 8.5m);
+        var source = new DefenderVulnerabilitySource(apiClient, FakeDefenderConfigProvider.Default(), NullLogger<DefenderVulnerabilitySource>.Instance);
+        var batch = await source.FetchCanonicalVulnerabilitiesAsync(Guid.NewGuid(), CancellationToken.None);
+        Assert.Single(batch.Vulnerabilities);
+        Assert.Equal("CVE-2026-0099", batch.Vulnerabilities[0].ExternalId);
+        Assert.Equal("microsoft-defender", batch.Vulnerabilities[0].Source);
+    }
+}
+```
+
+Implement the `FakeDefenderApiClient` / `FakeDefenderConfigProvider` helpers under `tests/PatchHound.Tests/Infrastructure/Testing/` if not present — simple stubs returning predefined payloads from the existing Defender DTOs.
+
+- [ ] **Step 4: Rewrite `DefenderVulnerabilitySource.FetchCanonicalVulnerabilitiesAsync`**
+
+Preserve all existing Defender payload parsing (CVE ID extraction, severity mapping, version range extraction) but emit `VulnerabilityResolveInput` / `CanonicalThreatAssessmentInput` directly instead of building `VulnerabilityDefinition` entities. Every applicability maps to `VulnerabilityApplicabilityInput` keyed by CPE string (Defender payloads don't carry `SoftwareProductId`; the NVD resolver will fill that in where possible, otherwise resolution happens in Phase 3 via CPE match fallback).
+
+```csharp
+public async Task<CanonicalVulnerabilityBatch> FetchCanonicalVulnerabilitiesAsync(
+    Guid tenantId, CancellationToken ct)
+{
+    _logger.LogInformation(
+        "Fetching canonical vulnerabilities from Microsoft Defender for tenant {TenantId}", tenantId);
+
+    var configuration = await _configurationProvider.GetConfigurationAsync(tenantId, ct);
+    if (configuration is null)
+        return new CanonicalVulnerabilityBatch(Array.Empty<VulnerabilityResolveInput>(), Array.Empty<CanonicalThreatAssessmentInput>());
+
+    DefenderMachineVulnerabilityResponse response;
+    try
+    {
+        response = await _apiClient.GetMachineVulnerabilitiesAsync(configuration, ct);
+    }
+    catch (Exception ex) when (IsRecoverableTimeout(ex, ct))
+    {
+        _logger.LogWarning(ex, "Defender vulnerability fetch timed out for tenant {TenantId}", tenantId);
+        return new CanonicalVulnerabilityBatch(Array.Empty<VulnerabilityResolveInput>(), Array.Empty<CanonicalThreatAssessmentInput>());
+    }
+
+    var vulns = new List<VulnerabilityResolveInput>();
+    var assessments = new List<CanonicalThreatAssessmentInput>();
+
+    foreach (var group in response.Value.Where(HasUsableCveId)
+        .GroupBy(v => v.CveId.Trim(), StringComparer.OrdinalIgnoreCase))
+    {
+        var first = group.First();
+        var severity = MapSeverity(first.Severity);
+        var apps = group
+            .Where(g => !string.IsNullOrWhiteSpace(g.ProductName))
+            .Select(g => new VulnerabilityApplicabilityInput(
+                SoftwareProductId: null,
+                CpeCriteria: BuildCpeCriteria(g),
+                Vulnerable: true,
+                VersionStartIncluding: null,
+                VersionStartExcluding: null,
+                VersionEndIncluding: g.ProductVersion,
+                VersionEndExcluding: null))
+            .ToList();
+
+        vulns.Add(new VulnerabilityResolveInput(
+            Source: SourceKey,
+            ExternalId: group.Key,
+            Title: first.Title ?? group.Key,
+            Description: first.Description ?? string.Empty,
+            VendorSeverity: severity,
+            CvssScore: first.CvssScore,
+            CvssVector: first.CvssVector,
+            PublishedDate: first.PublishedOn,
+            References: Array.Empty<VulnerabilityReferenceInput>(),
+            Applicabilities: apps));
+
+        if (first.EpssScore is not null || first.PublicExploit || first.KnownExploited)
+        {
+            assessments.Add(new CanonicalThreatAssessmentInput(
+                SourceKey, group.Key,
+                ThreatScore: (decimal)(first.CvssScore ?? 0m),
+                TechnicalScore: (decimal)(first.CvssScore ?? 0m),
+                ExploitLikelihoodScore: (decimal)(first.EpssScore ?? 0m),
+                ThreatActivityScore: first.KnownExploited ? 9m : 3m,
+                EpssScore: first.EpssScore,
+                KnownExploited: first.KnownExploited,
+                PublicExploit: first.PublicExploit,
+                ActiveAlert: false,
+                HasRansomwareAssociation: false,
+                HasMalwareAssociation: false,
+                FactorsJson: "[]",
+                CalculationVersion: "defender-v1"));
+        }
+    }
+
+    return new CanonicalVulnerabilityBatch(vulns, assessments);
+}
+
+private static string BuildCpeCriteria(DefenderMachineVulnerabilityEntry entry) =>
+    $"cpe:2.3:a:{(entry.ProductVendor ?? "*").ToLowerInvariant()}:{(entry.ProductName ?? "*").ToLowerInvariant()}:*:*:*:*:*:*:*:*";
+```
+
+> Reuse the existing `HasUsableCveId` / `IsRecoverableTimeout` / `MapSeverity` private helpers already in this file. Delete the legacy `FetchVulnerabilitiesAsync` body by replacing it with `throw new NotSupportedException("Removed in Phase 2. Use FetchCanonicalVulnerabilitiesAsync.");` (the interface-level `[Obsolete(error: true)]` causes callers to fail to compile).
+
+- [ ] **Step 5: Tests pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~DefenderVulnerabilitySourceCanonicalTests"` — PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Models/CanonicalVulnerabilityBatch.cs \
+        src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs \
+        src/PatchHound.Infrastructure/VulnerabilitySources/DefenderVulnerabilitySource.cs \
+        tests/PatchHound.Infrastructure.Tests/VulnerabilitySources/DefenderVulnerabilitySourceCanonicalTests.cs
+git commit -m "feat(phase-2): DefenderVulnerabilitySource emits CanonicalVulnerabilityBatch"
+```
+
+---
+
+## Task 8: Rewrite `NvdVulnerabilityEnrichmentRunner` and `DefenderVulnerabilityEnrichmentRunner` against canonical resolver
+
+Both runners currently read legacy `VulnerabilityDefinition`/`VulnerabilityThreatAssessment` rows and mutate them. Rewrite them to:
+
+1. Open a system-context `PatchHoundDbContext`
+2. Fetch canonical batches via `IVulnerabilitySource.FetchCanonicalVulnerabilitiesAsync`
+3. Call `VulnerabilityResolver.ResolveAsync` for each vulnerability
+4. For NVD specifically: attempt to match each applicability's CPE against `SoftwareAlias` (`SourceSystemId='nvd'`) → `SoftwareProductId`, and set `VulnerabilityApplicabilityInput.SoftwareProductId` when a match is found (CPE string is retained as fallback)
+5. Call `ThreatAssessmentService.UpsertAsync` for each canonical threat assessment input, mapping `(Source, ExternalId)` → `VulnerabilityId` via a single preloaded dictionary
+6. `SaveChangesAsync`
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/DefenderVulnerabilityEnrichmentRunner.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/NvdVulnerabilityEnrichmentRunner.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/NvdVulnerabilityEnrichmentRunnerTests.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/DefenderVulnerabilityEnrichmentRunnerTests.cs`
+
+- [ ] **Step 1: Write failing test for NVD runner (CPE→SoftwareProduct resolution)**
+
+```csharp
+[Fact]
+public async Task NvdEnrichmentRunner_resolves_applicability_to_SoftwareProduct_when_alias_exists()
+{
+    await using var db = TestDbContextFactory.CreateSystemContext();
+
+    // Arrange: seed a canonical SoftwareProduct and an NVD alias pointing to it
+    var nvdSource = SourceSystem.Create("nvd", "NVD", true);
+    db.SourceSystems.Add(nvdSource);
+    var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*");
+    db.SoftwareProducts.Add(product);
+    var alias = SoftwareAlias.Create(nvdSource.Id, "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*", product.Id);
+    db.SoftwareAliases.Add(alias);
+    await db.SaveChangesAsync();
+
+    // Arrange: fake NVD source returning a single vuln for acme:widget
+    var fakeSource = new FakeNvdSource(new CanonicalVulnerabilityBatch(
+        new[] {
+            new VulnerabilityResolveInput(
+                "nvd", "CVE-2026-5555", "t", "d", Severity.High, 7m, "v", DateTimeOffset.UtcNow,
+                Array.Empty<VulnerabilityReferenceInput>(),
+                new[] { new VulnerabilityApplicabilityInput(
+                    SoftwareProductId: null,
+                    CpeCriteria: "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*",
+                    Vulnerable: true, null, null, "1.0", null) })
+        },
+        Array.Empty<CanonicalThreatAssessmentInput>()));
+
+    var runner = new NvdVulnerabilityEnrichmentRunner(
+        fakeSource,
+        new VulnerabilityResolver(db),
+        new ThreatAssessmentService(db),
+        db,
+        NullLogger<NvdVulnerabilityEnrichmentRunner>.Instance);
+
+    await runner.RunAsync(CancellationToken.None);
+
+    // Assert: the applicability row has SoftwareProductId populated
+    var app = await db.VulnerabilityApplicabilities.SingleAsync();
+    Assert.Equal(product.Id, app.SoftwareProductId);
+    Assert.Equal("cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*", app.CpeCriteria);
+}
+```
+
+- [ ] **Step 2: Rewrite NVD runner**
+
+```csharp
+public class NvdVulnerabilityEnrichmentRunner
+{
+    private readonly IVulnerabilitySource _source;
+    private readonly VulnerabilityResolver _resolver;
+    private readonly ThreatAssessmentService _threatService;
+    private readonly PatchHoundDbContext _db;
+    private readonly ILogger<NvdVulnerabilityEnrichmentRunner> _logger;
+
+    public NvdVulnerabilityEnrichmentRunner(
+        IVulnerabilitySource source,
+        VulnerabilityResolver resolver,
+        ThreatAssessmentService threatService,
+        PatchHoundDbContext db,
+        ILogger<NvdVulnerabilityEnrichmentRunner> logger)
+    {
+        _source = source;
+        _resolver = resolver;
+        _threatService = threatService;
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        _db.SetSystemContext(true); // enables global writes per spec §4.10 Rule 9
+        try
+        {
+            var batch = await _source.FetchCanonicalVulnerabilitiesAsync(Guid.Empty /*global source*/, ct);
+
+            var nvdSourceSystemId = await _db.SourceSystems
+                .Where(s => s.Key == "nvd")
+                .Select(s => (Guid?)s.Id)
+                .FirstOrDefaultAsync(ct);
+
+            var aliasMap = nvdSourceSystemId is null
+                ? new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
+                : await _db.SoftwareAliases
+                    .Where(a => a.SourceSystemId == nvdSourceSystemId)
+                    .ToDictionaryAsync(a => a.ExternalId, a => a.SoftwareProductId, StringComparer.OrdinalIgnoreCase, ct);
+
+            foreach (var vuln in batch.Vulnerabilities)
+            {
+                var resolved = new VulnerabilityResolveInput(
+                    vuln.Source, vuln.ExternalId, vuln.Title, vuln.Description,
+                    vuln.VendorSeverity, vuln.CvssScore, vuln.CvssVector, vuln.PublishedDate,
+                    vuln.References,
+                    vuln.Applicabilities.Select(a =>
+                        a.SoftwareProductId is null
+                            && a.CpeCriteria is not null
+                            && aliasMap.TryGetValue(a.CpeCriteria, out var pid)
+                        ? a with { SoftwareProductId = pid }
+                        : a).ToList());
+
+                await _resolver.ResolveAsync(resolved, ct);
+            }
+
+            // Persist vulns so threat-assessment lookups find them
+            await _db.SaveChangesAsync(ct);
+
+            var externalIdToVulnId = await _db.Vulnerabilities
+                .Where(v => batch.ThreatAssessments.Select(t => t.ExternalId).Contains(v.ExternalId)
+                         && batch.ThreatAssessments.Select(t => t.Source).Contains(v.Source))
+                .ToDictionaryAsync(v => $"{v.Source}|{v.ExternalId}", v => v.Id, ct);
+
+            foreach (var a in batch.ThreatAssessments)
+            {
+                if (!externalIdToVulnId.TryGetValue($"{a.Source}|{a.ExternalId}", out var vulnId)) continue;
+                await _threatService.UpsertAsync(
+                    vulnId, a.ThreatScore, a.TechnicalScore, a.ExploitLikelihoodScore, a.ThreatActivityScore,
+                    a.EpssScore, a.KnownExploited, a.PublicExploit, a.ActiveAlert,
+                    a.HasRansomwareAssociation, a.HasMalwareAssociation, a.FactorsJson, a.CalculationVersion, ct);
+            }
+            await _db.SaveChangesAsync(ct);
+        }
+        finally
+        {
+            _db.SetSystemContext(false);
+        }
+    }
+}
+```
+
+> `PatchHoundDbContext.SetSystemContext(bool)` toggles the `IsSystemContext` flag introduced in Phase 1 Task 1. If the context does not yet expose a mutator, add one in `PatchHoundDbContext`: `public void SetSystemContext(bool value) => IsSystemContext = value;`.
+
+- [ ] **Step 3: Rewrite Defender runner similarly**
+
+Same structure, but Defender does not carry CPE aliases the same way — Defender applicabilities leave `SoftwareProductId` null and rely on Phase 3 CPE match fallback. Defender runner still upserts threat assessments.
+
+- [ ] **Step 4: NVD test passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~NvdVulnerabilityEnrichmentRunnerTests"` — PASS.
+
+- [ ] **Step 5: Defender runner test**
+
+Analogous test: given a fake Defender canonical batch with two vulnerabilities, assert that two `Vulnerability` rows, their CPE-based applicabilities (`SoftwareProductId` null), and matching `ThreatAssessment` rows are written.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/NvdVulnerabilityEnrichmentRunner.cs \
+        src/PatchHound.Infrastructure/Services/DefenderVulnerabilityEnrichmentRunner.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/NvdVulnerabilityEnrichmentRunnerTests.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/DefenderVulnerabilityEnrichmentRunnerTests.cs
+git commit -m "feat(phase-2): rewrite vulnerability enrichment runners against canonical resolver"
+```
+
+---
+
+## Task 9: Delete `StagedVulnerabilityMergeService`, `VulnerabilityAssessmentService`, `VulnerabilityThreatAssessmentService`, `SoftwareVulnerabilityMatchService`
+
+All four services operate on legacy tables that are deleted in Task 16. Delete them now (before the entity deletion so the compiler errors surface in one batch).
+
+**Files:**
+- Delete: `src/PatchHound.Infrastructure/Services/StagedVulnerabilityMergeService.cs`
+- Delete: `src/PatchHound.Infrastructure/Services/VulnerabilityAssessmentService.cs`
+- Delete: `src/PatchHound.Infrastructure/Services/VulnerabilityThreatAssessmentService.cs`
+- Delete: `src/PatchHound.Infrastructure/Services/SoftwareVulnerabilityMatchService.cs`
+- Delete: `src/PatchHound.Infrastructure/Services/VulnerabilityEpisodeRiskAssessmentService.cs`
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs` (remove registrations)
+- Delete: any tests that exercise the above services
+
+- [ ] **Step 1: Delete the service files and their test files**
+
+```bash
+rm src/PatchHound.Infrastructure/Services/StagedVulnerabilityMergeService.cs
+rm src/PatchHound.Infrastructure/Services/VulnerabilityAssessmentService.cs
+rm src/PatchHound.Infrastructure/Services/VulnerabilityThreatAssessmentService.cs
+rm src/PatchHound.Infrastructure/Services/SoftwareVulnerabilityMatchService.cs
+rm src/PatchHound.Infrastructure/Services/VulnerabilityEpisodeRiskAssessmentService.cs
+rm tests/PatchHound.Infrastructure.Tests/Services/StagedVulnerabilityMergeServiceTests.cs 2>/dev/null || true
+rm tests/PatchHound.Infrastructure.Tests/Services/VulnerabilityAssessmentServiceTests.cs 2>/dev/null || true
+rm tests/PatchHound.Infrastructure.Tests/Services/VulnerabilityThreatAssessmentServiceTests.cs 2>/dev/null || true
+rm tests/PatchHound.Infrastructure.Tests/Services/SoftwareVulnerabilityMatchServiceTests.cs 2>/dev/null || true
+rm tests/PatchHound.Infrastructure.Tests/Services/VulnerabilityEpisodeRiskAssessmentServiceTests.cs 2>/dev/null || true
+```
+
+- [ ] **Step 2: Remove DI registrations**
+
+In `src/PatchHound.Infrastructure/DependencyInjection.cs`, remove every `AddScoped<...>` and `AddSingleton<...>` line that references the five deleted services.
+
+- [ ] **Step 3: Build — expect errors**
+
+Run: `dotnet build`
+Expected: errors — every service/controller that still uses the deleted types. Tasks 10–12 clean those up.
+
+- [ ] **Step 4: Commit (intentional broken state marker)**
+
+```bash
+git add -u
+git commit -m "feat(phase-2): delete legacy vulnerability services (compile intentionally broken)"
+```
+
+---
+
+## Task 10: Rewrite `VulnerabilityDetailQueryService` against canonical `Vulnerability`
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/VulnerabilityDetailQueryService.cs`
+- Modify: `src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDetailDto.cs`
+- Test: `tests/PatchHound.Api.Tests/Services/VulnerabilityDetailQueryServiceTests.cs`
+
+The Phase 2 contract: `VulnerabilityDetailDto` is built from a canonical `Vulnerability` + its `VulnerabilityReference`s + its `VulnerabilityApplicability` rows + its `ThreatAssessment` (if any). The `AffectedDevices`, `ActiveExposures`, and `ResolvedExposures` fields are **always empty arrays in Phase 2** and are marked as such on the DTO with a `DataAvailable: false` flag.
+
+- [ ] **Step 1: Update the DTO**
+
+In `VulnerabilityDetailDto.cs`, add an explicit nested shape:
+
+```csharp
+public record VulnerabilityDetailDto(
+    Guid Id,
+    string ExternalId,
+    string Source,
+    string Title,
+    string Description,
+    string VendorSeverity,
+    decimal? CvssScore,
+    string? CvssVector,
+    DateTimeOffset? PublishedDate,
+    IReadOnlyList<VulnerabilityReferenceDto> References,
+    IReadOnlyList<VulnerabilityApplicabilityDto> Applicabilities,
+    ThreatAssessmentDto? ThreatAssessment,
+    ExposureSectionDto Exposures);
+
+public record VulnerabilityReferenceDto(string Url, string Source, IReadOnlyList<string> Tags);
+public record VulnerabilityApplicabilityDto(Guid? SoftwareProductId, string? SoftwareProductName, string? CpeCriteria, bool Vulnerable, string? VersionStartIncluding, string? VersionStartExcluding, string? VersionEndIncluding, string? VersionEndExcluding);
+public record ThreatAssessmentDto(decimal ThreatScore, decimal? EpssScore, bool KnownExploited, bool PublicExploit, bool ActiveAlert);
+public record ExposureSectionDto(
+    bool DataAvailable,
+    string DataAvailableReason,
+    IReadOnlyList<object> AffectedDevices,
+    IReadOnlyList<object> ActiveExposures,
+    IReadOnlyList<object> ResolvedExposures);
+```
+
+Phase 2 always returns:
+
+```csharp
+Exposures: new ExposureSectionDto(
+    DataAvailable: false,
+    DataAvailableReason: "Populated after the Phase 3 canonical exposure merge.",
+    AffectedDevices: Array.Empty<object>(),
+    ActiveExposures: Array.Empty<object>(),
+    ResolvedExposures: Array.Empty<object>());
+```
+
+- [ ] **Step 2: Rewrite `VulnerabilityDetailQueryService.BuildAsync`**
+
+```csharp
+public async Task<VulnerabilityDetailDto?> BuildAsync(Guid tenantId, Guid vulnerabilityId, CancellationToken ct)
+{
+    var vuln = await _db.Vulnerabilities.AsNoTracking()
+        .FirstOrDefaultAsync(v => v.Id == vulnerabilityId, ct);
+    if (vuln is null) return null;
+
+    var references = await _db.VulnerabilityReferences.AsNoTracking()
+        .Where(r => r.VulnerabilityId == vulnerabilityId)
+        .ToListAsync(ct);
+
+    var applicabilities = await _db.VulnerabilityApplicabilities.AsNoTracking()
+        .Where(a => a.VulnerabilityId == vulnerabilityId)
+        .ToListAsync(ct);
+
+    var productIds = applicabilities
+        .Where(a => a.SoftwareProductId is not null)
+        .Select(a => a.SoftwareProductId!.Value)
+        .ToList();
+    var productNames = await _db.SoftwareProducts.AsNoTracking()
+        .Where(p => productIds.Contains(p.Id))
+        .ToDictionaryAsync(p => p.Id, p => p.Name, ct);
+
+    var threat = await _db.ThreatAssessments.AsNoTracking()
+        .FirstOrDefaultAsync(t => t.VulnerabilityId == vulnerabilityId, ct);
+
+    return new VulnerabilityDetailDto(
+        vuln.Id,
+        vuln.ExternalId,
+        vuln.Source,
+        vuln.Title,
+        vuln.Description,
+        vuln.VendorSeverity.ToString(),
+        vuln.CvssScore,
+        vuln.CvssVector,
+        vuln.PublishedDate,
+        references.Select(r => new VulnerabilityReferenceDto(r.Url, r.Source, r.GetTags())).ToList(),
+        applicabilities.Select(a => new VulnerabilityApplicabilityDto(
+            a.SoftwareProductId,
+            a.SoftwareProductId is not null && productNames.TryGetValue(a.SoftwareProductId.Value, out var n) ? n : null,
+            a.CpeCriteria, a.Vulnerable,
+            a.VersionStartIncluding, a.VersionStartExcluding,
+            a.VersionEndIncluding, a.VersionEndExcluding)).ToList(),
+        threat is null ? null : new ThreatAssessmentDto(threat.ThreatScore, threat.EpssScore, threat.KnownExploited, threat.PublicExploit, threat.ActiveAlert),
+        new ExposureSectionDto(
+            DataAvailable: false,
+            DataAvailableReason: "Populated after the Phase 3 canonical exposure merge.",
+            AffectedDevices: Array.Empty<object>(),
+            ActiveExposures: Array.Empty<object>(),
+            ResolvedExposures: Array.Empty<object>()));
+}
+```
+
+- [ ] **Step 3: Write test**
+
+```csharp
+[Fact]
+public async Task BuildAsync_returns_canonical_detail_with_empty_exposure_section()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    var vuln = Vulnerability.Create("nvd", "CVE-2026-3333", "Title", "Desc", Severity.High, 7.5m, "vec", DateTimeOffset.UtcNow);
+    db.Vulnerabilities.Add(vuln);
+    db.VulnerabilityReferences.Add(VulnerabilityReference.Create(vuln.Id, "https://example.com", "nvd", new[] { "advisory" }));
+    await db.SaveChangesAsync();
+
+    var svc = new VulnerabilityDetailQueryService(db);
+    var dto = await svc.BuildAsync(tenantId, vuln.Id, CancellationToken.None);
+
+    Assert.NotNull(dto);
+    Assert.Equal("CVE-2026-3333", dto!.ExternalId);
+    Assert.Single(dto.References);
+    Assert.False(dto.Exposures.DataAvailable);
+    Assert.Empty(dto.Exposures.AffectedDevices);
+    Assert.Equal("Populated after the Phase 3 canonical exposure merge.", dto.Exposures.DataAvailableReason);
+}
+```
+
+Run: PASS after rewrite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Api/Services/VulnerabilityDetailQueryService.cs \
+        src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDetailDto.cs \
+        tests/PatchHound.Api.Tests/Services/VulnerabilityDetailQueryServiceTests.cs
+git commit -m "feat(phase-2): rewrite VulnerabilityDetailQueryService against canonical Vulnerability"
+```
+
+---
+
+## Task 11: Rewrite `VulnerabilitiesController` list endpoint against canonical `Vulnerability` + `ThreatAssessment`
+
+**Files:**
+- Modify: `src/PatchHound.Api/Controllers/VulnerabilitiesController.cs`
+- Modify: `src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDto.cs`
+- Modify: `src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityFilterQuery.cs` (drop `PresentOnly` / `RecurrenceOnly` filters — they depend on legacy `VulnerabilityAssetEpisodes` and are restored in Phase 3)
+
+The Phase 2 list endpoint:
+
+- Scopes to the current tenant only via authorization/policy (the result set is global, but the policy gate is preserved)
+- Queries `db.Vulnerabilities` (global, unfiltered)
+- Left-joins `ThreatAssessments` (global, unfiltered) for EPSS / KEV / public-exploit flags
+- Removes all joins to `TenantVulnerabilities`, `VulnerabilityAssets`, `VulnerabilityAssetEpisodes`, `VulnerabilityThreatAssessments`, `OrganizationalSeverities`
+- Returns `AffectedAssetCount = 0` and `AdjustedSeverity = null` with a flag `ExposureDataAvailable = false`
+- Removes the `id/organizational-severity` endpoint body until Phase 3 re-introduces tenant severity override via a separate mechanism; the endpoint itself stays registered but returns `409 Conflict { Title = "Organizational severity is disabled during canonical migration; restored in Phase 3." }`
+- Removes the `id/ai-report` endpoint body for now and returns `409 Conflict` with the same message (AI report generation is rewritten against `RemediationCase` + `DeviceVulnerabilityExposure` in Phase 4; Phase 2 cannot produce a useful report without exposure data)
+
+- [ ] **Step 1: Update `VulnerabilityDto`**
+
+```csharp
+public record VulnerabilityDto(
+    Guid Id,
+    string ExternalId,
+    string Title,
+    string VendorSeverity,
+    string Source,
+    decimal? CvssScore,
+    DateTimeOffset? PublishedDate,
+    bool ExposureDataAvailable,
+    int AffectedDeviceCount,
+    decimal? ThreatScore,
+    decimal? EpssScore,
+    bool PublicExploit,
+    bool KnownExploited,
+    bool ActiveAlert);
+```
+
+- [ ] **Step 2: Drop legacy fields from filter query**
+
+In `VulnerabilityFilterQuery.cs`, delete `PresentOnly`, `RecurrenceOnly`, and `TenantId`. Keep `Severity`, `Status` (maps to nothing for now — ignored), `Source`, `Search`, `MinAgeDays`, `PublicExploitOnly`, `KnownExploitedOnly`, `ActiveAlertOnly`.
+
+- [ ] **Step 3: Rewrite the `List` method**
+
+```csharp
+[HttpGet]
+[Authorize(Policy = Policies.ViewVulnerabilities)]
+public async Task<ActionResult<PagedResponse<VulnerabilityDto>>> List(
+    [FromQuery] VulnerabilityFilterQuery filter,
+    [FromQuery] PaginationQuery pagination,
+    CancellationToken ct)
+{
+    if (_tenantContext.CurrentTenantId is null)
+        return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+    var query = _dbContext.Vulnerabilities.AsNoTracking().AsQueryable();
+
+    if (!string.IsNullOrEmpty(filter.Severity) && Enum.TryParse<Severity>(filter.Severity, out var severity))
+        query = query.Where(v => v.VendorSeverity == severity);
+    if (!string.IsNullOrEmpty(filter.Source))
+        query = query.Where(v => v.Source.Contains(filter.Source));
+    if (!string.IsNullOrEmpty(filter.Search))
+        query = query.Where(v => v.Title.Contains(filter.Search) || v.ExternalId.Contains(filter.Search));
+    if (filter.MinAgeDays.HasValue)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-filter.MinAgeDays.Value);
+        query = query.Where(v => v.PublishedDate <= cutoff);
+    }
+    if (filter.PublicExploitOnly == true)
+        query = query.Where(v => _dbContext.ThreatAssessments.Any(a => a.VulnerabilityId == v.Id && a.PublicExploit));
+    if (filter.KnownExploitedOnly == true)
+        query = query.Where(v => _dbContext.ThreatAssessments.Any(a => a.VulnerabilityId == v.Id && a.KnownExploited));
+    if (filter.ActiveAlertOnly == true)
+        query = query.Where(v => _dbContext.ThreatAssessments.Any(a => a.VulnerabilityId == v.Id && a.ActiveAlert));
+
+    var total = await query.CountAsync(ct);
+
+    var items = await query
+        .OrderByDescending(v => v.CvssScore)
+        .ThenByDescending(v => v.PublishedDate)
+        .Skip(pagination.Skip)
+        .Take(pagination.BoundedPageSize)
+        .Select(v => new
+        {
+            v.Id,
+            v.ExternalId,
+            v.Title,
+            Severity = v.VendorSeverity.ToString(),
+            v.Source,
+            v.CvssScore,
+            v.PublishedDate,
+            Threat = _dbContext.ThreatAssessments
+                .Where(a => a.VulnerabilityId == v.Id)
+                .Select(a => new { a.ThreatScore, a.EpssScore, a.PublicExploit, a.KnownExploited, a.ActiveAlert })
+                .FirstOrDefault(),
+        })
+        .ToListAsync(ct);
+
+    var dtos = items.Select(v => new VulnerabilityDto(
+        v.Id, v.ExternalId, v.Title, v.Severity, v.Source, v.CvssScore, v.PublishedDate,
+        ExposureDataAvailable: false,
+        AffectedDeviceCount: 0,
+        ThreatScore: v.Threat?.ThreatScore,
+        EpssScore: v.Threat?.EpssScore,
+        PublicExploit: v.Threat?.PublicExploit ?? false,
+        KnownExploited: v.Threat?.KnownExploited ?? false,
+        ActiveAlert: v.Threat?.ActiveAlert ?? false)).ToList();
+
+    return Ok(new PagedResponse<VulnerabilityDto>(dtos, total, pagination.Page, pagination.BoundedPageSize));
+}
+```
+
+- [ ] **Step 4: Stub legacy mutation endpoints**
+
+```csharp
+[HttpPut("{id:guid}/organizational-severity")]
+[Authorize(Policy = Policies.AdjustSeverity)]
+public IActionResult UpdateOrganizationalSeverity(Guid id, [FromBody] UpdateOrgSeverityRequest _) =>
+    Conflict(new ProblemDetails { Title = "Organizational severity is disabled during canonical migration; restored in Phase 3." });
+
+[HttpPost("{id:guid}/ai-report")]
+[Authorize(Policy = Policies.GenerateAiReports)]
+public IActionResult GenerateAiReport(Guid id, [FromBody] GenerateAiReportRequest _) =>
+    Conflict(new ProblemDetails { Title = "AI report generation is disabled during canonical migration; restored in Phase 4 (case-first)." });
+```
+
+Remove `VulnerabilityService`, `AiReportService`, `TenantSnapshotResolver` constructor parameters — they are unused after this rewrite. Remove their `using` statements. The controller only needs `PatchHoundDbContext`, `ITenantContext`, and `VulnerabilityDetailQueryService`.
+
+- [ ] **Step 5: Controller test**
+
+```csharp
+[Fact]
+public async Task List_returns_canonical_vulns_with_ExposureDataAvailable_false()
+{
+    // Arrange in-memory dbcontext seeded with two vulnerabilities and one threat assessment
+    // ... similar to Phase 1 controller tests
+    // Assert response contains 2 items; each dto.ExposureDataAvailable == false; dto.AffectedDeviceCount == 0
+}
+```
+
+Run: `dotnet test --filter "FullyQualifiedName~VulnerabilitiesControllerTests"` — PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/VulnerabilitiesController.cs \
+        src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDto.cs \
+        src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityFilterQuery.cs \
+        tests/PatchHound.Api.Tests/Controllers/VulnerabilitiesControllerTests.cs
+git commit -m "feat(phase-2): rewrite VulnerabilitiesController against canonical Vulnerability"
+```
+
+---
+
+## Task 12: Delete legacy `VulnerabilityService`, `OrganizationalSeverity` writes through `VulnerabilityService`
+
+The legacy `VulnerabilityService.UpdateOrganizationalSeverityAsync` writes to `OrganizationalSeverities` keyed on `TenantVulnerabilityId`, which is going away. Delete the method and the entire `VulnerabilityService` class (its only consumer was the organizational-severity endpoint which now returns 409).
+
+**Files:**
+- Delete: `src/PatchHound.Core/Services/VulnerabilityService.cs` (or wherever it lives)
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs`
+- Delete: related test files
+
+- [ ] **Step 1: Confirm file location**
+
+Run: `grep -rn "class VulnerabilityService" src/ --include="*.cs"`
+
+- [ ] **Step 2: Delete file and registration**
+
+```bash
+rm src/PatchHound.Core/Services/VulnerabilityService.cs   # adjust path as needed
+rm tests/**/VulnerabilityServiceTests.cs 2>/dev/null || true
+```
+
+Remove `services.AddScoped<VulnerabilityService>()` from DI.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -u
+git commit -m "feat(phase-2): delete VulnerabilityService (replaced by canonical resolver)"
+```
+
+---
+
+## Task 13: Frontend — handle empty exposure section in vulnerability list/detail
+
+**Files:**
+- Modify: `web/src/routes/vulnerabilities/index.tsx` (list view)
+- Modify: `web/src/routes/vulnerabilities/$vulnerabilityId.tsx` (detail view)
+- Modify: `web/src/api/types/vulnerabilities.ts` (add `ExposureDataAvailable`, remove `AffectedAssetCount` semantics in favor of `AffectedDeviceCount`)
+- Test: `web/src/routes/vulnerabilities/__tests__/VulnerabilitiesList.test.tsx`
+- Test: `web/src/routes/vulnerabilities/__tests__/VulnerabilityDetail.test.tsx`
+
+- [ ] **Step 1: Update API types**
+
+Match the backend DTO field names exactly (camelCase). Add `exposureDataAvailable: boolean`, `affectedDeviceCount: number`, and in detail: `exposures: { dataAvailable: boolean; dataAvailableReason: string; affectedDevices: unknown[]; activeExposures: unknown[]; resolvedExposures: unknown[]; }`.
+
+- [ ] **Step 2: List view**
+
+Where the current list shows "Affected: N assets", render one of:
+
+- If `exposureDataAvailable === false`: show a small muted badge `Exposure data pending (Phase 3)` and omit the number.
+- Otherwise: show `Affected: {affectedDeviceCount} devices`.
+
+Remove any filter UI for "present only" / "recurrence only" (those filters were deleted server-side).
+
+- [ ] **Step 3: Detail view**
+
+Replace the "Affected Assets" and "Episodes" tabs with a single explanatory empty state when `exposures.dataAvailable === false`: a centered `Alert` component with the `dataAvailableReason` text. The "References", "Applicabilities", and "Threat Assessment" tabs render the new canonical data.
+
+- [ ] **Step 4: Component tests**
+
+```ts
+it('shows "Exposure data pending" when exposureDataAvailable is false', async () => {
+  mockApi({ items: [{ id: 'v1', externalId: 'CVE-2026-1111', exposureDataAvailable: false, affectedDeviceCount: 0, /* ... */ }] });
+  render(<VulnerabilitiesList />);
+  expect(await screen.findByText(/Exposure data pending/i)).toBeInTheDocument();
+});
+
+it('shows detail empty state when exposures.dataAvailable is false', async () => {
+  mockApi({ id: 'v1', exposures: { dataAvailable: false, dataAvailableReason: 'Populated after the Phase 3 canonical exposure merge.', affectedDevices: [], activeExposures: [], resolvedExposures: [] } });
+  render(<VulnerabilityDetail id="v1" />);
+  expect(await screen.findByText(/Populated after the Phase 3/i)).toBeInTheDocument();
+});
+```
+
+Run: `cd web && npm test -- --run vulnerabilities` — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/routes/vulnerabilities/ web/src/api/types/vulnerabilities.ts
+git commit -m "feat(phase-2): vulnerability UI handles empty exposure section"
+```
+
+---
+
+## Task 14: Remove legacy references from `EmailNotificationService`, `RemediationDecisionService`, `PatchingTaskService`, `RiskScoreService`, `EnrichmentJobEnqueuer`, `IngestionStateCache`
+
+Each of these files still references `TenantVulnerability`, `VulnerabilityDefinition`, `VulnerabilityAsset*`, or `VulnerabilityThreatAssessment`. Phase 2 strips those references to restore a green build. **Minimal** replacements only — do not re-add functionality that will be re-implemented in later phases.
+
+**Guidance for each file:**
+
+- `EmailNotificationService.cs` — Rewrite any query that pulls `TenantVulnerabilities.Include(v => v.VulnerabilityDefinition)` to query `Vulnerabilities` directly (scoped to the tenant via a follow-on join on `DeviceVulnerabilityExposure` in Phase 3). For Phase 2, if a notification can no longer be rendered without exposure data, guard the branch with `if (false)` and leave a TODO-anchor comment: `// phase-3: restore exposure-aware notification rendering`. Do not delete the notification type, just its unreachable body. **Tests:** update the existing notification tests to assert the Phase-2 fallback path renders a "no data yet" placeholder subject line.
+
+- `RemediationDecisionService.cs`, `PatchingTaskService.cs` — These reference `TenantVulnerabilityId` columns on `RemediationDecision`/`PatchingTask`. Phase 2 does not yet drop those columns (Phase 4 does). For Phase 2, when legacy code reads `TenantVulnerabilityId`, replace the lookup with `null` and short-circuit the code path. Add a new `[Obsolete("Replaced in Phase 4 case-first remediation", error: false)]` on any public method that was exclusively a legacy lookup; leave its body as a throwing stub.
+
+- `RiskScoreService.cs` — Replace `VulnerabilityThreatAssessment` joins with `ThreatAssessment` joins keyed on `VulnerabilityId`. Do not introduce canonical exposure reads yet — those come in Phase 5. For Phase 2, device risk scores continue to key off the Phase 1 inventory baseline (no vulnerability contribution). Add an explicit comment: `// phase-5: re-introduce vulnerability contribution from DeviceVulnerabilityExposure`.
+
+- `EnrichmentJobEnqueuer.cs` — Wherever it enqueues enrichment for `VulnerabilityDefinitionId`, switch to `VulnerabilityId` (the canonical identifier). Wherever it filters by `TenantVulnerability.SourceKey`, filter by `Vulnerability.Source` on the global table.
+
+- `IngestionStateCache.cs` — Any cache key that includes `VulnerabilityDefinitionId` switches to `VulnerabilityId`. Any entry keyed on `TenantVulnerabilityId` is deleted.
+
+- [ ] **Step 1: Grep the legacy symbols file-by-file**
+
+Run: `grep -n "TenantVulnerability\|VulnerabilityDefinition\|VulnerabilityThreatAssessment\|VulnerabilityAsset" src/PatchHound.Infrastructure/Services/EmailNotificationService.cs`
+
+Repeat for each file listed above.
+
+- [ ] **Step 2: Apply the rewrites per-file**
+
+Work one file at a time. After each file compiles, run the narrow test filter for that service (e.g. `dotnet test --filter "FullyQualifiedName~EmailNotificationService"`) and confirm the test either passes or has been updated to reflect the Phase-2 fallback behaviour.
+
+- [ ] **Step 3: Build — expect clean**
+
+Run: `dotnet build`
+Expected: 0 errors. Warnings are allowed only if they are `[Obsolete]` warnings on intentionally-stubbed methods; those are resolved in Phase 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "feat(phase-2): strip legacy vulnerability references from consumer services"
+```
+
+---
+
+## Task 15: Add global-entity write-protection test
+
+Spec §7 — "an authenticated non-system request that attempts to write a `SoftwareProduct`, `Vulnerability`, `VulnerabilityApplicability`, `VulnerabilityReference`, `ThreatAssessment`, or `SourceSystem` row returns 403 or 404. Tested explicitly."
+
+**Files:**
+- Test: `tests/PatchHound.Api.Tests/Security/GlobalEntityWriteProtectionTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Tests.Api.Testing;
+
+namespace PatchHound.Tests.Api.Security;
+
+public class GlobalEntityWriteProtectionTests
+{
+    [Fact]
+    public async Task Non_system_request_cannot_write_Vulnerability_directly()
+    {
+        await using var app = await TestApiFactory.CreateAsync();
+        var client = app.CreateAuthenticatedClient("tenant-admin");
+
+        // There is no endpoint that accepts vulnerability create payloads; verify that.
+        var response = await client.PostAsJsonAsync("/api/vulnerabilities", new { externalId = "CVE-2026-EVIL" });
+        Assert.True(
+            response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.MethodNotAllowed ||
+            response.StatusCode == HttpStatusCode.Forbidden,
+            $"Expected 404/405/403, got {response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Non_system_request_cannot_directly_insert_global_rows_via_any_controller()
+    {
+        await using var app = await TestApiFactory.CreateAsync();
+        var client = app.CreateAuthenticatedClient("tenant-admin");
+
+        foreach (var url in new[] {
+            "/api/software-products",
+            "/api/vulnerabilities",
+            "/api/vulnerability-references",
+            "/api/vulnerability-applicabilities",
+            "/api/threat-assessments",
+            "/api/source-systems"
+        })
+        {
+            var response = await client.PostAsJsonAsync(url, new { name = "evil" });
+            Assert.True(
+                response.StatusCode == HttpStatusCode.NotFound ||
+                response.StatusCode == HttpStatusCode.MethodNotAllowed ||
+                response.StatusCode == HttpStatusCode.Forbidden,
+                $"{url} returned unexpected {response.StatusCode}");
+        }
+    }
+
+    [Fact]
+    public async Task System_context_DbContext_can_write_global_Vulnerability_row()
+    {
+        await using var app = await TestApiFactory.CreateAsync();
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+        db.SetSystemContext(true);
+        db.Vulnerabilities.Add(Vulnerability.Create("test", "CVE-2026-9999", "t", "d", PatchHound.Core.Enums.Severity.High, 7m, "v", DateTimeOffset.UtcNow));
+        await db.SaveChangesAsync();
+        Assert.Equal(1, await db.Vulnerabilities.CountAsync());
+    }
+}
+```
+
+- [ ] **Step 2: Run — PASS**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Api.Tests/Security/GlobalEntityWriteProtectionTests.cs
+git commit -m "test(phase-2): assert global entities cannot be written via request-scoped context"
+```
+
+---
+
+## Task 16: Delete legacy vulnerability + exposure-asset entities, configurations, and DbSets
+
+**Deletions (files):**
+
+```
+src/PatchHound.Core/Entities/VulnerabilityDefinition.cs
+src/PatchHound.Core/Entities/VulnerabilityDefinitionReference.cs
+src/PatchHound.Core/Entities/VulnerabilityDefinitionAffectedSoftware.cs
+src/PatchHound.Core/Entities/TenantVulnerability.cs
+src/PatchHound.Core/Entities/VulnerabilityThreatAssessment.cs
+src/PatchHound.Core/Entities/VulnerabilityAsset.cs
+src/PatchHound.Core/Entities/VulnerabilityAssetEpisode.cs
+src/PatchHound.Core/Entities/VulnerabilityAssetAssessment.cs
+src/PatchHound.Core/Entities/VulnerabilityEpisodeRiskAssessment.cs
+src/PatchHound.Core/Entities/SoftwareVulnerabilityMatch.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityDefinitionConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityDefinitionReferenceConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityDefinitionAffectedSoftwareConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/TenantVulnerabilityConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityThreatAssessmentConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityAssetConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityAssetEpisodeConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityAssetAssessmentConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityEpisodeRiskAssessmentConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/SoftwareVulnerabilityMatchConfiguration.cs
+src/PatchHound.Infrastructure/Data/Configurations/NormalizedSoftwareVulnerabilityProjectionConfiguration.cs
+```
+
+**DbSets to remove from `PatchHoundDbContext`:**
+
+- `VulnerabilityDefinitions`
+- `VulnerabilityDefinitionReferences`
+- `VulnerabilityDefinitionAffectedSoftware`
+- `TenantVulnerabilities`
+- `VulnerabilityThreatAssessments`
+- `VulnerabilityAssets`
+- `VulnerabilityAssetEpisodes`
+- `VulnerabilityAssetAssessments`
+- `VulnerabilityEpisodeRiskAssessments`
+- `SoftwareVulnerabilityMatches`
+
+**Query filters to remove from `PatchHoundDbContext.OnModelCreating`:**
+
+- any `modelBuilder.Entity<TenantVulnerability>().HasQueryFilter(...)`
+- any `modelBuilder.Entity<VulnerabilityAsset>().HasQueryFilter(...)`
+- `VulnerabilityAssetEpisode`, `VulnerabilityAssetAssessment`, `VulnerabilityEpisodeRiskAssessment` filters
+
+- [ ] **Step 1: Delete the entity and configuration files**
+
+```bash
+git rm src/PatchHound.Core/Entities/VulnerabilityDefinition.cs \
+       src/PatchHound.Core/Entities/VulnerabilityDefinitionReference.cs \
+       src/PatchHound.Core/Entities/VulnerabilityDefinitionAffectedSoftware.cs \
+       src/PatchHound.Core/Entities/TenantVulnerability.cs \
+       src/PatchHound.Core/Entities/VulnerabilityThreatAssessment.cs \
+       src/PatchHound.Core/Entities/VulnerabilityAsset.cs \
+       src/PatchHound.Core/Entities/VulnerabilityAssetEpisode.cs \
+       src/PatchHound.Core/Entities/VulnerabilityAssetAssessment.cs \
+       src/PatchHound.Core/Entities/VulnerabilityEpisodeRiskAssessment.cs \
+       src/PatchHound.Core/Entities/SoftwareVulnerabilityMatch.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityDefinitionConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityDefinitionReferenceConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityDefinitionAffectedSoftwareConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/TenantVulnerabilityConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityThreatAssessmentConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityAssetConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityAssetEpisodeConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityAssetAssessmentConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/VulnerabilityEpisodeRiskAssessmentConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/SoftwareVulnerabilityMatchConfiguration.cs \
+       src/PatchHound.Infrastructure/Data/Configurations/NormalizedSoftwareVulnerabilityProjectionConfiguration.cs
+```
+
+- [ ] **Step 2: Remove DbSet declarations and query filters from `PatchHoundDbContext.cs`**
+
+Edit `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`:
+
+- Remove the ten legacy DbSet lines listed above.
+- Remove every `modelBuilder.Entity<LegacyType>()...` block that references the deleted types (query filters, `HasMany(...)` on legacy navigations, etc.).
+- Remove any `OrganizationalSeverity.TenantVulnerabilityId` FK registration. Change `OrganizationalSeverity` configuration to FK `VulnerabilityId` (column rename via EF model — no migration since Phase 2 does not generate migrations).
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build`
+Expected: clean. If any file still references the deleted types, fix them now (they should have been handled in Task 14, but the delete surface forces a final pass).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "feat(phase-2): delete legacy vulnerability + exposure-asset entities and configurations"
+```
+
+---
+
+## Task 17: Grep sweep — no legacy vulnerability references remain
+
+- [ ] **Step 1: Run these greps; each must return zero matches (excluding `docs/` archives and `tests/fixtures/`)**
+
+```bash
+grep -rn "VulnerabilityDefinition" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "TenantVulnerability" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "VulnerabilityThreatAssessment" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "VulnerabilityAsset" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "VulnerabilityEpisodeRiskAssessment" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "SoftwareVulnerabilityMatch" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "StagedVulnerabilityMergeService" src/ --include="*.cs" ; echo "---"
+grep -rn "NormalizedSoftwareVulnerabilityProjection" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "tenantVulnerabilityId" web/src --include="*.ts" --include="*.tsx" ; echo "---"
+grep -rn "vulnerabilityDefinitionId" web/src --include="*.ts" --include="*.tsx" ; echo "---"
+```
+
+All expected to return zero hits.
+
+- [ ] **Step 2: Check `IgnoreQueryFilters` usage**
+
+```bash
+grep -rn "IgnoreQueryFilters" src/ --include="*.cs" | grep -v "Migrations/"
+```
+
+Expected: only inside files under `src/PatchHound.Infrastructure/Services/` that are explicitly system-context (`VulnerabilityResolver`, `ThreatAssessmentService`, `NvdVulnerabilityEnrichmentRunner`, `DefenderVulnerabilityEnrichmentRunner`, `IngestionService`, `StagedDeviceMergeService`, `DeviceResolver` from Phase 1). Any hit outside that allow-list is a spec §4.10 Rule 5 violation and must be fixed.
+
+- [ ] **Step 3: Record the allow-list in the Phase 2 PR description**
+
+Append the allow-list to the PR description under a "§4.10 Rule 5 — `IgnoreQueryFilters()` allow-list" section so the spec-reviewer can verify it.
+
+- [ ] **Step 4: Commit (if any cleanup was needed)**
+
+If the greps returned unexpected hits that required fixes, commit them with `chore(phase-2): remove lingering legacy vulnerability references`.
+
+---
+
+## Task 18: Extend `TenantIsolationEndToEndTests` with Phase 2 assertions
+
+**Files:**
+- Modify: `tests/PatchHound.Api.Tests/EndToEnd/TenantIsolationEndToEndTests.cs`
+
+Phase 2 does not introduce new tenant-scoped entities (all four new entities are global). The tenant isolation test extension focuses on:
+
+1. `GET /api/vulnerabilities` for tenant A and tenant B both return the **same** global vulnerability rows (no leak either direction; this proves global data is not wrongly tenant-filtered).
+2. `GET /api/vulnerabilities/{id}` returns the same canonical detail for tenant A and tenant B, and both see `exposures.dataAvailable === false` (no cross-tenant affected-devices leak).
+3. A direct `PatchHoundDbContext` write of a `Vulnerability` row **from a request-scoped (non-system) context** throws or fails silently — add an explicit test asserting the write does not appear in the database (the DI wiring must not set `IsSystemContext = true` outside system-context services).
+
+- [ ] **Step 1: Add assertions**
+
+```csharp
+[Fact]
+public async Task Phase2_vulnerabilities_list_is_global_and_consistent_across_tenants()
+{
+    await using var app = await TestApiFactory.CreateAsync();
+    // Seed one global vulnerability via system-context
+    using (var scope = app.Services.CreateScope())
+    {
+        var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+        db.SetSystemContext(true);
+        db.Vulnerabilities.Add(Vulnerability.Create("nvd", "CVE-2026-ABCD", "Shared", "Shared", Severity.High, 7.5m, "v", DateTimeOffset.UtcNow));
+        await db.SaveChangesAsync();
+        db.SetSystemContext(false);
+    }
+
+    var tenantAClient = app.CreateAuthenticatedClient(TenantAId);
+    var tenantBClient = app.CreateAuthenticatedClient(TenantBId);
+
+    var listA = await tenantAClient.GetFromJsonAsync<PagedResponse<VulnerabilityDto>>("/api/vulnerabilities");
+    var listB = await tenantBClient.GetFromJsonAsync<PagedResponse<VulnerabilityDto>>("/api/vulnerabilities");
+
+    Assert.Equal(1, listA!.Items.Count);
+    Assert.Equal(1, listB!.Items.Count);
+    Assert.Equal("CVE-2026-ABCD", listA.Items[0].ExternalId);
+    Assert.Equal("CVE-2026-ABCD", listB.Items[0].ExternalId);
+    Assert.False(listA.Items[0].ExposureDataAvailable);
+    Assert.False(listB.Items[0].ExposureDataAvailable);
+}
+
+[Fact]
+public async Task Phase2_vulnerability_detail_is_global_and_exposes_no_cross_tenant_data()
+{
+    // ... seed one vulnerability + one reference; assert both tenants get the same detail
+    // with exposures.dataAvailable == false
+}
+
+[Fact]
+public async Task Phase2_request_scoped_context_does_not_leak_system_context_flag()
+{
+    await using var app = await TestApiFactory.CreateAsync();
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+    Assert.False(db.IsSystemContext);   // default is false
+}
+```
+
+- [ ] **Step 2: Run — PASS**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Api.Tests/EndToEnd/TenantIsolationEndToEndTests.cs
+git commit -m "test(phase-2): extend tenant isolation e2e with canonical vulnerability assertions"
+```
+
+---
+
+## Task 19: Final build, test suite, and PR description
+
+- [ ] **Step 1: Clean build + full test pass**
+
+```bash
+dotnet clean && dotnet build --no-incremental
+dotnet test
+cd web && npm run typecheck && npm test -- --run && cd ..
+```
+
+All green.
+
+- [ ] **Step 2: Per-phase exit checklist (spec §6)**
+
+- [ ] `dotnet build` clean (0 warnings, 0 errors)
+- [ ] `dotnet test` green
+- [ ] `npm run typecheck` clean
+- [ ] `npm test` green
+- [ ] Grep sweep (Task 17) clean
+- [ ] No new dual-path / fallback code introduced
+- [ ] PR description section: "Entities deleted" lists all 10 legacy entities + 11 configuration files
+- [ ] PR description section: "Global entities added" lists `Vulnerability`, `VulnerabilityReference`, `VulnerabilityApplicability`, `ThreatAssessment` with `TenantId=none, QueryFilter=none, Justification="Public CVE/applicability/threat reference data (spec §4.10 Rule 3)"`
+- [ ] PR description section: "IgnoreQueryFilters allow-list" lists every service file where `IgnoreQueryFilters()` is called and its justification
+- [ ] PR description section: "Exposure gap" explicitly states that vulnerability list/detail returns `ExposureDataAvailable=false` until Phase 3 merges and that `/api/vulnerabilities/{id}/organizational-severity` and `/api/vulnerabilities/{id}/ai-report` return `409 Conflict` with a migration-in-progress message
+- [ ] PR description section: "Phase 2 scope extension" calls out that `VulnerabilityAsset*`, `VulnerabilityEpisodeRiskAssessment`, and `SoftwareVulnerabilityMatch*` were deleted in Phase 2 rather than Phase 3 because they FK into `TenantVulnerability`; Phase 3 will therefore introduce `DeviceVulnerabilityExposure` et al. from a clean slate
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin data-model-canonical-cleanup-phase-2
+gh pr create --title "Data model canonical cleanup — phase 2: canonical vulnerability knowledge" --body "$(cat <<'EOF'
+## Summary
+- Introduces canonical global vulnerability knowledge: `Vulnerability`, `VulnerabilityReference`, `VulnerabilityApplicability`, `ThreatAssessment`.
+- Rewrites `DefenderVulnerabilitySource`, `NvdVulnerabilityEnrichmentRunner`, `DefenderVulnerabilityEnrichmentRunner`, and `VulnerabilitiesController`/`VulnerabilityDetailQueryService` against canonical tables.
+- Deletes the entire `VulnerabilityDefinition*`, `TenantVulnerability`, `VulnerabilityThreatAssessment`, `VulnerabilityAsset*`, `VulnerabilityEpisodeRiskAssessment`, `SoftwareVulnerabilityMatch*`, and `NormalizedSoftwareVulnerabilityProjection*` chain.
+- Vulnerability list/detail returns canonical data with `ExposureDataAvailable=false`; exposure data is restored in Phase 3.
+
+## Entities deleted
+- `VulnerabilityDefinition`, `VulnerabilityDefinitionReference`, `VulnerabilityDefinitionAffectedSoftware`
+- `TenantVulnerability`
+- `VulnerabilityThreatAssessment`
+- `VulnerabilityAsset`, `VulnerabilityAssetEpisode`, `VulnerabilityAssetAssessment`
+- `VulnerabilityEpisodeRiskAssessment`
+- `SoftwareVulnerabilityMatch`
+- Plus their EF configurations.
+
+## Global entities added (all no-TenantId, no-QueryFilter)
+| Entity | Justification |
+|---|---|
+| `Vulnerability` | Public CVE record; spec §4.10 Rule 3 |
+| `VulnerabilityReference` | Public advisory link; spec §4.10 Rule 3 |
+| `VulnerabilityApplicability` | Public product-affectedness mapping; spec §4.10 Rule 3 |
+| `ThreatAssessment` | Public EPSS/KEV/threat intel; spec §4.10 Rule 3 |
+
+## `IgnoreQueryFilters()` allow-list
+- `VulnerabilityResolver` (system-context upsert)
+- `ThreatAssessmentService` (system-context upsert)
+- `NvdVulnerabilityEnrichmentRunner`, `DefenderVulnerabilityEnrichmentRunner` (system-context enrichment)
+- `IngestionService`, `StagedDeviceMergeService`, `DeviceResolver` (inherited from Phase 1)
+
+## Scope extension vs spec §5.2
+Phase 2 deletes `VulnerabilityAsset*`, `VulnerabilityEpisodeRiskAssessment`, and `SoftwareVulnerabilityMatch*` (which spec §5.3 listed under Phase 3) because those rows FK into `TenantVulnerability`, which is a Phase 2 deletion target. Phase 3 therefore introduces `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment` from a clean slate.
+
+## Exposure gap (acceptable per spec §5.2)
+- `GET /api/vulnerabilities` returns `ExposureDataAvailable: false, AffectedDeviceCount: 0`
+- `GET /api/vulnerabilities/{id}` returns `exposures.dataAvailable: false, dataAvailableReason: "Populated after the Phase 3 canonical exposure merge."`
+- `PUT /api/vulnerabilities/{id}/organizational-severity` and `POST /api/vulnerabilities/{id}/ai-report` return `409 Conflict` during the Phase 2 → Phase 3 window.
+
+## Test plan
+- [ ] `dotnet build` clean
+- [ ] `dotnet test` full suite green
+- [ ] `cd web && npm run typecheck && npm test -- --run` green
+- [ ] `TenantIsolationEndToEndTests` extended with Phase 2 assertions (global-consistency across tenants)
+- [ ] `GlobalEntityWriteProtectionTests` asserts no public endpoint accepts `Vulnerability`/`SoftwareProduct`/`ThreatAssessment`/`SourceSystem` writes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Mark Phase 2 complete in `docs/data-model-refactor.md` once the PR merges** (Phase 6 will rewrite this doc entirely — for now just append one line: "Phase 2 merged YYYY-MM-DD").

--- a/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-3.md
+++ b/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-3.md
@@ -1,0 +1,2017 @@
+# Data Model Canonical Cleanup — Phase 3: Canonical Exposure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce canonical tenant-scoped `DeviceVulnerabilityExposure`, `ExposureEpisode`, and `ExposureAssessment` entities; derive exposures from `InstalledSoftware` × `VulnerabilityApplicability`; compute environmental severity via `SecurityProfile`; fill in the vulnerability list/detail "affected devices" section left empty by Phase 2.
+
+**Architecture:** Three tenant-scoped entities with direct `TenantId` columns and mandatory EF query filters (spec §4.10 Rules 1, 2). An `ExposureDerivationService` walks each tenant's `InstalledSoftware` rows, matches each installed product against `VulnerabilityApplicability` (product-keyed first, CPE-keyed fallback), and upserts `DeviceVulnerabilityExposure` rows. `ExposureEpisodeService` manages the open/reopen/resolve lifecycle per `(DeviceId, VulnerabilityId)`. `ExposureAssessmentService` computes environmental CVSS via `Device.SecurityProfileId → SecurityProfile` modifiers using the existing `EnvironmentalSeverityCalculator`. All writes run under tenant context (not system-context) because every row carries `TenantId`.
+
+**Tech Stack:** .NET 10, EF Core 10, xUnit, PostgreSQL, React, TanStack Router, Vitest.
+
+**Note on Phase 2 cleanup:** Phase 2 already deleted the legacy `VulnerabilityAsset*`/`VulnerabilityEpisodeRiskAssessment` chain. Phase 3 therefore introduces the canonical exposure entities from a clean slate — there are **no legacy deletions** in Phase 3.
+
+---
+
+## Preflight
+
+- [ ] **Step P1: Verify Phase 2 merged**
+
+Run: `git log --oneline main -20`
+Expected: Phase 2 merge commit present.
+
+- [ ] **Step P2: Create Phase 3 branch**
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b data-model-canonical-cleanup-phase-3
+```
+
+- [ ] **Step P3: Drop + recreate dev database**
+
+```bash
+PGPASSWORD=patchhound psql -h localhost -U patchhound -d postgres -c "DROP DATABASE IF EXISTS patchhound;"
+PGPASSWORD=patchhound psql -h localhost -U patchhound -d postgres -c "CREATE DATABASE patchhound;"
+```
+
+- [ ] **Step P4: Baseline green**
+
+```bash
+dotnet build && dotnet test
+cd web && npm run typecheck && npm test -- --run && cd ..
+```
+
+---
+
+## Task 1: Add `DeviceVulnerabilityExposure` tenant-scoped entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/DeviceVulnerabilityExposure.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/DeviceVulnerabilityExposureConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs` (DbSet + query filter)
+- Test: `tests/PatchHound.Core.Tests/Entities/DeviceVulnerabilityExposureTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class DeviceVulnerabilityExposureTests
+{
+    [Fact]
+    public void Observe_sets_identity_tenant_and_firstseen()
+    {
+        var tenantId = Guid.NewGuid();
+        var deviceId = Guid.NewGuid();
+        var vulnId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var installedId = Guid.NewGuid();
+
+        var e = DeviceVulnerabilityExposure.Observe(
+            tenantId, deviceId, vulnId, productId, installedId,
+            matchedVersion: "1.2.3", matchSource: ExposureMatchSource.Product,
+            observedAt: new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero));
+
+        Assert.NotEqual(Guid.Empty, e.Id);
+        Assert.Equal(tenantId, e.TenantId);
+        Assert.Equal(deviceId, e.DeviceId);
+        Assert.Equal(vulnId, e.VulnerabilityId);
+        Assert.Equal(productId, e.SoftwareProductId);
+        Assert.Equal(installedId, e.InstalledSoftwareId);
+        Assert.Equal("1.2.3", e.MatchedVersion);
+        Assert.Equal(ExposureMatchSource.Product, e.MatchSource);
+        Assert.Equal(ExposureStatus.Open, e.Status);
+        Assert.Equal(new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero), e.FirstObservedAt);
+        Assert.Equal(e.FirstObservedAt, e.LastObservedAt);
+    }
+
+    [Fact]
+    public void Reobserve_bumps_LastObservedAt_but_not_FirstObservedAt()
+    {
+        var e = DeviceVulnerabilityExposure.Observe(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), null, Guid.NewGuid(),
+            "1.0", ExposureMatchSource.Cpe, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        var first = e.FirstObservedAt;
+
+        e.Reobserve(new DateTimeOffset(2026, 4, 9, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal(first, e.FirstObservedAt);
+        Assert.Equal(new DateTimeOffset(2026, 4, 9, 0, 0, 0, TimeSpan.Zero), e.LastObservedAt);
+    }
+
+    [Fact]
+    public void Resolve_sets_status_resolved_and_ResolvedAt()
+    {
+        var e = DeviceVulnerabilityExposure.Observe(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), null, Guid.NewGuid(),
+            "1.0", ExposureMatchSource.Cpe, DateTimeOffset.UtcNow);
+
+        e.Resolve(new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal(ExposureStatus.Resolved, e.Status);
+        Assert.Equal(new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero), e.ResolvedAt);
+    }
+
+    [Fact]
+    public void Reopen_clears_ResolvedAt_and_flips_back_to_Open()
+    {
+        var e = DeviceVulnerabilityExposure.Observe(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), null, Guid.NewGuid(),
+            "1.0", ExposureMatchSource.Cpe, DateTimeOffset.UtcNow);
+        e.Resolve(DateTimeOffset.UtcNow);
+
+        e.Reopen(new DateTimeOffset(2026, 4, 20, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal(ExposureStatus.Open, e.Status);
+        Assert.Null(e.ResolvedAt);
+        Assert.Equal(new DateTimeOffset(2026, 4, 20, 0, 0, 0, TimeSpan.Zero), e.LastObservedAt);
+    }
+}
+```
+
+- [ ] **Step 2: Add enums**
+
+In `src/PatchHound.Core/Enums/` add:
+
+```csharp
+namespace PatchHound.Core.Enums;
+
+public enum ExposureStatus
+{
+    Open = 0,
+    Resolved = 1,
+}
+
+public enum ExposureMatchSource
+{
+    Product = 0,  // Matched via VulnerabilityApplicability.SoftwareProductId
+    Cpe = 1,      // Matched via VulnerabilityApplicability.CpeCriteria fallback
+}
+```
+
+Put them in `ExposureStatus.cs` and `ExposureMatchSource.cs` files respectively.
+
+- [ ] **Step 3: Create entity**
+
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class DeviceVulnerabilityExposure
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid DeviceId { get; private set; }
+    public Guid VulnerabilityId { get; private set; }
+    public Guid? SoftwareProductId { get; private set; }
+    public Guid InstalledSoftwareId { get; private set; }
+    public string MatchedVersion { get; private set; } = null!;
+    public ExposureMatchSource MatchSource { get; private set; }
+    public ExposureStatus Status { get; private set; }
+    public DateTimeOffset FirstObservedAt { get; private set; }
+    public DateTimeOffset LastObservedAt { get; private set; }
+    public DateTimeOffset? ResolvedAt { get; private set; }
+
+    public Device Device { get; private set; } = null!;
+    public Vulnerability Vulnerability { get; private set; } = null!;
+    public SoftwareProduct? SoftwareProduct { get; private set; }
+    public InstalledSoftware InstalledSoftware { get; private set; } = null!;
+
+    private DeviceVulnerabilityExposure() { }
+
+    public static DeviceVulnerabilityExposure Observe(
+        Guid tenantId,
+        Guid deviceId,
+        Guid vulnerabilityId,
+        Guid? softwareProductId,
+        Guid installedSoftwareId,
+        string matchedVersion,
+        ExposureMatchSource matchSource,
+        DateTimeOffset observedAt)
+    {
+        if (tenantId == Guid.Empty) throw new ArgumentException(nameof(tenantId));
+        if (deviceId == Guid.Empty) throw new ArgumentException(nameof(deviceId));
+        if (vulnerabilityId == Guid.Empty) throw new ArgumentException(nameof(vulnerabilityId));
+        if (installedSoftwareId == Guid.Empty) throw new ArgumentException(nameof(installedSoftwareId));
+
+        return new DeviceVulnerabilityExposure
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            DeviceId = deviceId,
+            VulnerabilityId = vulnerabilityId,
+            SoftwareProductId = softwareProductId,
+            InstalledSoftwareId = installedSoftwareId,
+            MatchedVersion = matchedVersion ?? string.Empty,
+            MatchSource = matchSource,
+            Status = ExposureStatus.Open,
+            FirstObservedAt = observedAt,
+            LastObservedAt = observedAt,
+            ResolvedAt = null,
+        };
+    }
+
+    public void Reobserve(DateTimeOffset observedAt)
+    {
+        LastObservedAt = observedAt;
+        if (Status == ExposureStatus.Resolved)
+        {
+            Status = ExposureStatus.Open;
+            ResolvedAt = null;
+        }
+    }
+
+    public void Resolve(DateTimeOffset resolvedAt)
+    {
+        Status = ExposureStatus.Resolved;
+        ResolvedAt = resolvedAt;
+    }
+
+    public void Reopen(DateTimeOffset observedAt)
+    {
+        Status = ExposureStatus.Open;
+        ResolvedAt = null;
+        LastObservedAt = observedAt;
+    }
+}
+```
+
+- [ ] **Step 4: Tests pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeviceVulnerabilityExposureTests"` — PASS.
+
+- [ ] **Step 5: EF configuration with query filter**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class DeviceVulnerabilityExposureConfiguration : IEntityTypeConfiguration<DeviceVulnerabilityExposure>
+{
+    public void Configure(EntityTypeBuilder<DeviceVulnerabilityExposure> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.MatchedVersion).IsRequired().HasMaxLength(128);
+        builder.Property(e => e.Status).HasConversion<string>().HasMaxLength(16);
+        builder.Property(e => e.MatchSource).HasConversion<string>().HasMaxLength(16);
+
+        builder.HasOne(e => e.Device)
+            .WithMany()
+            .HasForeignKey(e => e.DeviceId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(e => e.Vulnerability)
+            .WithMany()
+            .HasForeignKey(e => e.VulnerabilityId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(e => e.SoftwareProduct)
+            .WithMany()
+            .HasForeignKey(e => e.SoftwareProductId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(e => e.InstalledSoftware)
+            .WithMany()
+            .HasForeignKey(e => e.InstalledSoftwareId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(e => new { e.TenantId, e.DeviceId, e.VulnerabilityId }).IsUnique();
+        builder.HasIndex(e => new { e.TenantId, e.VulnerabilityId });
+        builder.HasIndex(e => new { e.TenantId, e.Status });
+    }
+}
+```
+
+- [ ] **Step 6: Register DbSet + query filter**
+
+In `PatchHoundDbContext`:
+
+```csharp
+public DbSet<DeviceVulnerabilityExposure> DeviceVulnerabilityExposures => Set<DeviceVulnerabilityExposure>();
+```
+
+In `OnModelCreating`, add (near other canonical tenant filters):
+
+```csharp
+modelBuilder.Entity<DeviceVulnerabilityExposure>()
+    .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+```
+
+- [ ] **Step 7: Build + commit**
+
+```bash
+dotnet build
+git add src/PatchHound.Core/Entities/DeviceVulnerabilityExposure.cs \
+        src/PatchHound.Core/Enums/ExposureStatus.cs \
+        src/PatchHound.Core/Enums/ExposureMatchSource.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/DeviceVulnerabilityExposureConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/DeviceVulnerabilityExposureTests.cs
+git commit -m "feat(phase-3): add DeviceVulnerabilityExposure tenant-scoped entity"
+```
+
+---
+
+## Task 2: Add `ExposureEpisode` tenant-scoped entity
+
+An episode captures a single Open → Resolved interval for an exposure. When an exposure is reopened, a new episode row is created.
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/ExposureEpisode.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/ExposureEpisodeConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Core.Tests/Entities/ExposureEpisodeTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class ExposureEpisodeTests
+{
+    [Fact]
+    public void Open_creates_first_episode()
+    {
+        var tenantId = Guid.NewGuid();
+        var exposureId = Guid.NewGuid();
+        var openedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ep = ExposureEpisode.Open(tenantId, exposureId, episodeNumber: 1, openedAt);
+
+        Assert.Equal(tenantId, ep.TenantId);
+        Assert.Equal(exposureId, ep.DeviceVulnerabilityExposureId);
+        Assert.Equal(1, ep.EpisodeNumber);
+        Assert.Equal(openedAt, ep.OpenedAt);
+        Assert.Null(ep.ClosedAt);
+    }
+
+    [Fact]
+    public void Close_sets_ClosedAt()
+    {
+        var ep = ExposureEpisode.Open(Guid.NewGuid(), Guid.NewGuid(), 1, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        var closedAt = new DateTimeOffset(2026, 4, 5, 0, 0, 0, TimeSpan.Zero);
+
+        ep.Close(closedAt);
+
+        Assert.Equal(closedAt, ep.ClosedAt);
+    }
+
+    [Fact]
+    public void Close_on_already_closed_episode_throws()
+    {
+        var ep = ExposureEpisode.Open(Guid.NewGuid(), Guid.NewGuid(), 1, DateTimeOffset.UtcNow);
+        ep.Close(DateTimeOffset.UtcNow);
+        Assert.Throws<InvalidOperationException>(() => ep.Close(DateTimeOffset.UtcNow));
+    }
+}
+```
+
+- [ ] **Step 2: Create entity**
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class ExposureEpisode
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid DeviceVulnerabilityExposureId { get; private set; }
+    public int EpisodeNumber { get; private set; }
+    public DateTimeOffset OpenedAt { get; private set; }
+    public DateTimeOffset? ClosedAt { get; private set; }
+
+    public DeviceVulnerabilityExposure Exposure { get; private set; } = null!;
+
+    private ExposureEpisode() { }
+
+    public static ExposureEpisode Open(Guid tenantId, Guid exposureId, int episodeNumber, DateTimeOffset openedAt)
+    {
+        if (tenantId == Guid.Empty) throw new ArgumentException(nameof(tenantId));
+        if (exposureId == Guid.Empty) throw new ArgumentException(nameof(exposureId));
+        if (episodeNumber < 1) throw new ArgumentOutOfRangeException(nameof(episodeNumber));
+
+        return new ExposureEpisode
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            DeviceVulnerabilityExposureId = exposureId,
+            EpisodeNumber = episodeNumber,
+            OpenedAt = openedAt,
+            ClosedAt = null,
+        };
+    }
+
+    public void Close(DateTimeOffset closedAt)
+    {
+        if (ClosedAt is not null) throw new InvalidOperationException("Episode already closed.");
+        ClosedAt = closedAt;
+    }
+}
+```
+
+- [ ] **Step 3: Test passes**
+
+- [ ] **Step 4: EF configuration**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class ExposureEpisodeConfiguration : IEntityTypeConfiguration<ExposureEpisode>
+{
+    public void Configure(EntityTypeBuilder<ExposureEpisode> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.HasOne(e => e.Exposure)
+            .WithMany()
+            .HasForeignKey(e => e.DeviceVulnerabilityExposureId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => new { e.TenantId, e.DeviceVulnerabilityExposureId, e.EpisodeNumber }).IsUnique();
+    }
+}
+```
+
+Register DbSet + query filter in `PatchHoundDbContext`:
+
+```csharp
+public DbSet<ExposureEpisode> ExposureEpisodes => Set<ExposureEpisode>();
+
+modelBuilder.Entity<ExposureEpisode>()
+    .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/ExposureEpisode.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/ExposureEpisodeConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/ExposureEpisodeTests.cs
+git commit -m "feat(phase-3): add ExposureEpisode tenant-scoped entity"
+```
+
+---
+
+## Task 3: Add `ExposureAssessment` tenant-scoped entity
+
+Environmental-severity assessment for a single exposure, keyed by `DeviceVulnerabilityExposureId`. Carries the `SecurityProfileId` that produced the environmental modifiers (spec §4.3).
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/ExposureAssessment.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/ExposureAssessmentConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+- Test: `tests/PatchHound.Core.Tests/Entities/ExposureAssessmentTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Core.Tests.Entities;
+
+public class ExposureAssessmentTests
+{
+    [Fact]
+    public void Create_captures_score_reason_and_profile()
+    {
+        var tenantId = Guid.NewGuid();
+        var exposureId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+
+        var a = ExposureAssessment.Create(
+            tenantId, exposureId, profileId,
+            baseCvss: 7.5m,
+            environmentalCvss: 8.2m,
+            reason: "InternetFacing + HighConfidentiality",
+            calculatedAt: new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal(tenantId, a.TenantId);
+        Assert.Equal(exposureId, a.DeviceVulnerabilityExposureId);
+        Assert.Equal(profileId, a.SecurityProfileId);
+        Assert.Equal(7.5m, a.BaseCvss);
+        Assert.Equal(8.2m, a.EnvironmentalCvss);
+        Assert.Equal(8.2m, a.Score);
+        Assert.Equal("InternetFacing + HighConfidentiality", a.Reason);
+        Assert.Equal(new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero), a.CalculatedAt);
+    }
+
+    [Fact]
+    public void Update_refreshes_score_and_CalculatedAt()
+    {
+        var a = ExposureAssessment.Create(Guid.NewGuid(), Guid.NewGuid(), null, 5m, 5m, "base", DateTimeOffset.UtcNow);
+        var original = a.CalculatedAt;
+        Thread.Sleep(5);
+        a.Update(baseCvss: 5m, environmentalCvss: 7.1m, reason: "updated", calculatedAt: DateTimeOffset.UtcNow);
+        Assert.Equal(7.1m, a.EnvironmentalCvss);
+        Assert.Equal("updated", a.Reason);
+        Assert.True(a.CalculatedAt > original);
+    }
+}
+```
+
+- [ ] **Step 2: Create entity**
+
+```csharp
+namespace PatchHound.Core.Entities;
+
+public class ExposureAssessment
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid DeviceVulnerabilityExposureId { get; private set; }
+    public Guid? SecurityProfileId { get; private set; }
+    public decimal BaseCvss { get; private set; }
+    public decimal EnvironmentalCvss { get; private set; }
+    public string Reason { get; private set; } = string.Empty;
+    public DateTimeOffset CalculatedAt { get; private set; }
+
+    public decimal Score => EnvironmentalCvss;
+
+    public DeviceVulnerabilityExposure Exposure { get; private set; } = null!;
+    public SecurityProfile? SecurityProfile { get; private set; }
+
+    private ExposureAssessment() { }
+
+    public static ExposureAssessment Create(
+        Guid tenantId,
+        Guid exposureId,
+        Guid? securityProfileId,
+        decimal baseCvss,
+        decimal environmentalCvss,
+        string reason,
+        DateTimeOffset calculatedAt)
+    {
+        if (tenantId == Guid.Empty) throw new ArgumentException(nameof(tenantId));
+        if (exposureId == Guid.Empty) throw new ArgumentException(nameof(exposureId));
+        return new ExposureAssessment
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            DeviceVulnerabilityExposureId = exposureId,
+            SecurityProfileId = securityProfileId,
+            BaseCvss = baseCvss,
+            EnvironmentalCvss = environmentalCvss,
+            Reason = reason ?? string.Empty,
+            CalculatedAt = calculatedAt,
+        };
+    }
+
+    public void Update(decimal baseCvss, decimal environmentalCvss, string reason, DateTimeOffset calculatedAt)
+    {
+        BaseCvss = baseCvss;
+        EnvironmentalCvss = environmentalCvss;
+        Reason = reason ?? string.Empty;
+        CalculatedAt = calculatedAt;
+    }
+}
+```
+
+- [ ] **Step 3: Test passes**
+
+- [ ] **Step 4: EF configuration**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class ExposureAssessmentConfiguration : IEntityTypeConfiguration<ExposureAssessment>
+{
+    public void Configure(EntityTypeBuilder<ExposureAssessment> builder)
+    {
+        builder.HasKey(a => a.Id);
+        builder.Property(a => a.BaseCvss).HasColumnType("numeric(4,2)");
+        builder.Property(a => a.EnvironmentalCvss).HasColumnType("numeric(4,2)");
+        builder.Property(a => a.Reason).HasMaxLength(512);
+
+        builder.HasOne(a => a.Exposure)
+            .WithMany()
+            .HasForeignKey(a => a.DeviceVulnerabilityExposureId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(a => a.SecurityProfile)
+            .WithMany()
+            .HasForeignKey(a => a.SecurityProfileId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.Ignore(a => a.Score); // computed property
+        builder.HasIndex(a => new { a.TenantId, a.DeviceVulnerabilityExposureId }).IsUnique();
+    }
+}
+```
+
+Register DbSet + filter in `PatchHoundDbContext`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/ExposureAssessment.cs \
+        src/PatchHound.Infrastructure/Data/Configurations/ExposureAssessmentConfiguration.cs \
+        src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs \
+        tests/PatchHound.Core.Tests/Entities/ExposureAssessmentTests.cs
+git commit -m "feat(phase-3): add ExposureAssessment tenant-scoped entity"
+```
+
+---
+
+## Task 4: `ExposureDerivationService` — match `InstalledSoftware` × `VulnerabilityApplicability`
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs`
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/ExposureDerivationServiceTests.cs`
+
+- [ ] **Step 1: Write failing test — product-keyed match**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.Testing;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class ExposureDerivationServiceTests
+{
+    [Fact]
+    public async Task Derives_exposure_for_product_keyed_applicability()
+    {
+        await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+
+        // Seed global: SoftwareProduct + Vulnerability + product-keyed applicability
+        var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", null);
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-7001", "t", "d", Severity.High, 7.5m, "v", DateTimeOffset.UtcNow);
+        db.SoftwareProducts.Add(product);
+        db.Vulnerabilities.Add(vuln);
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, softwareProductId: product.Id, cpeCriteria: null,
+            vulnerable: true, null, null, null, null));
+
+        // Seed tenant: Device + InstalledSoftware for the product
+        var sourceSystem = SourceSystem.Create("test-source", "Test", true);
+        db.SourceSystems.Add(sourceSystem);
+        var device = Device.Create(tenantId, sourceSystem.Id, "dev-1", "Device 1");
+        db.Devices.Add(device);
+        var installed = InstalledSoftware.Observe(
+            tenantId, device.Id, product.Id, sourceSystem.Id,
+            observedVersion: "1.2.3",
+            observedAt: DateTimeOffset.UtcNow);
+        db.InstalledSoftware.Add(installed);
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance);
+        var result = await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var exposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+        Assert.Single(exposures);
+        Assert.Equal(device.Id, exposures[0].DeviceId);
+        Assert.Equal(vuln.Id, exposures[0].VulnerabilityId);
+        Assert.Equal(product.Id, exposures[0].SoftwareProductId);
+        Assert.Equal(ExposureMatchSource.Product, exposures[0].MatchSource);
+        Assert.Equal("1.2.3", exposures[0].MatchedVersion);
+        Assert.Equal(1, result.Inserted);
+        Assert.Equal(0, result.Reobserved);
+        Assert.Equal(0, result.Resolved);
+    }
+
+    [Fact]
+    public async Task Re_deriving_same_state_reobserves_without_duplicating()
+    {
+        await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        SeedProductKeyedExposure(db, tenantId);
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance);
+        await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+        await db.SaveChangesAsync();
+        await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow.AddMinutes(5), CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var exposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+        Assert.Single(exposures);
+        Assert.True(exposures[0].LastObservedAt > exposures[0].FirstObservedAt);
+    }
+
+    [Fact]
+    public async Task Resolves_exposure_when_InstalledSoftware_row_is_missing_on_next_derive()
+    {
+        await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var (product, vuln, device, installed) = SeedProductKeyedExposure(db, tenantId);
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance);
+        await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        // Software uninstalled: remove InstalledSoftware row
+        db.InstalledSoftware.Remove(installed);
+        await db.SaveChangesAsync();
+
+        var resolvedAt = DateTimeOffset.UtcNow.AddHours(1);
+        await svc.DeriveForTenantAsync(tenantId, resolvedAt, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var exposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+        Assert.Single(exposures);
+        Assert.Equal(ExposureStatus.Resolved, exposures[0].Status);
+        Assert.Equal(resolvedAt, exposures[0].ResolvedAt);
+    }
+
+    [Fact]
+    public async Task CPE_fallback_match_for_applicability_without_SoftwareProductId()
+    {
+        await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*");
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-7002", "t", "d", Severity.Critical, 9.5m, "v", DateTimeOffset.UtcNow);
+        db.SoftwareProducts.Add(product);
+        db.Vulnerabilities.Add(vuln);
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, softwareProductId: null,
+            cpeCriteria: "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*",
+            vulnerable: true, null, null, null, null));
+
+        var src = SourceSystem.Create("test", "Test", true);
+        db.SourceSystems.Add(src);
+        var device = Device.Create(tenantId, src.Id, "dev-1", "Device");
+        db.Devices.Add(device);
+        db.InstalledSoftware.Add(InstalledSoftware.Observe(tenantId, device.Id, product.Id, src.Id, "1.0", DateTimeOffset.UtcNow));
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance);
+        await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var e = await db.DeviceVulnerabilityExposures.SingleAsync();
+        Assert.Equal(ExposureMatchSource.Cpe, e.MatchSource);
+    }
+
+    private static (SoftwareProduct, Vulnerability, Device, InstalledSoftware) SeedProductKeyedExposure(
+        Data.PatchHoundDbContext db, Guid tenantId)
+    {
+        var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", null);
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-SEED", "t", "d", Severity.High, 7m, "v", DateTimeOffset.UtcNow);
+        db.SoftwareProducts.Add(product);
+        db.Vulnerabilities.Add(vuln);
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, product.Id, null, true, null, null, null, null));
+
+        var src = SourceSystem.Create("test", "Test", true);
+        db.SourceSystems.Add(src);
+        var device = Device.Create(tenantId, src.Id, "dev-seed", "Seed");
+        db.Devices.Add(device);
+        var inst = InstalledSoftware.Observe(tenantId, device.Id, product.Id, src.Id, "1.2.3", DateTimeOffset.UtcNow);
+        db.InstalledSoftware.Add(inst);
+        return (product, vuln, device, inst);
+    }
+}
+```
+
+Run: FAIL (service not defined).
+
+- [ ] **Step 2: Implement `ExposureDerivationService`**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public record ExposureDerivationResult(int Inserted, int Reobserved, int Resolved);
+
+public class ExposureDerivationService
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly ILogger<ExposureDerivationService> _logger;
+
+    public ExposureDerivationService(PatchHoundDbContext db, ILogger<ExposureDerivationService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<ExposureDerivationResult> DeriveForTenantAsync(
+        Guid tenantId, DateTimeOffset observedAt, CancellationToken ct)
+    {
+        // Step 1: load current InstalledSoftware for the tenant
+        var installs = await _db.InstalledSoftware
+            .Where(i => i.TenantId == tenantId)
+            .Select(i => new
+            {
+                i.Id,
+                i.DeviceId,
+                i.SoftwareProductId,
+                i.ObservedVersion,
+                ProductCpe = i.SoftwareProduct.PrimaryCpe23Uri,
+            })
+            .ToListAsync(ct);
+
+        if (installs.Count == 0)
+        {
+            return await ResolveStaleExposuresAsync(tenantId, Array.Empty<(Guid DeviceId, Guid VulnerabilityId)>(), observedAt, ct);
+        }
+
+        var productIds = installs.Select(i => i.SoftwareProductId).Distinct().ToList();
+
+        // Step 2: all vulnerability applicabilities matching any installed product (by ID)
+        var productApps = await _db.VulnerabilityApplicabilities
+            .Where(a => a.SoftwareProductId != null && productIds.Contains(a.SoftwareProductId!.Value) && a.Vulnerable)
+            .Select(a => new
+            {
+                a.Id, a.VulnerabilityId, a.SoftwareProductId,
+                a.VersionStartIncluding, a.VersionStartExcluding, a.VersionEndIncluding, a.VersionEndExcluding,
+            })
+            .ToListAsync(ct);
+
+        // Step 3: CPE fallback — applicabilities with no product ID but CPE criteria equal to product's primary CPE
+        var cpeList = installs
+            .Where(i => !string.IsNullOrWhiteSpace(i.ProductCpe))
+            .Select(i => i.ProductCpe!)
+            .Distinct()
+            .ToList();
+
+        var cpeApps = await _db.VulnerabilityApplicabilities
+            .Where(a => a.SoftwareProductId == null
+                     && a.CpeCriteria != null
+                     && cpeList.Contains(a.CpeCriteria)
+                     && a.Vulnerable)
+            .Select(a => new
+            {
+                a.Id, a.VulnerabilityId, a.CpeCriteria,
+                a.VersionStartIncluding, a.VersionStartExcluding, a.VersionEndIncluding, a.VersionEndExcluding,
+            })
+            .ToListAsync(ct);
+
+        // Step 4: build the current (DeviceId, VulnerabilityId) set and track match metadata
+        var currentExposures = new Dictionary<(Guid DeviceId, Guid VulnerabilityId), (Guid InstalledSoftwareId, Guid? ProductId, ExposureMatchSource Source, string MatchedVersion)>();
+
+        foreach (var install in installs)
+        {
+            foreach (var app in productApps.Where(a => a.SoftwareProductId == install.SoftwareProductId))
+            {
+                if (!VersionRangeIncludes(install.ObservedVersion,
+                    app.VersionStartIncluding, app.VersionStartExcluding,
+                    app.VersionEndIncluding, app.VersionEndExcluding)) continue;
+
+                var key = (install.DeviceId, app.VulnerabilityId);
+                if (currentExposures.ContainsKey(key)) continue;
+                currentExposures[key] = (install.Id, install.SoftwareProductId, ExposureMatchSource.Product, install.ObservedVersion ?? string.Empty);
+            }
+
+            if (install.ProductCpe is not null)
+            {
+                foreach (var app in cpeApps.Where(a => a.CpeCriteria == install.ProductCpe))
+                {
+                    if (!VersionRangeIncludes(install.ObservedVersion,
+                        app.VersionStartIncluding, app.VersionStartExcluding,
+                        app.VersionEndIncluding, app.VersionEndExcluding)) continue;
+
+                    var key = (install.DeviceId, app.VulnerabilityId);
+                    if (currentExposures.ContainsKey(key)) continue;
+                    currentExposures[key] = (install.Id, install.SoftwareProductId, ExposureMatchSource.Cpe, install.ObservedVersion ?? string.Empty);
+                }
+            }
+        }
+
+        // Step 5: upsert each current exposure
+        var existing = await _db.DeviceVulnerabilityExposures
+            .Where(e => e.TenantId == tenantId)
+            .ToDictionaryAsync(e => (e.DeviceId, e.VulnerabilityId), ct);
+
+        int inserted = 0, reobserved = 0, resolved = 0;
+        foreach (var kv in currentExposures)
+        {
+            if (existing.TryGetValue(kv.Key, out var e))
+            {
+                e.Reobserve(observedAt);
+                reobserved++;
+            }
+            else
+            {
+                var fresh = DeviceVulnerabilityExposure.Observe(
+                    tenantId, kv.Key.DeviceId, kv.Key.VulnerabilityId,
+                    kv.Value.ProductId, kv.Value.InstalledSoftwareId,
+                    kv.Value.MatchedVersion, kv.Value.Source, observedAt);
+                _db.DeviceVulnerabilityExposures.Add(fresh);
+                inserted++;
+            }
+        }
+
+        // Step 6: resolve exposures no longer in the current set
+        foreach (var kv in existing)
+        {
+            if (currentExposures.ContainsKey(kv.Key)) continue;
+            if (kv.Value.Status == ExposureStatus.Resolved) continue;
+            kv.Value.Resolve(observedAt);
+            resolved++;
+        }
+
+        _logger.LogInformation(
+            "Exposure derivation for tenant {TenantId}: inserted={Inserted} reobserved={Reobserved} resolved={Resolved}",
+            tenantId, inserted, reobserved, resolved);
+
+        return new ExposureDerivationResult(inserted, reobserved, resolved);
+    }
+
+    private Task<ExposureDerivationResult> ResolveStaleExposuresAsync(
+        Guid tenantId, IReadOnlyCollection<(Guid, Guid)> current, DateTimeOffset observedAt, CancellationToken ct)
+    {
+        // Fallback path when tenant has no InstalledSoftware at all.
+        return Task.FromResult(new ExposureDerivationResult(0, 0, 0));
+    }
+
+    /// <summary>
+    /// CPE-style version range check. Returns true if <paramref name="observedVersion"/> falls inside
+    /// the (start, end] range. Empty bounds are unbounded.
+    /// </summary>
+    private static bool VersionRangeIncludes(
+        string? observedVersion,
+        string? startIncluding, string? startExcluding,
+        string? endIncluding, string? endExcluding)
+    {
+        if (string.IsNullOrWhiteSpace(observedVersion)) return true; // unknown version = always matches
+        var observed = TryParseVersion(observedVersion);
+        if (observed is null) return true;
+
+        if (!string.IsNullOrWhiteSpace(startIncluding) && TryParseVersion(startIncluding) is Version si && observed < si) return false;
+        if (!string.IsNullOrWhiteSpace(startExcluding) && TryParseVersion(startExcluding) is Version se && observed <= se) return false;
+        if (!string.IsNullOrWhiteSpace(endIncluding) && TryParseVersion(endIncluding) is Version ei && observed > ei) return false;
+        if (!string.IsNullOrWhiteSpace(endExcluding) && TryParseVersion(endExcluding) is Version ee && observed >= ee) return false;
+
+        return true;
+    }
+
+    private static Version? TryParseVersion(string s) =>
+        Version.TryParse(s.Trim(), out var v) ? v : null;
+}
+```
+
+- [ ] **Step 3: Register in DI**
+
+```csharp
+services.AddScoped<ExposureDerivationService>();
+```
+
+- [ ] **Step 4: Tests pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~ExposureDerivationServiceTests"` — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/ExposureDerivationServiceTests.cs
+git commit -m "feat(phase-3): add ExposureDerivationService with product + CPE matching"
+```
+
+---
+
+## Task 5: `ExposureEpisodeService` — manage episode lifecycle
+
+This service observes status transitions on `DeviceVulnerabilityExposure` and creates/closes `ExposureEpisode` rows. It is called immediately after `ExposureDerivationService` on the same SaveChanges cycle.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/ExposureEpisodeService.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/ExposureEpisodeServiceTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+[Fact]
+public async Task Opens_episode_1_on_first_observation()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    var exposure = SeedOpenExposure(db, tenantId, DateTimeOffset.UtcNow);
+    await db.SaveChangesAsync();
+
+    var svc = new ExposureEpisodeService(db);
+    await svc.SyncEpisodesForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    var episodes = await db.ExposureEpisodes.Where(e => e.DeviceVulnerabilityExposureId == exposure.Id).ToListAsync();
+    Assert.Single(episodes);
+    Assert.Equal(1, episodes[0].EpisodeNumber);
+    Assert.Null(episodes[0].ClosedAt);
+}
+
+[Fact]
+public async Task Closes_open_episode_when_exposure_resolves()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    var exposure = SeedOpenExposure(db, tenantId, DateTimeOffset.UtcNow);
+    await db.SaveChangesAsync();
+
+    var svc = new ExposureEpisodeService(db);
+    await svc.SyncEpisodesForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    exposure.Resolve(new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero));
+    await db.SaveChangesAsync();
+
+    await svc.SyncEpisodesForTenantAsync(tenantId, new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero), CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    var episodes = await db.ExposureEpisodes.ToListAsync();
+    Assert.Single(episodes);
+    Assert.NotNull(episodes[0].ClosedAt);
+    Assert.Equal(new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero), episodes[0].ClosedAt);
+}
+
+[Fact]
+public async Task Opens_new_episode_when_exposure_reopens_after_resolve()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    var exposure = SeedOpenExposure(db, tenantId, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+    await db.SaveChangesAsync();
+
+    var svc = new ExposureEpisodeService(db);
+    await svc.SyncEpisodesForTenantAsync(tenantId, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero), CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    exposure.Resolve(new DateTimeOffset(2026, 4, 5, 0, 0, 0, TimeSpan.Zero));
+    await db.SaveChangesAsync();
+    await svc.SyncEpisodesForTenantAsync(tenantId, new DateTimeOffset(2026, 4, 5, 0, 0, 0, TimeSpan.Zero), CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    exposure.Reobserve(new DateTimeOffset(2026, 4, 20, 0, 0, 0, TimeSpan.Zero));
+    await db.SaveChangesAsync();
+    await svc.SyncEpisodesForTenantAsync(tenantId, new DateTimeOffset(2026, 4, 20, 0, 0, 0, TimeSpan.Zero), CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    var episodes = await db.ExposureEpisodes.OrderBy(e => e.EpisodeNumber).ToListAsync();
+    Assert.Equal(2, episodes.Count);
+    Assert.Equal(1, episodes[0].EpisodeNumber);
+    Assert.NotNull(episodes[0].ClosedAt);
+    Assert.Equal(2, episodes[1].EpisodeNumber);
+    Assert.Null(episodes[1].ClosedAt);
+}
+```
+
+- [ ] **Step 2: Implement service**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class ExposureEpisodeService
+{
+    private readonly PatchHoundDbContext _db;
+
+    public ExposureEpisodeService(PatchHoundDbContext db) { _db = db; }
+
+    public async Task SyncEpisodesForTenantAsync(Guid tenantId, DateTimeOffset now, CancellationToken ct)
+    {
+        var exposures = await _db.DeviceVulnerabilityExposures
+            .Where(e => e.TenantId == tenantId)
+            .ToListAsync(ct);
+
+        var exposureIds = exposures.Select(e => e.Id).ToList();
+        var episodesByExposure = await _db.ExposureEpisodes
+            .Where(e => exposureIds.Contains(e.DeviceVulnerabilityExposureId))
+            .ToListAsync(ct);
+
+        var lookup = episodesByExposure
+            .GroupBy(e => e.DeviceVulnerabilityExposureId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(e => e.EpisodeNumber).ToList());
+
+        foreach (var exposure in exposures)
+        {
+            var episodes = lookup.TryGetValue(exposure.Id, out var list) ? list : new List<ExposureEpisode>();
+            var latest = episodes.FirstOrDefault();
+
+            if (exposure.Status == ExposureStatus.Open)
+            {
+                // Need an open episode.
+                if (latest is null || latest.ClosedAt is not null)
+                {
+                    var nextNumber = (latest?.EpisodeNumber ?? 0) + 1;
+                    _db.ExposureEpisodes.Add(ExposureEpisode.Open(tenantId, exposure.Id, nextNumber, exposure.LastObservedAt));
+                }
+            }
+            else // Resolved
+            {
+                if (latest is not null && latest.ClosedAt is null)
+                {
+                    latest.Close(exposure.ResolvedAt ?? now);
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Tests pass**
+
+- [ ] **Step 4: Register in DI**
+
+```csharp
+services.AddScoped<ExposureEpisodeService>();
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/ExposureEpisodeService.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/ExposureEpisodeServiceTests.cs
+git commit -m "feat(phase-3): add ExposureEpisodeService with open/close/reopen lifecycle"
+```
+
+---
+
+## Task 6: `ExposureAssessmentService` — environmental-severity computation
+
+Uses the **existing** `EnvironmentalSeverityCalculator` (renamed if necessary; it was left alive by Phase 1 as a pure function service). For each exposure, loads `Device.SecurityProfileId → SecurityProfile`, loads the vulnerability's base CVSS vector, computes the modified score, and upserts one `ExposureAssessment` row per exposure.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/ExposureAssessmentService.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/ExposureAssessmentServiceTests.cs`
+
+- [ ] **Step 1: Write failing test — assessment uses SecurityProfile modifiers**
+
+```csharp
+[Fact]
+public async Task Assessment_uses_security_profile_environmental_modifiers()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    var profile = SecurityProfile.Create(
+        tenantId, "Internet-facing",
+        description: "critical perimeter",
+        environmentClass: EnvironmentClass.Production,
+        internetReachability: InternetReachability.Public,
+        confidentialityRequirement: SecurityRequirementLevel.High,
+        integrityRequirement: SecurityRequirementLevel.High,
+        availabilityRequirement: SecurityRequirementLevel.High);
+    db.SecurityProfiles.Add(profile);
+
+    var src = SourceSystem.Create("test", "Test", true);
+    db.SourceSystems.Add(src);
+    var device = Device.Create(tenantId, src.Id, "dev-1", "Device");
+    device.AssignSecurityProfile(profile.Id);
+    db.Devices.Add(device);
+
+    var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", null);
+    db.SoftwareProducts.Add(product);
+    var vuln = Vulnerability.Create("nvd", "CVE-2026-ENV", "t", "d", Severity.Medium,
+        cvssScore: 5.0m,
+        cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        publishedDate: DateTimeOffset.UtcNow);
+    db.Vulnerabilities.Add(vuln);
+
+    var installed = InstalledSoftware.Observe(tenantId, device.Id, product.Id, src.Id, "1.0", DateTimeOffset.UtcNow);
+    db.InstalledSoftware.Add(installed);
+    var exposure = DeviceVulnerabilityExposure.Observe(
+        tenantId, device.Id, vuln.Id, product.Id, installed.Id, "1.0", ExposureMatchSource.Product, DateTimeOffset.UtcNow);
+    db.DeviceVulnerabilityExposures.Add(exposure);
+    await db.SaveChangesAsync();
+
+    var svc = new ExposureAssessmentService(db, new EnvironmentalSeverityCalculator());
+    await svc.AssessForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    var assessment = await db.ExposureAssessments.SingleAsync(a => a.DeviceVulnerabilityExposureId == exposure.Id);
+    Assert.Equal(profile.Id, assessment.SecurityProfileId);
+    Assert.Equal(5.0m, assessment.BaseCvss);
+    Assert.NotEqual(5.0m, assessment.EnvironmentalCvss); // must differ: High CIA requirements + internet-facing
+    Assert.Contains("Confidentiality", assessment.Reason, StringComparison.OrdinalIgnoreCase);
+}
+```
+
+- [ ] **Step 2: Implement service**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class ExposureAssessmentService
+{
+    private readonly PatchHoundDbContext _db;
+    private readonly EnvironmentalSeverityCalculator _calculator;
+
+    public ExposureAssessmentService(PatchHoundDbContext db, EnvironmentalSeverityCalculator calculator)
+    {
+        _db = db;
+        _calculator = calculator;
+    }
+
+    public async Task AssessForTenantAsync(Guid tenantId, DateTimeOffset calculatedAt, CancellationToken ct)
+    {
+        var exposures = await _db.DeviceVulnerabilityExposures
+            .Where(e => e.TenantId == tenantId)
+            .Include(e => e.Vulnerability)
+            .Include(e => e.Device)
+            .ToListAsync(ct);
+
+        var profileIds = exposures.Where(e => e.Device.SecurityProfileId is not null)
+                                  .Select(e => e.Device.SecurityProfileId!.Value).Distinct().ToList();
+        var profiles = await _db.SecurityProfiles
+            .Where(p => profileIds.Contains(p.Id))
+            .ToDictionaryAsync(p => p.Id, ct);
+
+        var existing = await _db.ExposureAssessments
+            .Where(a => a.TenantId == tenantId)
+            .ToDictionaryAsync(a => a.DeviceVulnerabilityExposureId, ct);
+
+        foreach (var exposure in exposures)
+        {
+            var baseCvss = exposure.Vulnerability.CvssScore ?? 0m;
+            var baseVector = exposure.Vulnerability.CvssVector;
+
+            SecurityProfile? profile = null;
+            if (exposure.Device.SecurityProfileId is { } pid && profiles.TryGetValue(pid, out var p))
+                profile = p;
+
+            var (envCvss, reason) = _calculator.Compute(baseCvss, baseVector, profile);
+
+            if (existing.TryGetValue(exposure.Id, out var a))
+            {
+                a.Update(baseCvss, envCvss, reason, calculatedAt);
+            }
+            else
+            {
+                _db.ExposureAssessments.Add(ExposureAssessment.Create(
+                    tenantId, exposure.Id, profile?.Id, baseCvss, envCvss, reason, calculatedAt));
+            }
+        }
+    }
+}
+```
+
+The `EnvironmentalSeverityCalculator.Compute(baseCvss, baseVector, profile)` returns `(decimal envCvss, string reason)`. **If** the existing calculator does not yet expose this exact signature, add an adapter method on the existing class that wraps whatever current `CalculateModified(…)` API it exposes and returns a short reason string that names the dominant modifier (e.g. `"High confidentiality requirement + Network attack vector"`). Keep the existing API intact so Phase 5 callers are unaffected.
+
+- [ ] **Step 3: Test passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ExposureAssessmentServiceTests"` — PASS.
+
+- [ ] **Step 4: Register in DI**
+
+```csharp
+services.AddScoped<ExposureAssessmentService>();
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/ExposureAssessmentService.cs \
+        src/PatchHound.Infrastructure/Services/EnvironmentalSeverityCalculator.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/ExposureAssessmentServiceTests.cs
+git commit -m "feat(phase-3): add ExposureAssessmentService using SecurityProfile env modifiers"
+```
+
+---
+
+## Task 7: **Hard-gate test** — environmental severity changes score non-trivially
+
+Spec §5.3 / §7 require a dedicated test that proves the environmental CVSS path is live: the same vulnerability against devices with different `SecurityProfile`s must produce different `ExposureAssessment.Score` values, and the reason string must reference the dominant environmental modifier.
+
+**Files:**
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/EnvironmentalSeverityHardGateTests.cs`
+
+- [ ] **Step 1: Write the hard-gate test**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.Testing;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class EnvironmentalSeverityHardGateTests
+{
+    [Fact]
+    public async Task Env_severity_differs_from_base_cvss_when_profile_raises_requirements()
+    {
+        await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+
+        // Profile A: internet-facing, HIGH CIA requirements
+        var profileA = SecurityProfile.Create(tenantId, "A", null,
+            EnvironmentClass.Production, InternetReachability.Public,
+            SecurityRequirementLevel.High, SecurityRequirementLevel.High, SecurityRequirementLevel.High);
+        db.SecurityProfiles.Add(profileA);
+
+        // Profile B: isolated, LOW CIA requirements
+        var profileB = SecurityProfile.Create(tenantId, "B", null,
+            EnvironmentClass.Development, InternetReachability.LocalOnly,
+            SecurityRequirementLevel.Low, SecurityRequirementLevel.Low, SecurityRequirementLevel.Low);
+        db.SecurityProfiles.Add(profileB);
+
+        var src = SourceSystem.Create("t", "T", true);
+        db.SourceSystems.Add(src);
+
+        var deviceA = Device.Create(tenantId, src.Id, "dev-A", "Internet-facing");
+        deviceA.AssignSecurityProfile(profileA.Id);
+        var deviceB = Device.Create(tenantId, src.Id, "dev-B", "Isolated");
+        deviceB.AssignSecurityProfile(profileB.Id);
+        db.Devices.AddRange(deviceA, deviceB);
+
+        var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", null);
+        db.SoftwareProducts.Add(product);
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-GATE",
+            "Env gate",
+            "Env gate",
+            Severity.Medium,
+            cvssScore: 5.0m,
+            cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            publishedDate: DateTimeOffset.UtcNow);
+        db.Vulnerabilities.Add(vuln);
+
+        var instA = InstalledSoftware.Observe(tenantId, deviceA.Id, product.Id, src.Id, "1.0", DateTimeOffset.UtcNow);
+        var instB = InstalledSoftware.Observe(tenantId, deviceB.Id, product.Id, src.Id, "1.0", DateTimeOffset.UtcNow);
+        db.InstalledSoftware.AddRange(instA, instB);
+
+        var exposureA = DeviceVulnerabilityExposure.Observe(tenantId, deviceA.Id, vuln.Id, product.Id, instA.Id, "1.0", ExposureMatchSource.Product, DateTimeOffset.UtcNow);
+        var exposureB = DeviceVulnerabilityExposure.Observe(tenantId, deviceB.Id, vuln.Id, product.Id, instB.Id, "1.0", ExposureMatchSource.Product, DateTimeOffset.UtcNow);
+        db.DeviceVulnerabilityExposures.AddRange(exposureA, exposureB);
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureAssessmentService(db, new EnvironmentalSeverityCalculator());
+        await svc.AssessForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        var assessmentA = await db.ExposureAssessments.SingleAsync(a => a.DeviceVulnerabilityExposureId == exposureA.Id);
+        var assessmentB = await db.ExposureAssessments.SingleAsync(a => a.DeviceVulnerabilityExposureId == exposureB.Id);
+
+        // Hard gate 1: profile A must raise the environmental CVSS above the base CVSS.
+        Assert.True(assessmentA.EnvironmentalCvss > assessmentA.BaseCvss,
+            $"Profile A env CVSS {assessmentA.EnvironmentalCvss} must exceed base {assessmentA.BaseCvss}");
+
+        // Hard gate 2: profile B must lower (or at least not raise) the environmental CVSS.
+        Assert.True(assessmentB.EnvironmentalCvss <= assessmentB.BaseCvss,
+            $"Profile B env CVSS {assessmentB.EnvironmentalCvss} must not exceed base {assessmentB.BaseCvss}");
+
+        // Hard gate 3: the two assessments must not be equal.
+        Assert.NotEqual(assessmentA.EnvironmentalCvss, assessmentB.EnvironmentalCvss);
+
+        // Hard gate 4: the reason strings must reference the dominant modifier.
+        Assert.False(string.IsNullOrWhiteSpace(assessmentA.Reason));
+        Assert.False(string.IsNullOrWhiteSpace(assessmentB.Reason));
+    }
+}
+```
+
+- [ ] **Step 2: Run — PASS**
+
+If the calculator does not currently raise env CVSS for High CIA requirements, fix the calculator — do not weaken the test. The hard gate is non-negotiable per spec §5.3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Infrastructure.Tests/Services/EnvironmentalSeverityHardGateTests.cs
+git commit -m "test(phase-3): env-severity hard-gate test blocks Phase 3 completion"
+```
+
+---
+
+## Task 8: Wire the derivation pipeline into `IngestionService`
+
+After Phase 1's `IngestionService` writes `Device` + `InstalledSoftware`, and Phase 2's enrichment runners populate `Vulnerability`/`VulnerabilityApplicability`, the Phase 3 pipeline runs three services per tenant in sequence:
+
+1. `ExposureDerivationService.DeriveForTenantAsync`
+2. `ExposureEpisodeService.SyncEpisodesForTenantAsync`
+3. `ExposureAssessmentService.AssessForTenantAsync`
+
+All under the tenant's normal request context (not system context), because all three write tenant-scoped rows.
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/IngestionServicePhase3Tests.cs`
+
+- [ ] **Step 1: Write an integration test**
+
+```csharp
+[Fact]
+public async Task IngestionService_run_end_to_end_produces_canonical_exposures_for_tenant()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    // Seed: one SoftwareProduct, one Vulnerability with applicability, one Device with InstalledSoftware
+    SeedFullTenantInventoryAndVulnerability(db, tenantId);
+    await db.SaveChangesAsync();
+
+    var ingestion = new IngestionService(
+        db,
+        new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance),
+        new ExposureEpisodeService(db),
+        new ExposureAssessmentService(db, new EnvironmentalSeverityCalculator()),
+        // ... other Phase 1 dependencies
+        NullLogger<IngestionService>.Instance);
+
+    await ingestion.RunExposureDerivationAsync(tenantId, CancellationToken.None);
+
+    Assert.NotEmpty(await db.DeviceVulnerabilityExposures.ToListAsync());
+    Assert.NotEmpty(await db.ExposureEpisodes.ToListAsync());
+    Assert.NotEmpty(await db.ExposureAssessments.ToListAsync());
+}
+```
+
+- [ ] **Step 2: Add `RunExposureDerivationAsync`**
+
+In `IngestionService`, add (or rename the existing exposure hook):
+
+```csharp
+public async Task RunExposureDerivationAsync(Guid tenantId, CancellationToken ct)
+{
+    var now = DateTimeOffset.UtcNow;
+    await _exposureDerivation.DeriveForTenantAsync(tenantId, now, ct);
+    await _db.SaveChangesAsync(ct);
+    await _exposureEpisodes.SyncEpisodesForTenantAsync(tenantId, now, ct);
+    await _db.SaveChangesAsync(ct);
+    await _exposureAssessments.AssessForTenantAsync(tenantId, now, ct);
+    await _db.SaveChangesAsync(ct);
+}
+```
+
+Call `RunExposureDerivationAsync` from the existing tenant-loop hook where legacy exposure derivation used to run (remove the legacy call in the same edit; it was removed in Phase 2 but the hook stub may still be there).
+
+- [ ] **Step 3: Test passes**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        tests/PatchHound.Infrastructure.Tests/Services/IngestionServicePhase3Tests.cs
+git commit -m "feat(phase-3): wire exposure derivation pipeline into IngestionService"
+```
+
+---
+
+## Task 9: Populate vulnerability list + detail affected-devices sections
+
+Replaces the Phase 2 empty stubs with real queries that read `DeviceVulnerabilityExposure` + `ExposureAssessment`.
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/VulnerabilityDetailQueryService.cs`
+- Modify: `src/PatchHound.Api/Controllers/VulnerabilitiesController.cs`
+- Modify: `src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDetailDto.cs` (add real shapes for affected devices)
+- Modify: `src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDto.cs` (set `ExposureDataAvailable = true`)
+- Test: `tests/PatchHound.Api.Tests/Services/VulnerabilityDetailQueryServicePhase3Tests.cs`
+
+- [ ] **Step 1: Update DTOs**
+
+Replace `IReadOnlyList<object> AffectedDevices` with:
+
+```csharp
+public record ExposureSectionDto(
+    bool DataAvailable,
+    string? DataAvailableReason,
+    IReadOnlyList<AffectedDeviceDto> AffectedDevices,
+    IReadOnlyList<ExposureEpisodeDto> ActiveEpisodes,
+    IReadOnlyList<ExposureEpisodeDto> ResolvedEpisodes);
+
+public record AffectedDeviceDto(
+    Guid DeviceId,
+    string DeviceName,
+    Guid? SoftwareProductId,
+    string? SoftwareProductName,
+    string? MatchedVersion,
+    string MatchSource,
+    string Status,
+    decimal? EnvironmentalCvss,
+    string? EnvironmentalReason,
+    DateTimeOffset FirstObservedAt,
+    DateTimeOffset LastObservedAt,
+    DateTimeOffset? ResolvedAt);
+
+public record ExposureEpisodeDto(
+    Guid EpisodeId, Guid ExposureId, int EpisodeNumber,
+    DateTimeOffset OpenedAt, DateTimeOffset? ClosedAt);
+```
+
+- [ ] **Step 2: Rewrite `VulnerabilityDetailQueryService.BuildAsync`**
+
+```csharp
+public async Task<VulnerabilityDetailDto?> BuildAsync(Guid tenantId, Guid vulnerabilityId, CancellationToken ct)
+{
+    var vuln = await _db.Vulnerabilities.AsNoTracking()
+        .FirstOrDefaultAsync(v => v.Id == vulnerabilityId, ct);
+    if (vuln is null) return null;
+
+    var references = await _db.VulnerabilityReferences.AsNoTracking()
+        .Where(r => r.VulnerabilityId == vulnerabilityId)
+        .ToListAsync(ct);
+
+    var applicabilities = await _db.VulnerabilityApplicabilities.AsNoTracking()
+        .Where(a => a.VulnerabilityId == vulnerabilityId)
+        .ToListAsync(ct);
+
+    var productIds = applicabilities
+        .Where(a => a.SoftwareProductId is not null)
+        .Select(a => a.SoftwareProductId!.Value).ToList();
+    var productNames = await _db.SoftwareProducts.AsNoTracking()
+        .Where(p => productIds.Contains(p.Id))
+        .ToDictionaryAsync(p => p.Id, p => p.Name, ct);
+
+    var threat = await _db.ThreatAssessments.AsNoTracking()
+        .FirstOrDefaultAsync(t => t.VulnerabilityId == vulnerabilityId, ct);
+
+    // Tenant-scoped exposure reads (query filter enforces tenant isolation).
+    var exposures = await _db.DeviceVulnerabilityExposures.AsNoTracking()
+        .Where(e => e.VulnerabilityId == vulnerabilityId)
+        .Join(_db.Devices.AsNoTracking(), e => e.DeviceId, d => d.Id, (e, d) => new { e, Device = d })
+        .ToListAsync(ct);
+
+    var exposureIds = exposures.Select(x => x.e.Id).ToList();
+    var assessments = await _db.ExposureAssessments.AsNoTracking()
+        .Where(a => exposureIds.Contains(a.DeviceVulnerabilityExposureId))
+        .ToDictionaryAsync(a => a.DeviceVulnerabilityExposureId, ct);
+    var episodes = await _db.ExposureEpisodes.AsNoTracking()
+        .Where(e => exposureIds.Contains(e.DeviceVulnerabilityExposureId))
+        .ToListAsync(ct);
+
+    var affected = exposures.Select(x =>
+    {
+        assessments.TryGetValue(x.e.Id, out var a);
+        var productName = x.e.SoftwareProductId is { } pid && productNames.TryGetValue(pid, out var pn) ? pn : null;
+        return new AffectedDeviceDto(
+            x.Device.Id, x.Device.Name,
+            x.e.SoftwareProductId, productName,
+            x.e.MatchedVersion,
+            x.e.MatchSource.ToString(),
+            x.e.Status.ToString(),
+            a?.EnvironmentalCvss,
+            a?.Reason,
+            x.e.FirstObservedAt, x.e.LastObservedAt, x.e.ResolvedAt);
+    }).ToList();
+
+    var activeEpisodes = episodes.Where(e => e.ClosedAt is null)
+        .Select(e => new ExposureEpisodeDto(e.Id, e.DeviceVulnerabilityExposureId, e.EpisodeNumber, e.OpenedAt, e.ClosedAt)).ToList();
+    var resolvedEpisodes = episodes.Where(e => e.ClosedAt is not null)
+        .Select(e => new ExposureEpisodeDto(e.Id, e.DeviceVulnerabilityExposureId, e.EpisodeNumber, e.OpenedAt, e.ClosedAt)).ToList();
+
+    return new VulnerabilityDetailDto(
+        vuln.Id, vuln.ExternalId, vuln.Source, vuln.Title, vuln.Description,
+        vuln.VendorSeverity.ToString(), vuln.CvssScore, vuln.CvssVector, vuln.PublishedDate,
+        references.Select(r => new VulnerabilityReferenceDto(r.Url, r.Source, r.GetTags())).ToList(),
+        applicabilities.Select(a => new VulnerabilityApplicabilityDto(
+            a.SoftwareProductId,
+            a.SoftwareProductId is not null && productNames.TryGetValue(a.SoftwareProductId.Value, out var n) ? n : null,
+            a.CpeCriteria, a.Vulnerable,
+            a.VersionStartIncluding, a.VersionStartExcluding,
+            a.VersionEndIncluding, a.VersionEndExcluding)).ToList(),
+        threat is null ? null : new ThreatAssessmentDto(threat.ThreatScore, threat.EpssScore, threat.KnownExploited, threat.PublicExploit, threat.ActiveAlert),
+        new ExposureSectionDto(
+            DataAvailable: true,
+            DataAvailableReason: null,
+            AffectedDevices: affected,
+            ActiveEpisodes: activeEpisodes,
+            ResolvedEpisodes: resolvedEpisodes));
+}
+```
+
+- [ ] **Step 3: Controller list — populate `AffectedDeviceCount`**
+
+In `VulnerabilitiesController.List`, the projected item becomes:
+
+```csharp
+.Select(v => new
+{
+    v.Id, v.ExternalId, v.Title,
+    Severity = v.VendorSeverity.ToString(),
+    v.Source, v.CvssScore, v.PublishedDate,
+    Threat = _dbContext.ThreatAssessments
+        .Where(a => a.VulnerabilityId == v.Id)
+        .Select(a => new { a.ThreatScore, a.EpssScore, a.PublicExploit, a.KnownExploited, a.ActiveAlert })
+        .FirstOrDefault(),
+    AffectedDeviceCount = _dbContext.DeviceVulnerabilityExposures
+        .Count(e => e.VulnerabilityId == v.Id && e.Status == ExposureStatus.Open),
+})
+```
+
+and the DTO construction sets `ExposureDataAvailable: true`.
+
+- [ ] **Step 4: Test**
+
+```csharp
+[Fact]
+public async Task BuildAsync_returns_affected_devices_from_tenant_exposures()
+{
+    // Seed one vuln + one exposure for tenant A. Assert AffectedDevices has 1 entry with
+    // DataAvailable == true and the device name populated.
+}
+
+[Fact]
+public async Task BuildAsync_never_returns_other_tenants_exposures()
+{
+    // Seed tenant B exposure on the same global vulnerability.
+    // Build with tenant A's context.
+    // Assert the only AffectedDevices entry is tenant A's.
+}
+```
+
+Run: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Api/Services/VulnerabilityDetailQueryService.cs \
+        src/PatchHound.Api/Controllers/VulnerabilitiesController.cs \
+        src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDetailDto.cs \
+        src/PatchHound.Api/Models/Vulnerabilities/VulnerabilityDto.cs \
+        tests/PatchHound.Api.Tests/Services/VulnerabilityDetailQueryServicePhase3Tests.cs
+git commit -m "feat(phase-3): populate vulnerability affected-devices section from canonical exposures"
+```
+
+---
+
+## Task 10: Device detail page — exposures tab
+
+**Files:**
+- Create: `src/PatchHound.Api/Controllers/DeviceExposuresController.cs` (or add endpoint to existing `DevicesController`)
+- Modify: `web/src/routes/devices/$deviceId.tsx` — add `Exposures` tab
+- Test: backend: `tests/PatchHound.Api.Tests/Controllers/DeviceExposuresControllerTests.cs`
+- Test: frontend: `web/src/routes/devices/__tests__/DeviceDetail.exposures.test.tsx`
+
+- [ ] **Step 1: Backend endpoint**
+
+Add `GET /api/devices/{deviceId}/exposures` on `DevicesController` (preferred; avoid a new controller):
+
+```csharp
+[HttpGet("{deviceId:guid}/exposures")]
+[Authorize(Policy = Policies.ViewDevices)]
+public async Task<ActionResult<PagedResponse<DeviceExposureDto>>> ListExposures(
+    Guid deviceId, [FromQuery] PaginationQuery pagination, CancellationToken ct)
+{
+    if (_tenantContext.CurrentTenantId is null)
+        return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+    var device = await _db.Devices.AsNoTracking()
+        .FirstOrDefaultAsync(d => d.Id == deviceId, ct);
+    if (device is null) return NotFound();
+    // tenant query filter already applied; if not visible, NotFound is correct.
+
+    var query = _db.DeviceVulnerabilityExposures.AsNoTracking()
+        .Where(e => e.DeviceId == deviceId);
+    var total = await query.CountAsync(ct);
+
+    var items = await query
+        .OrderByDescending(e => e.Status == ExposureStatus.Open)
+        .ThenByDescending(e => e.LastObservedAt)
+        .Skip(pagination.Skip)
+        .Take(pagination.BoundedPageSize)
+        .Select(e => new DeviceExposureDto(
+            e.Id,
+            e.VulnerabilityId,
+            e.Vulnerability.ExternalId,
+            e.Vulnerability.Title,
+            e.Vulnerability.VendorSeverity.ToString(),
+            e.MatchedVersion,
+            e.MatchSource.ToString(),
+            e.Status.ToString(),
+            e.FirstObservedAt,
+            e.LastObservedAt,
+            e.ResolvedAt,
+            _db.ExposureAssessments
+                .Where(a => a.DeviceVulnerabilityExposureId == e.Id)
+                .Select(a => (decimal?)a.EnvironmentalCvss)
+                .FirstOrDefault()))
+        .ToListAsync(ct);
+
+    return Ok(new PagedResponse<DeviceExposureDto>(items, total, pagination.Page, pagination.BoundedPageSize));
+}
+```
+
+```csharp
+public record DeviceExposureDto(
+    Guid ExposureId,
+    Guid VulnerabilityId,
+    string ExternalId,
+    string Title,
+    string Severity,
+    string MatchedVersion,
+    string MatchSource,
+    string Status,
+    DateTimeOffset FirstObservedAt,
+    DateTimeOffset LastObservedAt,
+    DateTimeOffset? ResolvedAt,
+    decimal? EnvironmentalCvss);
+```
+
+- [ ] **Step 2: Backend test**
+
+```csharp
+[Fact]
+public async Task ListExposures_returns_tenant_scoped_exposures_for_device()
+{
+    // Seed two tenants each with one device and one exposure.
+    // Assert tenant A sees only tenant A's exposure for tenant A's device.
+    // Assert tenant A gets 404 when requesting tenant B's device ID.
+}
+```
+
+- [ ] **Step 3: Frontend Exposures tab**
+
+Add an `Exposures` tab on the device detail route. Render columns: CVE, Severity, Matched version, Status, Environmental CVSS, First observed, Last observed. Empty state: "No exposures observed for this device."
+
+- [ ] **Step 4: Frontend test**
+
+```ts
+it('renders exposures list with environmental cvss column', async () => {
+  mockApi({ items: [{ exposureId: 'e1', externalId: 'CVE-2026-1', title: 'T', severity: 'High', matchedVersion: '1.0', matchSource: 'Product', status: 'Open', environmentalCvss: 8.2, firstObservedAt: '...', lastObservedAt: '...' }] });
+  render(<DeviceDetail id="dev-1" initialTab="exposures" />);
+  expect(await screen.findByText('CVE-2026-1')).toBeInTheDocument();
+  expect(screen.getByText('8.2')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/DevicesController.cs \
+        src/PatchHound.Api/Models/DeviceExposureDto.cs \
+        web/src/routes/devices/$deviceId.tsx \
+        web/src/routes/devices/__tests__/DeviceDetail.exposures.test.tsx \
+        tests/PatchHound.Api.Tests/Controllers/DeviceExposuresControllerTests.cs
+git commit -m "feat(phase-3): add device exposures tab and /api/devices/{id}/exposures endpoint"
+```
+
+---
+
+## Task 11: Frontend — vulnerability list + detail show affected devices
+
+**Files:**
+- Modify: `web/src/routes/vulnerabilities/index.tsx`
+- Modify: `web/src/routes/vulnerabilities/$vulnerabilityId.tsx`
+- Modify: `web/src/api/types/vulnerabilities.ts`
+- Test: `web/src/routes/vulnerabilities/__tests__/VulnerabilitiesList.phase3.test.tsx`
+- Test: `web/src/routes/vulnerabilities/__tests__/VulnerabilityDetail.phase3.test.tsx`
+
+- [ ] **Step 1: Remove the Phase 2 "Exposure data pending" badge**
+
+List rows now unconditionally show `Affected: {affectedDeviceCount} devices`.
+
+- [ ] **Step 2: Detail — populate Affected Devices tab**
+
+The tab renders a table of `AffectedDeviceDto` items with columns: Device, Product, Matched version, Status, Environmental CVSS (reason on hover), First observed, Last observed. An `Episodes` sub-tab lists active and resolved episodes.
+
+- [ ] **Step 3: Tests**
+
+```ts
+it('shows affected devices count when exposureDataAvailable is true', async () => { /* ... */ });
+it('renders affected devices table in vulnerability detail', async () => { /* ... */ });
+```
+
+Run: `cd web && npm test -- --run vulnerabilities.phase3` — PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/routes/vulnerabilities/ web/src/api/types/vulnerabilities.ts
+git commit -m "feat(phase-3): vulnerability UI renders affected devices and episodes"
+```
+
+---
+
+## Task 12: Extend `TenantIsolationEndToEndTests` with Phase 3 assertions
+
+**Files:**
+- Modify: `tests/PatchHound.Api.Tests/EndToEnd/TenantIsolationEndToEndTests.cs`
+
+- [ ] **Step 1: Add Phase 3 assertions**
+
+```csharp
+[Fact]
+public async Task Phase3_vulnerability_detail_scopes_affected_devices_per_tenant()
+{
+    await using var app = await TestApiFactory.CreateAsync();
+
+    // Seed a global vuln + two tenants each with their own devices + exposures on the same vuln.
+    var vulnId = await SeedGlobalVulnerabilityAsync(app);
+    await SeedTenantExposureAsync(app, TenantAId, vulnId, deviceName: "A1");
+    await SeedTenantExposureAsync(app, TenantBId, vulnId, deviceName: "B1");
+
+    var clientA = app.CreateAuthenticatedClient(TenantAId);
+    var detailA = await clientA.GetFromJsonAsync<VulnerabilityDetailDto>($"/api/vulnerabilities/{vulnId}");
+    Assert.Single(detailA!.Exposures.AffectedDevices);
+    Assert.Equal("A1", detailA.Exposures.AffectedDevices[0].DeviceName);
+
+    var clientB = app.CreateAuthenticatedClient(TenantBId);
+    var detailB = await clientB.GetFromJsonAsync<VulnerabilityDetailDto>($"/api/vulnerabilities/{vulnId}");
+    Assert.Single(detailB!.Exposures.AffectedDevices);
+    Assert.Equal("B1", detailB.Exposures.AffectedDevices[0].DeviceName);
+}
+
+[Fact]
+public async Task Phase3_device_exposures_endpoint_returns_404_for_cross_tenant_device()
+{
+    await using var app = await TestApiFactory.CreateAsync();
+    var tenantBDeviceId = await SeedTenantDeviceAsync(app, TenantBId);
+    var clientA = app.CreateAuthenticatedClient(TenantAId);
+    var resp = await clientA.GetAsync($"/api/devices/{tenantBDeviceId}/exposures");
+    Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+}
+
+[Fact]
+public async Task Phase3_ExposureEpisodes_and_ExposureAssessments_are_tenant_filtered_at_db_level()
+{
+    await using var app = await TestApiFactory.CreateAsync();
+    // Seed tenant A + B exposures; use a request-scoped context for tenant A.
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+    SetTenantContext(scope, TenantAId);
+
+    var visibleExposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+    Assert.All(visibleExposures, e => Assert.Equal(TenantAId, e.TenantId));
+
+    var visibleEpisodes = await db.ExposureEpisodes.ToListAsync();
+    Assert.All(visibleEpisodes, e => Assert.Equal(TenantAId, e.TenantId));
+
+    var visibleAssessments = await db.ExposureAssessments.ToListAsync();
+    Assert.All(visibleAssessments, a => Assert.Equal(TenantAId, a.TenantId));
+}
+```
+
+- [ ] **Step 2: Run — PASS**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Api.Tests/EndToEnd/TenantIsolationEndToEndTests.cs
+git commit -m "test(phase-3): extend tenant isolation e2e with canonical exposure assertions"
+```
+
+---
+
+## Task 13: Ingestion idempotency + source collision tests (spec §7 gates)
+
+**Files:**
+- Test: `tests/PatchHound.Infrastructure.Tests/Services/ExposureIdempotencyTests.cs`
+
+- [ ] **Step 1: Idempotency test**
+
+```csharp
+[Fact]
+public async Task Re_running_ingestion_does_not_duplicate_exposures()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    // Seed one device, one installed, one applicable vulnerability
+    // ...
+    var svc = new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance);
+
+    await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+    await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+    await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    Assert.Single(await db.DeviceVulnerabilityExposures.ToListAsync());
+}
+
+[Fact]
+public async Task Source_collision_same_external_id_different_source_produces_two_devices_and_two_exposures()
+{
+    await using var db = TestDbContextFactory.CreateTenantContext(out var tenantId);
+    var srcA = SourceSystem.Create("defender", "Defender", true);
+    var srcB = SourceSystem.Create("tanium", "Tanium", true);
+    db.SourceSystems.AddRange(srcA, srcB);
+
+    var deviceA = Device.Create(tenantId, srcA.Id, "same-external-id", "Defender Device");
+    var deviceB = Device.Create(tenantId, srcB.Id, "same-external-id", "Tanium Device");
+    db.Devices.AddRange(deviceA, deviceB);
+
+    var product = SoftwareProduct.Create("acme:widget", "Widget", "Acme", null);
+    db.SoftwareProducts.Add(product);
+    var vuln = Vulnerability.Create("nvd", "CVE-2026-COLL", "t", "d", Severity.High, 7m, "v", DateTimeOffset.UtcNow);
+    db.Vulnerabilities.Add(vuln);
+    db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(vuln.Id, product.Id, null, true, null, null, null, null));
+
+    db.InstalledSoftware.Add(InstalledSoftware.Observe(tenantId, deviceA.Id, product.Id, srcA.Id, "1.0", DateTimeOffset.UtcNow));
+    db.InstalledSoftware.Add(InstalledSoftware.Observe(tenantId, deviceB.Id, product.Id, srcB.Id, "1.0", DateTimeOffset.UtcNow));
+    await db.SaveChangesAsync();
+
+    var svc = new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance);
+    await svc.DeriveForTenantAsync(tenantId, DateTimeOffset.UtcNow, CancellationToken.None);
+    await db.SaveChangesAsync();
+
+    var exposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+    Assert.Equal(2, exposures.Count);
+    Assert.Equal(2, exposures.Select(e => e.DeviceId).Distinct().Count());
+}
+```
+
+- [ ] **Step 2: Run — PASS**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Infrastructure.Tests/Services/ExposureIdempotencyTests.cs
+git commit -m "test(phase-3): exposure idempotency + source collision gates (spec §7)"
+```
+
+---
+
+## Task 14: Grep sweep
+
+- [ ] **Step 1: Ensure no legacy references survive**
+
+```bash
+grep -rn "VulnerabilityAsset" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "VulnerabilityEpisodeRiskAssessment" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "TenantVulnerabilityId" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "SoftwareVulnerabilityMatch" src/ --include="*.cs" | grep -v "Migrations/" ; echo "---"
+grep -rn "IgnoreQueryFilters" src/ --include="*.cs" | grep -v "Migrations/"
+```
+
+All expected to return zero hits (except `IgnoreQueryFilters` in the documented allow-list — Phase 3 adds no new entries).
+
+- [ ] **Step 2: Verify no new `IgnoreQueryFilters()` in Phase 3 services**
+
+The exposure services (derivation, episode, assessment) all run under tenant context and write tenant-scoped rows; they must **not** call `IgnoreQueryFilters()`. Confirm by grep above.
+
+- [ ] **Step 3: If clean, no commit needed**
+
+---
+
+## Task 15: Final build, tests, PR
+
+- [ ] **Step 1: Clean build + full suite green**
+
+```bash
+dotnet clean && dotnet build --no-incremental
+dotnet test
+cd web && npm run typecheck && npm test -- --run && cd ..
+```
+
+- [ ] **Step 2: Phase exit checklist**
+
+- [ ] `dotnet build` clean
+- [ ] `dotnet test` green
+- [ ] `npm run typecheck` clean
+- [ ] `npm test` green
+- [ ] Env-severity hard-gate test (`EnvironmentalSeverityHardGateTests`) green
+- [ ] Idempotency + source-collision tests green
+- [ ] `TenantIsolationEndToEndTests` extended with 3 new exposure assertions
+- [ ] Grep sweep clean
+- [ ] PR description includes: "Entities added: `DeviceVulnerabilityExposure` (tenant-scoped, filter=yes), `ExposureEpisode` (tenant-scoped, filter=yes), `ExposureAssessment` (tenant-scoped, filter=yes)"
+- [ ] PR description notes: "Phase 2 gap closed — vulnerability list/detail now returns `ExposureDataAvailable = true` and populates affected devices"
+- [ ] PR description re-states the `IgnoreQueryFilters()` allow-list — unchanged from Phase 2
+
+- [ ] **Step 3: PR**
+
+```bash
+git push -u origin data-model-canonical-cleanup-phase-3
+gh pr create --title "Data model canonical cleanup — phase 3: canonical exposure" --body "$(cat <<'EOF'
+## Summary
+- Introduces `DeviceVulnerabilityExposure`, `ExposureEpisode`, and `ExposureAssessment` tenant-scoped entities.
+- `ExposureDerivationService` matches `InstalledSoftware` × `VulnerabilityApplicability` (product-keyed first, CPE fallback).
+- `ExposureEpisodeService` manages open/close/reopen lifecycle.
+- `ExposureAssessmentService` computes environmental CVSS via `Device.SecurityProfileId → SecurityProfile`.
+- Closes the Phase 2 "affected devices" gap in vulnerability list/detail.
+- Adds the device exposures tab.
+
+## Entities added (all tenant-scoped, direct `TenantId`, EF query filter yes)
+| Entity | Rule | Justification |
+|---|---|---|
+| `DeviceVulnerabilityExposure` | §4.10 R1/R2 | Tenant exposure current-state row |
+| `ExposureEpisode` | §4.10 R1/R2 | Tenant exposure lifecycle history |
+| `ExposureAssessment` | §4.10 R1/R2 | Tenant environmental severity calculation |
+
+## Hard gates
+- `EnvironmentalSeverityHardGateTests` proves `SecurityProfile` modifiers move `ExposureAssessment.EnvironmentalCvss` away from the base CVSS — blocking.
+- `ExposureIdempotencyTests` proves repeated derivation does not duplicate rows.
+- Source-collision test proves two sources producing the same external device ID result in two `Device` + two `DeviceVulnerabilityExposure` rows.
+
+## `IgnoreQueryFilters()` allow-list
+Unchanged from Phase 2. Phase 3 services run under tenant context.
+
+## Test plan
+- [ ] `dotnet build` clean
+- [ ] `dotnet test` full suite green (includes `EnvironmentalSeverityHardGateTests`)
+- [ ] `cd web && npm run typecheck && npm test -- --run` green
+- [ ] `TenantIsolationEndToEndTests` passes with Phase 3 assertions
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-4.md
+++ b/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-4.md
@@ -1,0 +1,2055 @@
+# Data Model Canonical Cleanup — Phase 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `RemediationCase` as the tenant-scoped scope key for all remediation work and rewrite every remediation entity, service, controller, and frontend component to be case-first, dropping `TenantSoftwareId`/`SoftwareAssetId`/`TenantVulnerabilityId` from the remediation domain entirely.
+
+**Architecture:** A `RemediationCase` is uniquely keyed by `(TenantId, SoftwareProductId)` — one case per tenant per product. Cases are created lazily from the remediation entry points (whenever a user opens decision context, a recommendation is filed, or a patching task is requested) via a `RemediationCaseService`. `RemediationWorkflow`, `RemediationDecision`, `PatchingTask`, `ApprovalTask`, `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob`, `RemediationDecisionVulnerabilityOverride`, and `RemediationWorkflowStageRecord` all re-anchor on `RemediationCaseId`. `SoftwareDescriptionJob` re-anchors on `SoftwareProductId` directly. The API surface collapses to `/api/remediation/cases/{caseId}/*` and the frontend routes follow. Spec §5.4.
+
+**Tech Stack:** .NET 10 / EF Core 10 / xUnit / React + TanStack Router + Vitest. Same stack as Phases 1–3.
+
+**Prerequisites:** Phase 3 is merged. `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment` exist. `SoftwareProduct` exists (Phase 1). `Vulnerability` exists (Phase 2). `TenantSoftware`, `Asset`/`SoftwareAsset`, `TenantVulnerability`, `NormalizedSoftware*` are all gone.
+
+**Phase 3 handoff — dangling FKs Phase 4 must fix:** `RemediationDecisionVulnerabilityOverride`, `RiskAcceptance`, and `AnalystRecommendation` still carry a `TenantVulnerabilityId` column pointing at the deleted `TenantVulnerability` table. Phase 2/3 did **not** re-anchor these. Task 7 already covers `RiskAcceptance` + `AnalystRecommendation`; Task 7b (added here) handles `RemediationDecisionVulnerabilityOverride`. Scope assumptions in downstream tasks (e.g. Task 11) that the override "already points at canonical `Vulnerability.Id`" are stale — do not rely on them.
+
+---
+
+## Preflight
+
+- [ ] **P1: Confirm Phase 3 merged**
+
+Run:
+```bash
+git log --oneline main -30 | grep -i "phase.3\|canonical-cleanup-phase-3"
+```
+Expected: at least one commit. If nothing, STOP and wait for Phase 3.
+
+- [ ] **P2: Cut Phase 4 branch**
+
+Run:
+```bash
+git checkout main && git pull
+git checkout -b data-model-canonical-cleanup-phase-4
+```
+
+- [ ] **P3: Wipe dev database**
+
+Run:
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS patchhound;"
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "CREATE DATABASE patchhound;"
+```
+Expected: `DROP DATABASE` / `CREATE DATABASE`.
+
+- [ ] **P4: Baseline green build**
+
+Run:
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx
+cd frontend && npm run typecheck && npm test -- --run && cd ..
+```
+Expected: all green. If anything is red on a fresh Phase 3 main, STOP and fix main first.
+
+---
+
+### Task 1: `RemediationCase` entity
+
+**Files:**
+- Create: `src/PatchHound.Core/Entities/RemediationCase.cs`
+- Create: `src/PatchHound.Core/Enums/RemediationCaseStatus.cs`
+- Test: `tests/PatchHound.Tests/Core/Entities/RemediationCaseTests.cs`
+
+- [ ] **Step 1: Write the failing entity test**
+
+Create `tests/PatchHound.Tests/Core/Entities/RemediationCaseTests.cs`:
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using Xunit;
+
+namespace PatchHound.Tests.Core.Entities;
+
+public class RemediationCaseTests
+{
+    [Fact]
+    public void Create_sets_tenant_product_and_open_status()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+
+        var c = RemediationCase.Create(tenantId, productId);
+
+        Assert.NotEqual(Guid.Empty, c.Id);
+        Assert.Equal(tenantId, c.TenantId);
+        Assert.Equal(productId, c.SoftwareProductId);
+        Assert.Equal(RemediationCaseStatus.Open, c.Status);
+        Assert.NotEqual(default, c.CreatedAt);
+        Assert.Equal(c.CreatedAt, c.UpdatedAt);
+        Assert.Null(c.ClosedAt);
+    }
+
+    [Fact]
+    public void Create_rejects_empty_tenant()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            RemediationCase.Create(Guid.Empty, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Create_rejects_empty_product()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            RemediationCase.Create(Guid.NewGuid(), Guid.Empty));
+    }
+
+    [Fact]
+    public void Close_sets_status_and_timestamp()
+    {
+        var c = RemediationCase.Create(Guid.NewGuid(), Guid.NewGuid());
+        c.Close();
+        Assert.Equal(RemediationCaseStatus.Closed, c.Status);
+        Assert.NotNull(c.ClosedAt);
+    }
+
+    [Fact]
+    public void Close_is_idempotent()
+    {
+        var c = RemediationCase.Create(Guid.NewGuid(), Guid.NewGuid());
+        c.Close();
+        var firstClosedAt = c.ClosedAt;
+        c.Close();
+        Assert.Equal(firstClosedAt, c.ClosedAt);
+    }
+
+    [Fact]
+    public void Reopen_from_closed_clears_timestamp()
+    {
+        var c = RemediationCase.Create(Guid.NewGuid(), Guid.NewGuid());
+        c.Close();
+        c.Reopen();
+        Assert.Equal(RemediationCaseStatus.Open, c.Status);
+        Assert.Null(c.ClosedAt);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationCaseTests"`
+Expected: FAIL — `RemediationCase`, `RemediationCaseStatus` don't exist.
+
+- [ ] **Step 3: Create the enum**
+
+Create `src/PatchHound.Core/Enums/RemediationCaseStatus.cs`:
+```csharp
+namespace PatchHound.Core.Enums;
+
+public enum RemediationCaseStatus
+{
+    Open = 0,
+    Closed = 1,
+}
+```
+
+- [ ] **Step 4: Create the entity**
+
+Create `src/PatchHound.Core/Entities/RemediationCase.cs`:
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class RemediationCase
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public RemediationCaseStatus Status { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+    public DateTimeOffset? ClosedAt { get; private set; }
+
+    public SoftwareProduct SoftwareProduct { get; private set; } = null!;
+
+    private RemediationCase() { }
+
+    public static RemediationCase Create(Guid tenantId, Guid softwareProductId)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (softwareProductId == Guid.Empty)
+            throw new ArgumentException("SoftwareProductId is required.", nameof(softwareProductId));
+
+        var now = DateTimeOffset.UtcNow;
+        return new RemediationCase
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            SoftwareProductId = softwareProductId,
+            Status = RemediationCaseStatus.Open,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Close()
+    {
+        if (Status == RemediationCaseStatus.Closed)
+            return;
+        Status = RemediationCaseStatus.Closed;
+        ClosedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = ClosedAt.Value;
+    }
+
+    public void Reopen()
+    {
+        if (Status == RemediationCaseStatus.Open)
+            return;
+        Status = RemediationCaseStatus.Open;
+        ClosedAt = null;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationCaseTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/RemediationCase.cs src/PatchHound.Core/Enums/RemediationCaseStatus.cs tests/PatchHound.Tests/Core/Entities/RemediationCaseTests.cs
+git commit -m "feat(phase-4): add RemediationCase entity keyed by (TenantId, SoftwareProductId)"
+```
+
+---
+
+### Task 2: EF configuration + DbContext wiring for `RemediationCase`
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`
+
+- [ ] **Step 1: Create the configuration**
+
+Create `src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class RemediationCaseConfiguration : IEntityTypeConfiguration<RemediationCase>
+{
+    public void Configure(EntityTypeBuilder<RemediationCase> builder)
+    {
+        builder.ToTable("RemediationCases");
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.TenantId).IsRequired();
+        builder.Property(c => c.SoftwareProductId).IsRequired();
+        builder.Property(c => c.Status).HasConversion<string>().HasMaxLength(32);
+        builder.Property(c => c.CreatedAt).IsRequired();
+        builder.Property(c => c.UpdatedAt).IsRequired();
+
+        builder.HasIndex(c => new { c.TenantId, c.SoftwareProductId }).IsUnique();
+        builder.HasIndex(c => c.TenantId);
+
+        builder.HasOne(c => c.SoftwareProduct)
+            .WithMany()
+            .HasForeignKey(c => c.SoftwareProductId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+- [ ] **Step 2: Add DbSet + query filter to DbContext**
+
+In `src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs`, add `public DbSet<RemediationCase> RemediationCases => Set<RemediationCase>();` alongside the other remediation DbSets. In the `OnModelCreating` block where other tenant-scoped entities get their query filters, add:
+```csharp
+modelBuilder.Entity<RemediationCase>()
+    .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build PatchHound.slnx`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+git commit -m "feat(phase-4): wire RemediationCase into EF context with tenant filter"
+```
+
+---
+
+### Task 3: `RemediationCaseService` — lazy upsert by `(TenantId, SoftwareProductId)`
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/RemediationCaseService.cs`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseServiceTests.cs`
+
+- [ ] **Step 1: Write the failing service test**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseServiceTests.cs`:
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.TestInfrastructure;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class RemediationCaseServiceTests
+{
+    [Fact]
+    public async Task GetOrCreate_returns_existing_case_for_same_tenant_and_product()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var productId = Guid.NewGuid();
+        ctx.SoftwareProducts.Add(TestData.Product(productId));
+        await ctx.SaveChangesAsync();
+
+        var sut = new RemediationCaseService(ctx);
+        var first = await sut.GetOrCreateAsync(tenantId, productId, CancellationToken.None);
+        var second = await sut.GetOrCreateAsync(tenantId, productId, CancellationToken.None);
+
+        Assert.Equal(first.Id, second.Id);
+        Assert.Equal(1, ctx.RemediationCases.Count());
+    }
+
+    [Fact]
+    public async Task GetOrCreate_creates_separate_case_per_tenant()
+    {
+        using var ctx = TestDbContextFactory.CreateSystemContext();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        ctx.SoftwareProducts.Add(TestData.Product(productId));
+        await ctx.SaveChangesAsync();
+
+        var sut = new RemediationCaseService(ctx);
+        var a = await sut.GetOrCreateAsync(tenantA, productId, CancellationToken.None);
+        var b = await sut.GetOrCreateAsync(tenantB, productId, CancellationToken.None);
+
+        Assert.NotEqual(a.Id, b.Id);
+        Assert.Equal(tenantA, a.TenantId);
+        Assert.Equal(tenantB, b.TenantId);
+    }
+
+    [Fact]
+    public async Task GetOrCreate_rejects_unknown_product()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var sut = new RemediationCaseService(ctx);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetOrCreateAsync(tenantId, Guid.NewGuid(), CancellationToken.None));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationCaseServiceTests"`
+Expected: FAIL — `RemediationCaseService` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+Create `src/PatchHound.Infrastructure/Services/RemediationCaseService.cs`:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class RemediationCaseService(PatchHoundDbContext db)
+{
+    public async Task<RemediationCase> GetOrCreateAsync(
+        Guid tenantId,
+        Guid softwareProductId,
+        CancellationToken ct)
+    {
+        var existing = await db.RemediationCases
+            .FirstOrDefaultAsync(
+                c => c.TenantId == tenantId && c.SoftwareProductId == softwareProductId,
+                ct);
+        if (existing is not null)
+            return existing;
+
+        var productExists = await db.SoftwareProducts
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == softwareProductId, ct);
+        if (!productExists)
+            throw new InvalidOperationException(
+                $"SoftwareProduct {softwareProductId} does not exist; cannot create remediation case.");
+
+        var created = RemediationCase.Create(tenantId, softwareProductId);
+        db.RemediationCases.Add(created);
+        await db.SaveChangesAsync(ct);
+        return created;
+    }
+
+    public async Task<RemediationCase?> GetAsync(Guid caseId, CancellationToken ct)
+    {
+        return await db.RemediationCases.FirstOrDefaultAsync(c => c.Id == caseId, ct);
+    }
+}
+```
+
+- [ ] **Step 4: Register in DI**
+
+In `src/PatchHound.Api/Program.cs` (or wherever infrastructure services are registered alongside `RemediationWorkflowService`), add:
+```csharp
+builder.Services.AddScoped<RemediationCaseService>();
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationCaseServiceTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/RemediationCaseService.cs tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseServiceTests.cs src/PatchHound.Api/Program.cs
+git commit -m "feat(phase-4): add RemediationCaseService for lazy upsert by (tenant, product)"
+```
+
+---
+
+### Task 4: Re-anchor `RemediationWorkflow` on `RemediationCaseId`
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/RemediationWorkflow.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowConfiguration.cs`
+- Test: `tests/PatchHound.Tests/Core/Entities/RemediationWorkflowTests.cs` (new or extend)
+
+- [ ] **Step 1: Write the failing entity test**
+
+Create or extend `tests/PatchHound.Tests/Core/Entities/RemediationWorkflowTests.cs`:
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using Xunit;
+
+namespace PatchHound.Tests.Core.Entities;
+
+public class RemediationWorkflowTests
+{
+    [Fact]
+    public void Create_takes_tenant_case_and_owner_team()
+    {
+        var tenantId = Guid.NewGuid();
+        var caseId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+
+        var w = RemediationWorkflow.Create(tenantId, caseId, teamId);
+
+        Assert.Equal(tenantId, w.TenantId);
+        Assert.Equal(caseId, w.RemediationCaseId);
+        Assert.Equal(teamId, w.SoftwareOwnerTeamId);
+        Assert.Equal(RemediationWorkflowStatus.Active, w.Status);
+        Assert.Equal(RemediationWorkflowStage.SecurityAnalysis, w.CurrentStage);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationWorkflowTests"`
+Expected: FAIL — `RemediationCaseId` does not exist on `RemediationWorkflow`.
+
+- [ ] **Step 3: Rewrite the entity**
+
+Replace the body of `src/PatchHound.Core/Entities/RemediationWorkflow.cs` with:
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class RemediationWorkflow
+{
+    private readonly List<RemediationWorkflowStageRecord> _stageRecords = [];
+
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public Guid SoftwareOwnerTeamId { get; private set; }
+    public Guid? RecurrenceSourceWorkflowId { get; private set; }
+    public RemediationWorkflowStage CurrentStage { get; private set; }
+    public RemediationWorkflowStatus Status { get; private set; }
+    public RemediationOutcome? ProposedOutcome { get; private set; }
+    public RemediationWorkflowPriority? Priority { get; private set; }
+    public RemediationWorkflowApprovalMode ApprovalMode { get; private set; }
+    public DateTimeOffset CurrentStageStartedAt { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+    public DateTimeOffset? CancelledAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public RemediationCase RemediationCase { get; private set; } = null!;
+    public IReadOnlyCollection<RemediationWorkflowStageRecord> StageRecords => _stageRecords.AsReadOnly();
+
+    private RemediationWorkflow() { }
+
+    public static RemediationWorkflow Create(
+        Guid tenantId,
+        Guid remediationCaseId,
+        Guid softwareOwnerTeamId,
+        RemediationWorkflowStage initialStage = RemediationWorkflowStage.SecurityAnalysis,
+        Guid? recurrenceSourceWorkflowId = null)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (remediationCaseId == Guid.Empty)
+            throw new ArgumentException("RemediationCaseId is required.", nameof(remediationCaseId));
+
+        var now = DateTimeOffset.UtcNow;
+        return new RemediationWorkflow
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            SoftwareOwnerTeamId = softwareOwnerTeamId,
+            RecurrenceSourceWorkflowId = recurrenceSourceWorkflowId,
+            CurrentStage = initialStage,
+            Status = RemediationWorkflowStatus.Active,
+            ApprovalMode = RemediationWorkflowApprovalMode.None,
+            CurrentStageStartedAt = now,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void SetDecisionContext(
+        RemediationOutcome? proposedOutcome,
+        RemediationWorkflowPriority? priority,
+        RemediationWorkflowApprovalMode approvalMode)
+    {
+        ProposedOutcome = proposedOutcome;
+        Priority = priority;
+        ApprovalMode = approvalMode;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void MoveToStage(RemediationWorkflowStage stage)
+    {
+        CurrentStage = stage;
+        CurrentStageStartedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Complete()
+    {
+        Status = RemediationWorkflowStatus.Completed;
+        CompletedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Cancel()
+    {
+        Status = RemediationWorkflowStatus.Cancelled;
+        CancelledAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+Note: `ReassignTenantSoftware` is deleted entirely. A case is stable per `(TenantId, SoftwareProductId)`; reassignment no longer exists.
+
+- [ ] **Step 4: Update EF configuration**
+
+In `src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowConfiguration.cs`:
+- Remove the `TenantSoftwareId` property config and index.
+- Add `builder.Property(w => w.RemediationCaseId).IsRequired();`
+- Add `builder.HasOne(w => w.RemediationCase).WithMany().HasForeignKey(w => w.RemediationCaseId).OnDelete(DeleteBehavior.Restrict);`
+- Add `builder.HasIndex(w => new { w.TenantId, w.RemediationCaseId, w.Status });`
+
+- [ ] **Step 5: Run the entity test to verify it passes**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationWorkflowTests"`
+Expected: PASS.
+
+(The solution will not yet build because downstream services still pass `tenantSoftwareId`. That is fixed in later tasks. Skip the full build here.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/RemediationWorkflow.cs src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowConfiguration.cs tests/PatchHound.Tests/Core/Entities/RemediationWorkflowTests.cs
+git commit -m "refactor(phase-4): anchor RemediationWorkflow on RemediationCaseId"
+```
+
+---
+
+### Task 5: Re-anchor `RemediationDecision` on `RemediationCaseId`
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/RemediationDecision.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionConfiguration.cs`
+
+- [ ] **Step 1: Rewrite the entity**
+
+Replace `RemediationDecision` with:
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class RemediationDecision
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public Guid? RemediationWorkflowId { get; private set; }
+    public RemediationOutcome Outcome { get; private set; }
+    public DecisionApprovalStatus ApprovalStatus { get; private set; }
+    public string Justification { get; private set; } = null!;
+    public Guid DecidedBy { get; private set; }
+    public DateTimeOffset DecidedAt { get; private set; }
+    public Guid? ApprovedBy { get; private set; }
+    public DateTimeOffset? ApprovedAt { get; private set; }
+    public DateTimeOffset? MaintenanceWindowDate { get; private set; }
+    public DateTimeOffset? ExpiryDate { get; private set; }
+    public DateTimeOffset? ReEvaluationDate { get; private set; }
+    public DateTimeOffset? LastSlaNotifiedAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public RemediationCase RemediationCase { get; private set; } = null!;
+    public RemediationWorkflow? RemediationWorkflow { get; private set; }
+    public ICollection<RemediationDecisionVulnerabilityOverride> VulnerabilityOverrides { get; private set; } = [];
+
+    private static readonly RemediationOutcome[] OutcomesRequiringApproval =
+    [
+        RemediationOutcome.RiskAcceptance,
+        RemediationOutcome.AlternateMitigation,
+    ];
+
+    private static readonly RemediationOutcome[] OutcomesRequiringJustification =
+    [
+        RemediationOutcome.RiskAcceptance,
+        RemediationOutcome.AlternateMitigation,
+        RemediationOutcome.PatchingDeferred,
+    ];
+
+    private RemediationDecision() { }
+
+    public static RemediationDecision Create(
+        Guid tenantId,
+        Guid remediationCaseId,
+        RemediationOutcome outcome,
+        string? justification,
+        Guid decidedBy,
+        DecisionApprovalStatus? initialApprovalStatus = null,
+        DateTimeOffset? expiryDate = null,
+        DateTimeOffset? reEvaluationDate = null,
+        DateTimeOffset? maintenanceWindowDate = null)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (remediationCaseId == Guid.Empty)
+            throw new ArgumentException("RemediationCaseId is required.", nameof(remediationCaseId));
+
+        if (OutcomesRequiringJustification.Contains(outcome) && string.IsNullOrWhiteSpace(justification))
+            throw new ArgumentException($"Justification is required for {outcome}.");
+
+        if (outcome == RemediationOutcome.PatchingDeferred && !reEvaluationDate.HasValue)
+            throw new ArgumentException("Re-evaluation date is required for PatchingDeferred.");
+
+        var now = DateTimeOffset.UtcNow;
+        var requiresApproval = initialApprovalStatus.HasValue
+            ? initialApprovalStatus.Value == DecisionApprovalStatus.PendingApproval
+            : OutcomesRequiringApproval.Contains(outcome);
+        var approvalStatus = initialApprovalStatus
+            ?? (requiresApproval ? DecisionApprovalStatus.PendingApproval : DecisionApprovalStatus.Approved);
+
+        return new RemediationDecision
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            Outcome = outcome,
+            ApprovalStatus = approvalStatus,
+            Justification = justification ?? string.Empty,
+            DecidedBy = decidedBy,
+            DecidedAt = now,
+            ApprovedBy = approvalStatus == DecisionApprovalStatus.Approved ? decidedBy : null,
+            ApprovedAt = approvalStatus == DecisionApprovalStatus.Approved ? now : null,
+            MaintenanceWindowDate = maintenanceWindowDate,
+            ExpiryDate = expiryDate,
+            ReEvaluationDate = reEvaluationDate,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Approve(Guid approvedBy)
+    {
+        if (ApprovalStatus != DecisionApprovalStatus.PendingApproval)
+            throw new InvalidOperationException($"Cannot approve a decision with status {ApprovalStatus}.");
+        ApprovedBy = approvedBy;
+        ApprovedAt = DateTimeOffset.UtcNow;
+        ApprovalStatus = DecisionApprovalStatus.Approved;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void SetMaintenanceWindowDate(DateTimeOffset? maintenanceWindowDate)
+    {
+        MaintenanceWindowDate = maintenanceWindowDate;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Reject(Guid rejectedBy)
+    {
+        if (ApprovalStatus != DecisionApprovalStatus.PendingApproval)
+            throw new InvalidOperationException($"Cannot reject a decision with status {ApprovalStatus}.");
+        ApprovedBy = rejectedBy;
+        ApprovedAt = DateTimeOffset.UtcNow;
+        ApprovalStatus = DecisionApprovalStatus.Rejected;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Expire()
+    {
+        ApprovalStatus = DecisionApprovalStatus.Expired;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void MarkSlaNotified()
+    {
+        LastSlaNotifiedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void AttachToWorkflow(Guid remediationWorkflowId)
+    {
+        RemediationWorkflowId = remediationWorkflowId;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+Note: `SoftwareAsset`, `ReassignTenantSoftware`, `TenantSoftwareId`, `SoftwareAssetId` all removed.
+
+- [ ] **Step 2: Update EF configuration**
+
+In `RemediationDecisionConfiguration.cs`:
+- Remove `TenantSoftwareId`, `SoftwareAssetId`, `SoftwareAsset` navigation config.
+- Add `builder.Property(d => d.RemediationCaseId).IsRequired();`
+- Add `builder.HasOne(d => d.RemediationCase).WithMany().HasForeignKey(d => d.RemediationCaseId).OnDelete(DeleteBehavior.Restrict);`
+- Add index `builder.HasIndex(d => new { d.TenantId, d.RemediationCaseId, d.ApprovalStatus });`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/RemediationDecision.cs src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionConfiguration.cs
+git commit -m "refactor(phase-4): anchor RemediationDecision on RemediationCaseId"
+```
+
+---
+
+### Task 6: Re-anchor `PatchingTask` on `RemediationCaseId`
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/PatchingTask.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/PatchingTaskConfiguration.cs`
+
+- [ ] **Step 1: Rewrite the entity**
+
+Replace `PatchingTask` with:
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class PatchingTask
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public Guid? RemediationWorkflowId { get; private set; }
+    public Guid RemediationDecisionId { get; private set; }
+    public Guid OwnerTeamId { get; private set; }
+    public PatchingTaskStatus Status { get; private set; }
+    public DateTimeOffset DueDate { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+
+    public RemediationCase RemediationCase { get; private set; } = null!;
+    public RemediationDecision RemediationDecision { get; private set; } = null!;
+    public RemediationWorkflow? RemediationWorkflow { get; private set; }
+
+    private PatchingTask() { }
+
+    public static PatchingTask Create(
+        Guid tenantId,
+        Guid remediationCaseId,
+        Guid remediationDecisionId,
+        Guid ownerTeamId,
+        DateTimeOffset dueDate)
+    {
+        if (tenantId == Guid.Empty) throw new ArgumentException("TenantId is required.");
+        if (remediationCaseId == Guid.Empty) throw new ArgumentException("RemediationCaseId is required.");
+        var now = DateTimeOffset.UtcNow;
+        return new PatchingTask
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            RemediationDecisionId = remediationDecisionId,
+            OwnerTeamId = ownerTeamId,
+            Status = PatchingTaskStatus.Pending,
+            DueDate = dueDate,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Start()
+    {
+        Status = PatchingTaskStatus.InProgress;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Complete()
+    {
+        Status = PatchingTaskStatus.Completed;
+        CompletedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void AttachToWorkflow(Guid remediationWorkflowId)
+    {
+        RemediationWorkflowId = remediationWorkflowId;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [ ] **Step 2: Update EF configuration**
+
+In `PatchingTaskConfiguration.cs`:
+- Remove `TenantSoftwareId`, `SoftwareAssetId` property config and any indexes on them.
+- Add `builder.Property(t => t.RemediationCaseId).IsRequired();`
+- Add `builder.HasOne(t => t.RemediationCase).WithMany().HasForeignKey(t => t.RemediationCaseId).OnDelete(DeleteBehavior.Restrict);`
+- Add `builder.HasIndex(t => new { t.TenantId, t.RemediationCaseId, t.Status });`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/PatchingTask.cs src/PatchHound.Infrastructure/Data/Configurations/PatchingTaskConfiguration.cs
+git commit -m "refactor(phase-4): anchor PatchingTask on RemediationCaseId"
+```
+
+---
+
+### Task 7: Re-anchor sidecar entities on `RemediationCaseId`
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/ApprovalTask.cs`
+- Modify: `src/PatchHound.Core/Entities/RiskAcceptance.cs`
+- Modify: `src/PatchHound.Core/Entities/AnalystRecommendation.cs`
+- Modify: `src/PatchHound.Core/Entities/AIReport.cs`
+- Modify: `src/PatchHound.Core/Entities/RemediationAiJob.cs`
+- Modify: Corresponding configurations under `src/PatchHound.Infrastructure/Data/Configurations/`
+
+- [ ] **Step 1: `ApprovalTask` — add `RemediationCaseId`**
+
+Add `public Guid RemediationCaseId { get; private set; }` to `ApprovalTask`. Change `Create` signature to:
+```csharp
+public static ApprovalTask Create(
+    Guid tenantId,
+    Guid remediationCaseId,
+    Guid remediationDecisionId,
+    RemediationOutcome outcome,
+    ApprovalTaskStatus? initialStatus,
+    DateTimeOffset expiresAt)
+```
+Set `RemediationCaseId = remediationCaseId` in the constructor. Update `ApprovalTaskConfiguration` to add `builder.Property(a => a.RemediationCaseId).IsRequired();` + `builder.HasIndex(a => new { a.TenantId, a.RemediationCaseId, a.Status });`.
+
+- [ ] **Step 2: `RiskAcceptance` — replace `TenantVulnerabilityId` with `RemediationCaseId`**
+
+Replace the class with:
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class RiskAcceptance
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public Guid? VulnerabilityId { get; private set; }
+    public Guid RequestedBy { get; private set; }
+    public DateTimeOffset RequestedAt { get; private set; }
+    public Guid? ApprovedBy { get; private set; }
+    public DateTimeOffset? ApprovedAt { get; private set; }
+    public RiskAcceptanceStatus Status { get; private set; }
+    public string Justification { get; private set; } = null!;
+    public string? Conditions { get; private set; }
+    public DateTimeOffset? ExpiryDate { get; private set; }
+    public int? ReviewFrequency { get; private set; }
+    public DateTimeOffset? NextReviewDate { get; private set; }
+
+    public RemediationCase RemediationCase { get; private set; } = null!;
+
+    private RiskAcceptance() { }
+
+    public static RiskAcceptance Create(
+        Guid tenantId,
+        Guid remediationCaseId,
+        Guid requestedBy,
+        string justification,
+        Guid? vulnerabilityId = null,
+        string? conditions = null,
+        DateTimeOffset? expiryDate = null,
+        int? reviewFrequency = null,
+        DateTimeOffset? nextReviewDate = null)
+    {
+        if (string.IsNullOrWhiteSpace(justification))
+            throw new ArgumentException("Justification is required.", nameof(justification));
+
+        return new RiskAcceptance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            VulnerabilityId = vulnerabilityId,
+            RequestedBy = requestedBy,
+            RequestedAt = DateTimeOffset.UtcNow,
+            Status = RiskAcceptanceStatus.Pending,
+            Justification = justification,
+            Conditions = conditions,
+            ExpiryDate = expiryDate,
+            ReviewFrequency = reviewFrequency,
+            NextReviewDate = nextReviewDate,
+        };
+    }
+
+    public void Approve(Guid approvedBy, string? conditions = null, DateTimeOffset? expiryDate = null, int? reviewFrequency = null)
+    {
+        ApprovedBy = approvedBy;
+        ApprovedAt = DateTimeOffset.UtcNow;
+        Status = RiskAcceptanceStatus.Approved;
+        if (conditions is not null) Conditions = conditions;
+        if (expiryDate.HasValue) ExpiryDate = expiryDate;
+        if (reviewFrequency.HasValue) ReviewFrequency = reviewFrequency;
+    }
+
+    public void Reject(Guid rejectedBy)
+    {
+        ApprovedBy = rejectedBy;
+        ApprovedAt = DateTimeOffset.UtcNow;
+        Status = RiskAcceptanceStatus.Rejected;
+    }
+
+    public void Expire() => Status = RiskAcceptanceStatus.Expired;
+}
+```
+
+Update `RiskAcceptanceConfiguration.cs`: drop `TenantVulnerabilityId` / `AssetId` config, add `RemediationCaseId` required + FK + index `(TenantId, RemediationCaseId, Status)`.
+
+- [ ] **Step 3: `AnalystRecommendation` — anchor on `RemediationCaseId`**
+
+Replace `SoftwareAssetId` and `TenantVulnerabilityId` with `RemediationCaseId` (required) and `VulnerabilityId` (nullable, references canonical `Vulnerability`). New `Create`:
+```csharp
+public static AnalystRecommendation Create(
+    Guid tenantId,
+    Guid remediationCaseId,
+    RemediationOutcome recommendedOutcome,
+    string rationale,
+    Guid analystId,
+    Guid? vulnerabilityId = null,
+    string? priorityOverride = null)
+```
+Update `Update` method signature symmetrically. Update configuration: remove `SoftwareAssetId`, `TenantVulnerabilityId`; add `RemediationCaseId` required + FK + index.
+
+- [ ] **Step 4: `AIReport` — anchor on `RemediationCaseId`**
+
+Replace `TenantVulnerabilityId` with `RemediationCaseId`. Add optional `VulnerabilityId` if the report is vulnerability-specific (nullable, references canonical `Vulnerability`). Drop the `TenantVulnerability` navigation property. New `Create`:
+```csharp
+public static AIReport Create(
+    Guid tenantId,
+    Guid remediationCaseId,
+    Guid tenantAiProfileId,
+    string content,
+    string providerType,
+    string profileName,
+    string model,
+    string systemPromptHash,
+    decimal temperature,
+    int maxOutputTokens,
+    Guid generatedBy,
+    Guid? vulnerabilityId = null)
+```
+Update `AIReportConfiguration` — drop `TenantVulnerability` FK; add `RemediationCaseId` required + FK + index `(TenantId, RemediationCaseId, GeneratedAt)`.
+
+- [ ] **Step 5: `RemediationAiJob` — replace `TenantSoftwareId` with `RemediationCaseId`**
+
+Replace `TenantSoftwareId` with `RemediationCaseId`. New `Create` and `Refresh` signatures take `remediationCaseId`. Update configuration: drop `TenantSoftwareId`; add `RemediationCaseId` + unique index `(TenantId, RemediationCaseId)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/ApprovalTask.cs src/PatchHound.Core/Entities/RiskAcceptance.cs src/PatchHound.Core/Entities/AnalystRecommendation.cs src/PatchHound.Core/Entities/AIReport.cs src/PatchHound.Core/Entities/RemediationAiJob.cs src/PatchHound.Infrastructure/Data/Configurations/ApprovalTaskConfiguration.cs src/PatchHound.Infrastructure/Data/Configurations/RiskAcceptanceConfiguration.cs src/PatchHound.Infrastructure/Data/Configurations/AnalystRecommendationConfiguration.cs src/PatchHound.Infrastructure/Data/Configurations/AIReportConfiguration.cs src/PatchHound.Infrastructure/Data/Configurations/RemediationAiJobConfiguration.cs
+git commit -m "refactor(phase-4): anchor ApprovalTask/RiskAcceptance/AnalystRecommendation/AIReport/RemediationAiJob on RemediationCaseId"
+```
+
+---
+
+### Task 7b: Re-anchor `RemediationDecisionVulnerabilityOverride` on canonical `VulnerabilityId`
+
+**Context:** Phase 2/3 deleted the `TenantVulnerability` table but left `RemediationDecisionVulnerabilityOverride.TenantVulnerabilityId` in place as a dangling FK. This task replaces it with canonical `VulnerabilityId` pointing at the global `Vulnerability` table. Must land before Task 11 rewrites `AddVulnerabilityOverrideAsync`.
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/RemediationDecisionVulnerabilityOverride.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionVulnerabilityOverrideConfiguration.cs`
+- Add: EF migration `RemediationOverrideVulnerabilityReanchor`
+
+**Steps:**
+
+- [ ] **Step 1: Entity field rename**
+
+Replace `public Guid TenantVulnerabilityId { get; private set; }` with `public Guid VulnerabilityId { get; private set; }`. Update `Create(...)` factory signature + body symmetrically. Add `public Vulnerability Vulnerability { get; private set; } = null!;` navigation (global entity, no tenant filter). Remove any residual `TenantVulnerability` navigation.
+
+- [ ] **Step 2: Configuration**
+
+In `RemediationDecisionVulnerabilityOverrideConfiguration.Configure`: drop the `TenantVulnerabilityId` index, add `builder.HasIndex(vo => new { vo.RemediationDecisionId, vo.VulnerabilityId }).IsUnique();` and `builder.HasOne(vo => vo.Vulnerability).WithMany().HasForeignKey(vo => vo.VulnerabilityId).OnDelete(DeleteBehavior.Restrict);`.
+
+- [ ] **Step 3: EF migration**
+
+```bash
+dotnet ef migrations add RemediationOverrideVulnerabilityReanchor --project src/PatchHound.Infrastructure --startup-project src/PatchHound.Api
+```
+
+Review the generated migration: it must **rename** the column (not drop + add), preserving existing row data only if the old `TenantVulnerability.VulnerabilityId` mapping is still derivable. If it is not (TenantVulnerability rows were dropped in Phase 2 without backfill), the migration must:
+1. Drop the `TenantVulnerabilityId` column.
+2. Add `VulnerabilityId` nullable, then mark nullable=false after backfill from application state. Since the deleted-table rows are gone, existing override rows have no canonical target — **delete orphan override rows** in the migration's `Up` body before setting the column to non-nullable. Document the data loss in the migration file's comment header.
+
+- [ ] **Step 4: Callers**
+
+Update every caller of `RemediationDecisionVulnerabilityOverride.Create(...)` and every `vo.TenantVulnerabilityId` reference to use `VulnerabilityId`. Controllers (`RemediationDecisionsController`), query services (`RemediationDecisionQueryService`), services (`RemediationDecisionService`), and the DTO (`RemediationDecisionDto.VulnerabilityOverrideDto`) all change. DTO field name changes from `TenantVulnerabilityId` → `VulnerabilityId` — frontend consumers must follow (handled in Task 20).
+
+- [ ] **Step 5: Build and commit**
+
+```bash
+dotnet build
+git add -A
+git commit -m "refactor(phase-4): re-anchor RemediationDecisionVulnerabilityOverride on canonical VulnerabilityId"
+```
+
+---
+
+### Task 8: Re-anchor `SoftwareDescriptionJob` on `SoftwareProductId`
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/SoftwareDescriptionJob.cs`
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/SoftwareDescriptionJobConfiguration.cs`
+
+- [ ] **Step 1: Rewrite the entity**
+
+Replace with:
+```csharp
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class SoftwareDescriptionJob
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public Guid? TenantAiProfileId { get; private set; }
+    public SoftwareDescriptionJobStatus Status { get; private set; }
+    public string Error { get; private set; } = string.Empty;
+    public DateTimeOffset RequestedAt { get; private set; }
+    public DateTimeOffset? StartedAt { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private SoftwareDescriptionJob() { }
+
+    public static SoftwareDescriptionJob Create(
+        Guid tenantId,
+        Guid softwareProductId,
+        Guid? tenantAiProfileId,
+        DateTimeOffset requestedAt)
+    {
+        if (tenantId == Guid.Empty) throw new ArgumentException("TenantId is required.");
+        if (softwareProductId == Guid.Empty) throw new ArgumentException("SoftwareProductId is required.");
+        return new SoftwareDescriptionJob
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            SoftwareProductId = softwareProductId,
+            TenantAiProfileId = tenantAiProfileId,
+            Status = SoftwareDescriptionJobStatus.Pending,
+            RequestedAt = requestedAt,
+            UpdatedAt = requestedAt,
+        };
+    }
+
+    public void Start(DateTimeOffset startedAt)
+    {
+        Status = SoftwareDescriptionJobStatus.Running;
+        StartedAt = startedAt;
+        Error = string.Empty;
+        UpdatedAt = startedAt;
+    }
+
+    public void CompleteSucceeded(DateTimeOffset completedAt)
+    {
+        Status = SoftwareDescriptionJobStatus.Succeeded;
+        CompletedAt = completedAt;
+        Error = string.Empty;
+        UpdatedAt = completedAt;
+    }
+
+    public void CompleteFailed(DateTimeOffset completedAt, string error)
+    {
+        Status = SoftwareDescriptionJobStatus.Failed;
+        CompletedAt = completedAt;
+        Error = error;
+        UpdatedAt = completedAt;
+    }
+}
+```
+
+Note: `TenantSoftwareId` and `NormalizedSoftwareId` both removed. `TenantSoftwareProductInsight` is the tenant-scoped shadow for descriptions (Phase 1); this job writes *into* that insight table once complete — that wiring belongs in the service, not the entity.
+
+- [ ] **Step 2: Update EF configuration**
+
+In `SoftwareDescriptionJobConfiguration.cs`:
+- Drop `TenantSoftwareId`, `NormalizedSoftwareId`.
+- Add `builder.Property(j => j.SoftwareProductId).IsRequired();`
+- Add `builder.HasIndex(j => new { j.TenantId, j.SoftwareProductId, j.Status });`
+- No FK navigation to `SoftwareProduct` since the job references a global row — keep it as a bare column with an index.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Core/Entities/SoftwareDescriptionJob.cs src/PatchHound.Infrastructure/Data/Configurations/SoftwareDescriptionJobConfiguration.cs
+git commit -m "refactor(phase-4): anchor SoftwareDescriptionJob on SoftwareProductId"
+```
+
+---
+
+### Task 9: Drop `RemediationWorkflowStageRecord` `TenantSoftwareId` fallout
+
+**Files:**
+- Modify: `src/PatchHound.Core/Entities/RemediationWorkflowStageRecord.cs` (verify it has no `TenantSoftware*` fields — only `RemediationWorkflowId`)
+- Modify: `src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowStageRecordConfiguration.cs` (verify)
+
+- [ ] **Step 1: Grep for any `TenantSoftware*` references in the file**
+
+Run: `grep -n "TenantSoftware\|SoftwareAsset" src/PatchHound.Core/Entities/RemediationWorkflowStageRecord.cs`
+Expected: no matches. If matches exist, delete them.
+
+- [ ] **Step 2: Confirm config has no stale FKs**
+
+Run: `grep -n "TenantSoftware\|SoftwareAsset" src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowStageRecordConfiguration.cs`
+Expected: no matches.
+
+- [ ] **Step 3: If no changes, skip commit. Otherwise:**
+
+```bash
+git add src/PatchHound.Core/Entities/RemediationWorkflowStageRecord.cs src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowStageRecordConfiguration.cs
+git commit -m "refactor(phase-4): clean up RemediationWorkflowStageRecord"
+```
+
+---
+
+### Task 10: Rewrite `RemediationWorkflowService` case-first
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs`
+
+- [ ] **Step 1: Replace `GetOrCreateActiveWorkflowAsync` signature**
+
+Change every method that previously took `(tenantId, tenantSoftwareId)` to take `(tenantId, remediationCaseId)`. The owner team lookup now comes from `RemediationCase.SoftwareProduct` → software-team mapping (via `TenantSoftwareProductInsight` if present, otherwise fallback to the tenant's default team). Example signature:
+
+```csharp
+public async Task<RemediationWorkflow> GetOrCreateActiveWorkflowAsync(
+    Guid tenantId,
+    Guid remediationCaseId,
+    CancellationToken ct)
+{
+    var existing = await dbContext.RemediationWorkflows
+        .FirstOrDefaultAsync(w =>
+            w.TenantId == tenantId
+            && w.RemediationCaseId == remediationCaseId
+            && w.Status == RemediationWorkflowStatus.Active, ct);
+    if (existing is not null) return existing;
+
+    var softwareOwnerTeamId = await ResolveSoftwareOwnerTeamIdAsync(tenantId, remediationCaseId, ct);
+    var previousWorkflow = await dbContext.RemediationWorkflows.AsNoTracking()
+        .Where(w => w.TenantId == tenantId
+            && w.RemediationCaseId == remediationCaseId
+            && w.Status != RemediationWorkflowStatus.Active
+            && w.ProposedOutcome != null)
+        .OrderByDescending(w => w.CreatedAt)
+        .FirstOrDefaultAsync(ct);
+
+    var isRecurrence = previousWorkflow is not null;
+    var initialStage = isRecurrence
+        ? RemediationWorkflowStage.Verification
+        : RemediationWorkflowStage.SecurityAnalysis;
+    var workflow = RemediationWorkflow.Create(
+        tenantId, remediationCaseId, softwareOwnerTeamId, initialStage, previousWorkflow?.Id);
+    // ... (carry over ProposedOutcome/Priority/ApprovalMode as before)
+    dbContext.RemediationWorkflows.Add(workflow);
+    // ... (stage record creation as before, unchanged)
+    return workflow;
+}
+```
+
+- [ ] **Step 2: Rewrite `ResolveSoftwareOwnerTeamIdAsync` to take `remediationCaseId`**
+
+The method loads the `RemediationCase` to get `SoftwareProductId`, then resolves the software owner team via whatever ownership mapping exists (check `TenantSoftwareProductInsight` for an `OwnerTeamId` field, or the tenant default team). If Phase 1 didn't introduce a product-owner mapping, fall back to `tenant.DefaultSoftwareOwnerTeamId`. Leave a `// TODO(phase-5): revisit owner team assignment when dashboard rewrite lands` comment inline.
+
+- [ ] **Step 3: Delete every remaining reference to `TenantSoftwareId` in this file**
+
+Run: `grep -n "TenantSoftware\|tenantSoftware\|SoftwareAsset" src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs`
+Expected: no matches.
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build PatchHound.slnx 2>&1 | grep -E "error CS" | head -20`
+Expected: errors are now confined to callers of this service (next tasks handle them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
+git commit -m "refactor(phase-4): rewrite RemediationWorkflowService case-first"
+```
+
+---
+
+### Task 11: Rewrite `RemediationDecisionService` case-first
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs`
+
+- [ ] **Step 1: Rename and rewrite `CreateDecisionForTenantSoftwareAsync` → `CreateDecisionForCaseAsync`**
+
+New signature:
+```csharp
+public async Task<Result<RemediationDecision>> CreateDecisionForCaseAsync(
+    Guid tenantId,
+    Guid remediationCaseId,
+    RemediationOutcome outcome,
+    string? justification,
+    Guid decidedBy,
+    DateTimeOffset? expiryDate,
+    DateTimeOffset? reEvaluationDate,
+    CancellationToken ct)
+```
+Body: verify the case exists for the tenant, construct the decision via `RemediationDecision.Create(tenantId, remediationCaseId, outcome, ...)`, attach to workflow via `workflowService.AttachDecisionAsync(decision, ct)`. All `TenantSoftware` / `SoftwareAsset` lookups and reassignments are deleted.
+
+- [ ] **Step 2: Rewrite `AddVulnerabilityOverrideAsync`**
+
+The method already takes a `decisionId`; after Task 7b re-anchors the override on canonical `VulnerabilityId`, it no longer needs to resolve `TenantVulnerabilityId`. (The "re-anchored in Phase 2" claim in earlier plan drafts is stale — Phase 2 only deleted `TenantVulnerability`; the column rename/drop happens in Task 7b.) Signature:
+```csharp
+public async Task<Result<RemediationDecisionVulnerabilityOverride>> AddVulnerabilityOverrideAsync(
+    Guid decisionId,
+    Guid vulnerabilityId,
+    RemediationOutcome outcome,
+    string justification,
+    CancellationToken ct)
+```
+
+- [ ] **Step 3: Rewrite `VerifyAndCarryForwardDecisionAsync` and `VerifyAndRequireNewDecisionAsync`**
+
+Both methods now read the previous decision by `RemediationCaseId` instead of `TenantSoftwareId`. The verification flow is otherwise unchanged.
+
+- [ ] **Step 4: Delete all `ReassignTenantSoftware*` methods**
+
+Run: `grep -n "ReassignTenantSoftware\|TenantSoftware\|SoftwareAsset" src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs`
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
+git commit -m "refactor(phase-4): rewrite RemediationDecisionService case-first"
+```
+
+---
+
+### Task 12: Rewrite remaining remediation services case-first
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/RemediationAiJobService.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/AnalystRecommendationService.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/ApprovalTaskService.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/SoftwareDescriptionJobService.cs` (if present)
+
+- [ ] **Step 1: `RemediationAiJobService.EnqueueAsync`**
+
+Change signature from `(tenantId, tenantSoftwareId, inputHash, ct)` to `(tenantId, remediationCaseId, inputHash, ct)`. All queries that looked up the job by `TenantSoftwareId` now look up by `RemediationCaseId`.
+
+- [ ] **Step 2: `AnalystRecommendationService.AddRecommendationForTenantSoftwareAsync` → `AddRecommendationForCaseAsync`**
+
+New signature:
+```csharp
+public async Task<Result<AnalystRecommendation>> AddRecommendationForCaseAsync(
+    Guid tenantId,
+    Guid remediationCaseId,
+    RemediationOutcome outcome,
+    string rationale,
+    Guid analystId,
+    Guid? vulnerabilityId,
+    string? priorityOverride,
+    CancellationToken ct)
+```
+The body constructs via `AnalystRecommendation.Create(tenantId, remediationCaseId, ...)` and calls `workflowService.AttachRecommendationAsync(tenantId, remediationCaseId, recommendation, ct)`.
+
+- [ ] **Step 3: `ApprovalTaskService` ensure all creation paths pass the case ID**
+
+Any method that builds an `ApprovalTask` now reads the parent `RemediationDecision.RemediationCaseId` and forwards it to `ApprovalTask.Create`.
+
+- [ ] **Step 4: `SoftwareDescriptionJobService` (if present)**
+
+Enqueue signature becomes `(tenantId, softwareProductId, tenantAiProfileId, ct)`. On success, write the description into `TenantSoftwareProductInsight` (tenant-scoped) rather than any legacy software row.
+
+- [ ] **Step 5: Grep sweep**
+
+Run: `grep -rn "TenantSoftware\|SoftwareAsset" src/PatchHound.Infrastructure/Services/ | grep -v "\.cs.bak"`
+Expected: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/RemediationAiJobService.cs src/PatchHound.Infrastructure/Services/AnalystRecommendationService.cs src/PatchHound.Infrastructure/Services/ApprovalTaskService.cs src/PatchHound.Infrastructure/Services/SoftwareDescriptionJobService.cs
+git commit -m "refactor(phase-4): rewrite remaining remediation services case-first"
+```
+
+---
+
+### Task 13: Rewrite `RemediationDecisionQueryService` case-first
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/RemediationDecisionQueryService.cs` (1882 lines)
+
+This is the heaviest rewrite. The service currently has `BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, includeArchived, ct)` returning a `DecisionContextDto`. It joins across `TenantSoftware`, `TenantVulnerability`, `VulnerabilityAssetEpisode` (all deleted in earlier phases).
+
+- [ ] **Step 1: Rename the entry point**
+
+`BuildByTenantSoftwareAsync` → `BuildByCaseAsync(Guid tenantId, Guid remediationCaseId, bool includeArchived, CancellationToken ct)`.
+
+- [ ] **Step 2: Rewrite the join pipeline to read from canonical**
+
+The new pipeline:
+1. Load `RemediationCase` by `(TenantId, Id)`; return null if missing.
+2. Load `SoftwareProduct` by `case.SoftwareProductId`.
+3. Load `InstalledSoftware` rows for the tenant + product via `InstalledSoftware.SoftwareProductId == case.SoftwareProductId && InstalledSoftware.TenantId == tenantId`.
+4. Load `DeviceVulnerabilityExposure` rows for those `InstalledSoftwareId`s, join canonical `Vulnerability` and `ExposureAssessment` for severity and env score.
+5. Load `RemediationWorkflow` + `RemediationDecision` + `ApprovalTask` + `AnalystRecommendation` + `AIReport` by `RemediationCaseId == caseId`.
+6. Assemble into `DecisionContextDto`.
+
+- [ ] **Step 3: Update `DecisionContextDto`**
+
+Remove `TenantSoftwareId`, `SoftwareAssetId`, `TenantVulnerabilityId` fields from the DTO. Add `RemediationCaseId`, `SoftwareProductId`, `ProductName`, `Vendor`. Vulnerability list items carry `VulnerabilityId` (canonical) and `EnvironmentalCvss` from `ExposureAssessment`.
+
+- [ ] **Step 4: Update any DTO sub-records**
+
+Every nested DTO that referenced a legacy ID (`RemediationDecisionDto`, `AnalystRecommendationDto`, `VulnerabilityOverrideDto`, `ApprovalTaskDto`) updates to canonical IDs. `VulnerabilityOverrideDto` carries `VulnerabilityId`, `AnalystRecommendationDto` carries `VulnerabilityId`, etc.
+
+- [ ] **Step 5: Grep sweep inside the file**
+
+Run: `grep -n "TenantSoftware\|SoftwareAsset\|TenantVulnerability\|VulnerabilityAsset" src/PatchHound.Api/Services/RemediationDecisionQueryService.cs`
+Expected: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Api/Services/RemediationDecisionQueryService.cs src/PatchHound.Api/Models/Decisions/
+git commit -m "refactor(phase-4): rewrite RemediationDecisionQueryService to case-first canonical joins"
+```
+
+---
+
+### Task 14: Rewrite `RemediationTaskQueryService` case-first
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/RemediationTaskQueryService.cs`
+- Modify: `src/PatchHound.Api/Models/Remediation/*` (as needed)
+
+- [ ] **Step 1: Replace `ListOpenTasksAsync` joins**
+
+All joins against `TenantSoftware` / `Asset` replaced with joins against `RemediationCase` + `SoftwareProduct` + `InstalledSoftware` (for device counts) + `DeviceVulnerabilityExposure` (for exposure counts).
+
+- [ ] **Step 2: Replace `ListTeamStatusesForSoftwareAsync(tenantId, tenantSoftwareId, ct)` → `ListTeamStatusesForCaseAsync(tenantId, remediationCaseId, ct)`**
+
+Query joins `PatchingTask` → `RemediationCase` and groups by `OwnerTeamId`. The result DTO carries `RemediationCaseId`.
+
+- [ ] **Step 3: Replace `CreateMissingTasksForSoftwareAsync(tenantId, tenantSoftwareId, userId, ct)` → `CreateMissingTasksForCaseAsync(tenantId, remediationCaseId, userId, ct)`**
+
+Body loads the latest approved `RemediationDecision` for the case and creates `PatchingTask` rows per owner team via `PatchingTask.Create(tenantId, remediationCaseId, decisionId, ownerTeamId, dueDate)`.
+
+- [ ] **Step 4: Update `RemediationTaskListItemDto`, `RemediationTaskTeamStatusDto`, `RemediationTaskCreateResultDto`**
+
+Drop `TenantSoftwareId` / `SoftwareAssetId`. Add `RemediationCaseId`, `SoftwareProductId`, `ProductName`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Api/Services/RemediationTaskQueryService.cs src/PatchHound.Api/Models/Remediation/
+git commit -m "refactor(phase-4): rewrite RemediationTaskQueryService case-first"
+```
+
+---
+
+### Task 15: Rewrite `RemediationWorkflowAuthorizationService` case-first
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/RemediationWorkflowAuthorizationService.cs`
+
+- [ ] **Step 1: Change signatures**
+
+Every `(tenantId, tenantSoftwareId, ...)` method becomes `(tenantId, remediationCaseId, ...)`. The authorization check loads the `RemediationCase`, then resolves the software owner team from the case and checks the current user's role/team membership.
+
+- [ ] **Step 2: Grep sweep**
+
+Run: `grep -n "TenantSoftware\|SoftwareAsset" src/PatchHound.Api/Services/RemediationWorkflowAuthorizationService.cs`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Api/Services/RemediationWorkflowAuthorizationService.cs
+git commit -m "refactor(phase-4): rewrite RemediationWorkflowAuthorizationService case-first"
+```
+
+---
+
+### Task 16: Rewrite `RemediationDecisionsController` to `/api/remediation/cases/{caseId}/*`
+
+**Files:**
+- Modify: `src/PatchHound.Api/Controllers/RemediationDecisionsController.cs`
+
+- [ ] **Step 1: Change the route prefix**
+
+Replace `[Route("api/software/{tenantSoftwareId:guid}/remediation")]` with `[Route("api/remediation/cases/{caseId:guid}")]`. Delete every cross-route `[HttpPost("/api/remediation/{workflowId:guid}/...")]` — replace with case-scoped routes.
+
+- [ ] **Step 2: Rewrite each action**
+
+Every action that took `Guid tenantSoftwareId` now takes `Guid caseId`. Controller body delegates to `queryService.BuildByCaseAsync(tenantId, caseId, ...)`, `decisionService.CreateDecisionForCaseAsync(tenantId, caseId, ...)`, etc. The AI summary endpoints read through the case, and `ai-summary/review` marks the tenant insight (not tenant software) as reviewed.
+
+Example for `GetDecisionContext`:
+```csharp
+[HttpGet("decision-context")]
+[Authorize(Policy = Policies.ViewVulnerabilities)]
+public async Task<ActionResult<DecisionContextDto>> GetDecisionContext(Guid caseId, CancellationToken ct)
+{
+    if (tenantContext.CurrentTenantId is not Guid tenantId)
+        return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+    var result = await queryService.BuildByCaseAsync(tenantId, caseId, false, ct);
+    if (result is null)
+        return NotFound();
+    return Ok(result);
+}
+```
+
+- [ ] **Step 3: Rewrite `EnsureWorkflow`**
+
+New route `POST /api/remediation/cases/{caseId:guid}/workflow`. Body looks up the case, calls `workflowService.GetOrCreateActiveWorkflowAsync(tenantId, caseId, ct)`, returns `EnsureRemediationWorkflowResponse(workflow.Id)`.
+
+- [ ] **Step 4: Delete every reference to `tenantSoftwareId`**
+
+Run: `grep -n "tenantSoftwareId\|TenantSoftware\|SoftwareAsset" src/PatchHound.Api/Controllers/RemediationDecisionsController.cs`
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+git commit -m "refactor(phase-4): collapse remediation decisions API to /api/remediation/cases/{caseId}/*"
+```
+
+---
+
+### Task 17: Rewrite `RemediationTasksController` case-first
+
+**Files:**
+- Modify: `src/PatchHound.Api/Controllers/RemediationTasksController.cs`
+
+- [ ] **Step 1: Change routes**
+
+- `GET /api/remediation/tasks` — unchanged (global tenant-scoped list).
+- `GET /api/remediation/cases/{caseId:guid}/team-statuses` — replaces `/api/remediation/tasks/software/{tenantSoftwareId}/team-statuses`.
+- `POST /api/remediation/cases/{caseId:guid}/tasks` — replaces `/api/remediation/tasks/software/{tenantSoftwareId}`.
+
+- [ ] **Step 2: Rewrite action bodies**
+
+Delegate to `queryService.ListTeamStatusesForCaseAsync(tenantId, caseId, ct)` and `queryService.CreateMissingTasksForCaseAsync(tenantId, caseId, userId, ct)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/RemediationTasksController.cs
+git commit -m "refactor(phase-4): rewrite RemediationTasksController case-first"
+```
+
+---
+
+### Task 18: Add `RemediationCasesController` entry points
+
+**Files:**
+- Create: `src/PatchHound.Api/Controllers/RemediationCasesController.cs`
+- Create: `src/PatchHound.Api/Models/Remediation/RemediationCaseDto.cs`
+
+- [ ] **Step 1: Create the DTO**
+
+```csharp
+namespace PatchHound.Api.Models.Remediation;
+
+public record RemediationCaseDto(
+    Guid Id,
+    Guid TenantId,
+    Guid SoftwareProductId,
+    string ProductName,
+    string Vendor,
+    string Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    DateTimeOffset? ClosedAt,
+    int AffectedDeviceCount,
+    int OpenExposureCount);
+```
+
+- [ ] **Step 2: Create the controller**
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models;
+using PatchHound.Api.Models.Remediation;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/remediation/cases")]
+[Authorize]
+public class RemediationCasesController(
+    PatchHoundDbContext db,
+    RemediationCaseService caseService,
+    ITenantContext tenantContext) : ControllerBase
+{
+    [HttpGet]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<PagedResponse<RemediationCaseDto>>> List(
+        [FromQuery] PaginationQuery pagination,
+        CancellationToken ct)
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        var query = db.RemediationCases.AsNoTracking()
+            .Where(c => c.TenantId == tenantId)
+            .OrderByDescending(c => c.UpdatedAt);
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip(pagination.Skip).Take(pagination.BoundedPageSize)
+            .Select(c => new RemediationCaseDto(
+                c.Id, c.TenantId, c.SoftwareProductId,
+                c.SoftwareProduct.Name, c.SoftwareProduct.Vendor,
+                c.Status.ToString(), c.CreatedAt, c.UpdatedAt, c.ClosedAt,
+                db.InstalledSoftware.Count(i =>
+                    i.TenantId == tenantId && i.SoftwareProductId == c.SoftwareProductId),
+                db.DeviceVulnerabilityExposures.Count(e =>
+                    e.TenantId == tenantId
+                    && e.SoftwareProductId == c.SoftwareProductId
+                    && e.Status == Core.Enums.DeviceExposureStatus.Open)))
+            .ToListAsync(ct);
+
+        return new PagedResponse<RemediationCaseDto>(items, total, pagination.Page, pagination.BoundedPageSize);
+    }
+
+    [HttpGet("{caseId:guid}")]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<RemediationCaseDto>> Get(Guid caseId, CancellationToken ct)
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        var c = await db.RemediationCases.AsNoTracking()
+            .Include(x => x.SoftwareProduct)
+            .FirstOrDefaultAsync(x => x.TenantId == tenantId && x.Id == caseId, ct);
+        if (c is null) return NotFound();
+
+        return new RemediationCaseDto(
+            c.Id, c.TenantId, c.SoftwareProductId,
+            c.SoftwareProduct.Name, c.SoftwareProduct.Vendor,
+            c.Status.ToString(), c.CreatedAt, c.UpdatedAt, c.ClosedAt,
+            await db.InstalledSoftware.CountAsync(i =>
+                i.TenantId == tenantId && i.SoftwareProductId == c.SoftwareProductId, ct),
+            await db.DeviceVulnerabilityExposures.CountAsync(e =>
+                e.TenantId == tenantId
+                && e.SoftwareProductId == c.SoftwareProductId
+                && e.Status == Core.Enums.DeviceExposureStatus.Open, ct));
+    }
+
+    public record CreateCaseRequest(Guid SoftwareProductId);
+
+    [HttpPost]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<RemediationCaseDto>> GetOrCreate(
+        [FromBody] CreateCaseRequest req, CancellationToken ct)
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        try
+        {
+            var c = await caseService.GetOrCreateAsync(tenantId, req.SoftwareProductId, ct);
+            return await Get(c.Id, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new ProblemDetails { Title = ex.Message });
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/RemediationCasesController.cs src/PatchHound.Api/Models/Remediation/RemediationCaseDto.cs
+git commit -m "feat(phase-4): add RemediationCasesController list/get/create endpoints"
+```
+
+---
+
+### Task 19: Green the backend build
+
+**Files:**
+- Modify: any remaining file that the compiler flags.
+
+- [ ] **Step 1: Run the build and collect errors**
+
+Run: `dotnet build PatchHound.slnx 2>&1 | grep -E "error CS" > /tmp/phase4-build-errors.txt; wc -l /tmp/phase4-build-errors.txt`
+
+- [ ] **Step 2: Fix each remaining call site**
+
+Typical remaining fixes:
+- Services still passing `tenantSoftwareId` to workflow/decision/task services — switch to a `RemediationCase` lookup via `RemediationCaseService.GetOrCreateAsync`.
+- DTO mappers referencing dropped fields — remove.
+- Test fixtures constructing `RemediationWorkflow`/`RemediationDecision`/`PatchingTask` with the old signatures — update to pass a `remediationCaseId`.
+
+Work through the error list top to bottom. Rebuild after each cluster of fixes until `dotnet build` reports zero errors.
+
+- [ ] **Step 3: Run backend tests**
+
+Run: `dotnet test PatchHound.slnx`
+Expected: all existing tests green (some will legitimately have been updated to use case IDs in their arrange step; any test that asserted on `TenantSoftwareId` should have its assertion rewritten to `RemediationCaseId`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(phase-4): fix remaining compile and test failures after case-first rewrite"
+```
+
+---
+
+### Task 20: Frontend — collapse remediation routes to case-first
+
+**Files:**
+- Delete: `frontend/src/routes/_authed/software/$id_.remediation.tsx`
+- Delete: `frontend/src/routes/_authed/assets/$id_.remediation.tsx`
+- Create: `frontend/src/routes/_authed/remediation/cases.$caseId.tsx`
+- Modify: `frontend/src/routes/_authed/remediation/index.tsx`
+- Modify: `frontend/src/routes/_authed/remediation/task.$id.tsx`
+- Modify: `frontend/src/routes/_authed/remediation/tasks.tsx`
+- Modify: every component under `frontend/src/components/features/remediation/*`
+- Modify: any callers in `frontend/src/components/features/software/*`, `dashboard/*`, `assets/*`, `vulnerabilities/*` that navigate to remediation
+
+- [ ] **Step 1: Create the case route file**
+
+Create `frontend/src/routes/_authed/remediation/cases.$caseId.tsx`:
+```tsx
+import { createFileRoute } from '@tanstack/react-router';
+import { RemediationWorkbench } from '@/components/features/remediation/RemediationWorkbench';
+
+export const Route = createFileRoute('/_authed/remediation/cases/$caseId')({
+  component: RemediationCaseRoute,
+});
+
+function RemediationCaseRoute() {
+  const { caseId } = Route.useParams();
+  return <RemediationWorkbench caseId={caseId} />;
+}
+```
+
+- [ ] **Step 2: Rewrite `RemediationWorkbench` props**
+
+Change `RemediationWorkbench` to accept `{ caseId: string }`. All `tenantSoftwareId` references inside the component and its children become `caseId`. The API calls change:
+- `GET /api/software/${tenantSoftwareId}/remediation/decision-context` → `GET /api/remediation/cases/${caseId}/decision-context`
+- `POST /api/software/${tenantSoftwareId}/remediation/workflow` → `POST /api/remediation/cases/${caseId}/workflow`
+- `POST /api/remediation/${workflowId}/decision` — keep the route (workflow id lookup still works) or re-point it to `/api/remediation/cases/${caseId}/decision` if Task 16 renamed it. **Use the renamed route.**
+- `POST /api/remediation/${workflowId}/analysis` → `POST /api/remediation/cases/${caseId}/analysis`
+- `POST /api/remediation/${workflowId}/verification` → `POST /api/remediation/cases/${caseId}/verification`
+- `POST /api/remediation/${workflowId}/approval` → `POST /api/remediation/cases/${caseId}/approval`
+- `POST /api/software/${tenantSoftwareId}/remediation/ai-summary` → `POST /api/remediation/cases/${caseId}/ai-summary`
+- `POST /api/software/${tenantSoftwareId}/remediation/ai-summary/review` → `POST /api/remediation/cases/${caseId}/ai-summary/review`
+- `GET /api/software/${tenantSoftwareId}/remediation/audit-trail` → `GET /api/remediation/cases/${caseId}/audit-trail`
+- `POST /api/remediation/tasks/software/${tenantSoftwareId}` → `POST /api/remediation/cases/${caseId}/tasks`
+- `GET /api/remediation/tasks/software/${tenantSoftwareId}/team-statuses` → `GET /api/remediation/cases/${caseId}/team-statuses`
+
+- [ ] **Step 3: Update navigation from software detail**
+
+In `frontend/src/components/features/software/SoftwareDetailPage.tsx` and `SoftwareTable.tsx`, remediation deep links previously routed to `/software/$id/remediation`. Replace with a two-step flow: call `POST /api/remediation/cases` with `{ softwareProductId }` to get-or-create a case, then navigate to `/remediation/cases/$caseId`. A small hook `useOpenRemediationCase(productId)` in `frontend/src/hooks/useOpenRemediationCase.ts` encapsulates this.
+
+- [ ] **Step 4: Update dashboard deep links**
+
+In `frontend/src/components/features/dashboard/{AssetOwnerOverview,SecurityManagerOverview,TechnicalManagerOverview}.tsx`, every "open remediation" link that pointed at `/software/$id/remediation` goes through `useOpenRemediationCase`.
+
+- [ ] **Step 5: Update `RemediationTaskWorkbench` / task detail**
+
+`frontend/src/routes/_authed/remediation/task.$id.tsx` loads a `PatchingTask` by id. The DTO now carries `remediationCaseId` instead of `tenantSoftwareId`. The "open related case" button navigates to `/remediation/cases/$caseId`.
+
+- [ ] **Step 6: Update remediation task list**
+
+`frontend/src/routes/_authed/remediation/tasks.tsx` and `RemediationSummaryCards.tsx` render columns using `caseId` / `productName` — drop the `tenantSoftwareId` column.
+
+- [ ] **Step 7: Delete the old routes**
+
+```bash
+rm frontend/src/routes/_authed/software/\$id_.remediation.tsx
+rm frontend/src/routes/_authed/assets/\$id_.remediation.tsx
+```
+
+- [ ] **Step 8: Grep sweep**
+
+Run: `grep -rn "tenantSoftwareId" frontend/src | head -20`
+Expected: no matches (except possibly in soft-deleted test snapshot files — if any, delete them).
+
+- [ ] **Step 9: Typecheck and test**
+
+Run: `cd frontend && npm run typecheck && npm test -- --run`
+Expected: both green.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd ..
+git add frontend/src/
+git commit -m "refactor(phase-4): collapse remediation UI to /remediation/cases/\$caseId"
+```
+
+---
+
+### Task 21: Extend `TenantIsolationEndToEndTests` with remediation-case assertions
+
+**Files:**
+- Modify: `tests/PatchHound.Tests/Api/Tests/TenantIsolationEndToEndTests.cs`
+
+- [ ] **Step 1: Seed a remediation case per tenant**
+
+In the two-tenant fixture, for each tenant seed:
+- A `SoftwareProduct` (global — same product id is fine; cases are keyed by tenant + product).
+- An `InstalledSoftware` row for that tenant's device.
+- A `RemediationCase` for `(tenantId, productId)`.
+- A `RemediationWorkflow`, `RemediationDecision` (approved), `PatchingTask`, `ApprovalTask`, `AnalystRecommendation`, `AIReport` anchored on the case.
+
+- [ ] **Step 2: Add assertions**
+
+```csharp
+[Fact]
+public async Task Tenant_A_cannot_see_tenant_B_remediation_cases()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+
+    var listResponse = await tenantAClient.GetAsync("/api/remediation/cases?page=1&pageSize=100");
+    listResponse.EnsureSuccessStatusCode();
+    var page = await listResponse.Content.ReadFromJsonAsync<PagedResponse<RemediationCaseDto>>();
+    Assert.NotNull(page);
+    Assert.All(page!.Items, c => Assert.Equal(TenantA.Id, c.TenantId));
+    Assert.DoesNotContain(page.Items, c => c.Id == TenantBSeed.RemediationCase.Id);
+}
+
+[Fact]
+public async Task Tenant_A_cannot_open_tenant_B_case_by_id()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var response = await tenantAClient.GetAsync(
+        $"/api/remediation/cases/{TenantBSeed.RemediationCase.Id}");
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+}
+
+[Fact]
+public async Task Tenant_A_cannot_read_decision_context_for_tenant_B_case()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var response = await tenantAClient.GetAsync(
+        $"/api/remediation/cases/{TenantBSeed.RemediationCase.Id}/decision-context");
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+}
+
+[Fact]
+public async Task Tenant_A_cannot_file_a_decision_against_tenant_B_case()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var body = new CreateDecisionRequest(
+        Outcome: RemediationOutcome.ApprovedForPatching.ToString(),
+        Justification: "xss",
+        ExpiryDate: null,
+        ReEvaluationDate: null);
+    var response = await tenantAClient.PostAsJsonAsync(
+        $"/api/remediation/cases/{TenantBSeed.RemediationCase.Id}/decision", body);
+    Assert.True(response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Forbidden);
+}
+
+[Fact]
+public async Task Decisions_created_by_tenant_A_carry_tenant_A_id_even_if_payload_lies()
+{
+    // Spec §4.10 Rule 4: TenantId is stamped from TenantContext, never from the payload.
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var body = new CreateDecisionRequest(
+        Outcome: RemediationOutcome.ApprovedForPatching.ToString(),
+        Justification: "ok",
+        ExpiryDate: null,
+        ReEvaluationDate: null);
+    var response = await tenantAClient.PostAsJsonAsync(
+        $"/api/remediation/cases/{TenantASeed.RemediationCase.Id}/decision", body);
+    response.EnsureSuccessStatusCode();
+
+    using var scope = _factory.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<PatchHoundDbContext>();
+    var systemDb = db.AsSystemContext();
+    var decision = await systemDb.RemediationDecisions
+        .OrderByDescending(d => d.CreatedAt)
+        .FirstAsync();
+    Assert.Equal(TenantA.Id, decision.TenantId);
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~TenantIsolationEndToEndTests"`
+Expected: all assertions pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/PatchHound.Tests/Api/Tests/TenantIsolationEndToEndTests.cs
+git commit -m "test(phase-4): extend tenant isolation e2e with remediation case assertions"
+```
+
+---
+
+### Task 22: Remediation case stability test (spec §7)
+
+**Files:**
+- Create: `tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseStabilityTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.TestInfrastructure;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class RemediationCaseStabilityTests
+{
+    [Fact]
+    public async Task Case_id_is_stable_across_multiple_get_or_create_calls()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var productId = Guid.NewGuid();
+        ctx.SoftwareProducts.Add(TestData.Product(productId));
+        await ctx.SaveChangesAsync();
+
+        var sut = new RemediationCaseService(ctx);
+
+        var ids = new List<Guid>();
+        for (var i = 0; i < 5; i++)
+        {
+            var c = await sut.GetOrCreateAsync(tenantId, productId, CancellationToken.None);
+            ids.Add(c.Id);
+        }
+
+        Assert.Single(ids.Distinct());
+        Assert.Equal(1, ctx.RemediationCases.Count());
+    }
+
+    [Fact]
+    public async Task Case_id_is_stable_across_device_churn()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var productId = Guid.NewGuid();
+        ctx.SoftwareProducts.Add(TestData.Product(productId));
+        await ctx.SaveChangesAsync();
+
+        var sut = new RemediationCaseService(ctx);
+        var initial = await sut.GetOrCreateAsync(tenantId, productId, CancellationToken.None);
+
+        // Simulate Phase 1 snapshot churn: delete and recreate installed software for the product.
+        // The case should not change.
+        var device = TestData.Device(tenantId);
+        ctx.Devices.Add(device);
+        ctx.InstalledSoftware.Add(TestData.InstalledSoftware(tenantId, device.Id, productId));
+        await ctx.SaveChangesAsync();
+
+        ctx.InstalledSoftware.RemoveRange(ctx.InstalledSoftware);
+        await ctx.SaveChangesAsync();
+
+        var afterChurn = await sut.GetOrCreateAsync(tenantId, productId, CancellationToken.None);
+        Assert.Equal(initial.Id, afterChurn.Id);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RemediationCaseStabilityTests"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseStabilityTests.cs
+git commit -m "test(phase-4): assert remediation case (tenant,product) stability across churn"
+```
+
+---
+
+### Task 23: Final grep sweep
+
+- [ ] **Step 1: Legacy identifier sweep**
+
+Run:
+```bash
+grep -rn "TenantSoftwareId\|SoftwareAssetId\|tenantSoftwareId\|softwareAssetId" src/ frontend/src/ 2>/dev/null | grep -v "\.Migrations/" | grep -v "Phase4" | head -30
+```
+Expected: empty (no matches).
+
+- [ ] **Step 2: Legacy route sweep**
+
+Run:
+```bash
+grep -rn "/api/software/.*remediation\|/api/remediation/tasks/software" src/ frontend/src/ 2>/dev/null | head -20
+```
+Expected: empty.
+
+- [ ] **Step 3: `IgnoreQueryFilters` audit**
+
+Run: `grep -rn "IgnoreQueryFilters" src/ | grep -v "\.bak"`
+Expected: only the documented system-context allow-list from Phase 1. Record the exact lines in the PR description. No new entries from Phase 4.
+
+- [ ] **Step 4: If sweeps are dirty, fix and commit; else skip**
+
+---
+
+### Task 24: Final build, test, PR
+
+- [ ] **Step 1: Full build and test**
+
+Run in parallel:
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx
+(cd frontend && npm run typecheck && npm test -- --run)
+```
+Expected: all green, 0 warnings, 0 errors.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin data-model-canonical-cleanup-phase-4
+```
+
+- [ ] **Step 3: Open the PR**
+
+Run:
+```bash
+gh pr create --title "Phase 4: RemediationCase case-first data model" --body "$(cat <<'EOF'
+## Summary
+- Introduce `RemediationCase` (tenant-scoped, keyed by `(TenantId, SoftwareProductId)`) as the remediation scope root.
+- Re-anchor `RemediationWorkflow`, `RemediationDecision`, `PatchingTask`, `ApprovalTask`, `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob` on `RemediationCaseId`.
+- Re-anchor `SoftwareDescriptionJob` on `SoftwareProductId` directly; description text lands in `TenantSoftwareProductInsight`.
+- Collapse remediation API to `/api/remediation/cases/{caseId}/*`; delete `/api/software/{tenantSoftwareId}/remediation/*` and `/api/remediation/tasks/software/*`.
+- Collapse remediation UI to `/remediation/cases/$caseId`; delete `_authed/software/$id_.remediation.tsx` and `_authed/assets/$id_.remediation.tsx`.
+- Tenant isolation e2e extended: cross-tenant case access returns 404; `TenantId` on every decision is stamped from `TenantContext`.
+- Remediation case stability test: `(TenantId, SoftwareProductId)` is stable across snapshot churn.
+
+## Tenant scope audit
+| Entity | Direct `TenantId` | EF global filter | Notes |
+| --- | --- | --- | --- |
+| `RemediationCase` | yes | yes | New — unique `(TenantId, SoftwareProductId)` |
+| `RemediationWorkflow` | yes | yes | Re-anchored via `RemediationCaseId` (same-tenant FK) |
+| `RemediationDecision` | yes | yes | Same |
+| `PatchingTask` | yes | yes | Same |
+| `ApprovalTask` | yes | yes | Same |
+| `RiskAcceptance` | yes | yes | Same |
+| `AnalystRecommendation` | yes | yes | Same |
+| `AIReport` | yes | yes | Same |
+| `RemediationAiJob` | yes | yes | Same |
+| `SoftwareDescriptionJob` | yes | yes | Anchored on global `SoftwareProductId` (no FK navigation) |
+
+## IgnoreQueryFilters audit
+No new entries. Allow-list unchanged from Phase 1 (recorded in Phase 1 PR).
+
+## Spec §4.10 rule compliance
+- R1 (direct `TenantId`): every remediation entity keeps its own column.
+- R2 (global filter): every new/modified entity has the filter.
+- R4 (`TenantId` from context): tenant isolation test `Decisions_created_by_tenant_A_carry_tenant_A_id_even_if_payload_lies` proves it.
+- R5 (no new `IgnoreQueryFilters`): grep clean.
+- R8 (same-tenant FK): `RemediationCase.TenantId == workflow.TenantId == decision.TenantId == ...` — verified by isolation test seed path.
+
+## Test plan
+- [ ] `dotnet build` clean
+- [ ] `dotnet test` green (new: `RemediationCaseTests`, `RemediationCaseServiceTests`, `RemediationCaseStabilityTests`, `RemediationWorkflowTests` extension, `TenantIsolationEndToEndTests` extension)
+- [ ] `npm run typecheck` clean
+- [ ] `npm test` green
+- [ ] Manual smoke: open a software product in the UI → "Open remediation case" routes to `/remediation/cases/$caseId` → file decision → approve → create patching task
+
+EOF
+)"
+```
+
+- [ ] **Step 4: Confirm PR URL printed**
+
+Expected: `https://github.com/frodehus/PatchHound/pull/<n>`
+
+---
+
+## Plan self-review
+
+**Spec coverage (spec §5.4):**
+- `RemediationCase` (tenant-scoped, non-null `SoftwareProductId`) — Task 1.
+- `RemediationWorkflow`, `RemediationDecision`, `PatchingTask`, `ApprovalTask` re-anchored on `RemediationCaseId` — Tasks 4–7.
+- `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob`, `RemediationWorkflowStageRecord` re-anchored — Tasks 7, 9.
+- `SoftwareDescriptionJob` re-anchored on `SoftwareProductId` — Task 8.
+- Drop `TenantSoftwareId`/`SoftwareAssetId` from every remediation table — Tasks 4–7.
+- API collapses to `/api/remediation/cases/{caseId}/*` — Tasks 16–18.
+- Frontend uses case IDs — Task 20.
+- Tenant isolation test extended — Task 21.
+- Case stability test (spec §7) — Task 22.
+
+**Type consistency:** every task that creates a `RemediationCase`-anchored entity calls `Create(tenantId, remediationCaseId, ...)`. Service methods uniformly use `remediationCaseId`. Route params uniformly use `caseId` (URL segment) / `remediationCaseId` (service parameter).
+
+**Placeholder scan:** no `TBD`/`TODO(phase-later)` except the one explicit `// TODO(phase-5)` note on owner-team resolution in Task 10 Step 2, which is legitimate — owner-team mapping is reworked in Phase 5 when dashboards are rewritten.
+
+**Cross-phase dependency check:** Phase 4 assumes Phase 2 already replaced `TenantVulnerabilityId` with canonical `VulnerabilityId` on `RemediationDecisionVulnerabilityOverride`, `RiskAcceptance`, `AnalystRecommendation`, `AIReport`. The plan header prerequisites call this out. If Phase 2 left any of those fields in place, Phase 2 merged incomplete — treat that as a bug in Phase 2, not a Phase 4 fix.

--- a/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-5.md
+++ b/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-5.md
@@ -1,0 +1,817 @@
+# Data Model Canonical Cleanup — Phase 5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite every read-side path — risk scoring, dashboard summaries, and email notifications — against canonical `Device`, `InstalledSoftware`, `DeviceVulnerabilityExposure`, `ExposureAssessment`, `ExposureEpisode`, and `RemediationCase` data. Remove any remaining stubs that Phases 2–4 parked while the write side was being rebuilt.
+
+**Architecture:** Phase 5 is a read-side cleanup. Nothing new is introduced; everything downstream of the ingestion + exposure + remediation pipelines is re-pointed at canonical rows. `RiskScoreService` reads `DeviceVulnerabilityExposure` joined to `ExposureAssessment` (tenant-scoped canonical) and writes `DeviceRiskScore`, `SoftwareRiskScore(TenantId, SoftwareProductId)`, `TeamRiskScore`, `DeviceGroupRiskScore`, `TenantRiskScoreSnapshot`. `DashboardQueryService` reads the same canonical rows and joins to `RemediationCase` for case-level summaries. `EmailNotificationService` renders emails from canonical rows with deep links to `/remediation/cases/{caseId}`.
+
+**Tech Stack:** .NET 10 / EF Core 10 / xUnit / React + Vitest.
+
+**Prerequisites:** Phases 1–4 merged. `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment`, `RemediationCase` exist and are populated. `VulnerabilityAsset*`, `TenantVulnerability`, `VulnerabilityAssetEpisode`, `AssetRiskScore`, `TenantSoftwareRiskScore` are all deleted. `DeviceRiskScore` and `SoftwareRiskScore` entities exist (introduced in Phase 1 per §5.1). Dashboard, email, and risk score code paths compile during Phases 2–4 only because they were left as trivially-returning stubs while the write side was rebuilt; Phase 5 fills those stubs in.
+
+**Phase 3 handoff — stubs still returning empty/409 after Phase 3 merged:**
+- `ApprovalTaskQueryService` (7 inline stubs tagged `Phase 4 debt (#17)`) — joined `SoftwareVulnerabilityMatch` / `VulnerabilityDefinition` / `TenantVulnerability` / `VulnerabilityAsset`. Must be rewired against canonical `Vulnerability` + `DeviceVulnerabilityExposure`.
+- `SoftwareDescriptionGenerationService` (1 stub) — consumed `NormalizedSoftwareVulnerabilityProjection`. Must be rewired against canonical exposure rows aggregated per `SoftwareProduct`.
+- `VulnerabilitiesController.UpdateOrganizationalSeverity` currently returns 409 Conflict with a "disabled during canonical migration" message. Must be restored using canonical `Vulnerability` + `OrganizationalSeverity` tenant-scoped entity (already carries canonical `VulnerabilityId`).
+
+These three items are not risk/dashboard/notification work strictly, but they live on read-surface controllers/services and share the canonical-exposure read substrate this phase rebuilds. They are added as Tasks at the end of this phase (see "Phase 3 handoff tasks" section).
+
+---
+
+## Preflight
+
+- [ ] **P1: Confirm Phase 4 merged**
+
+Run:
+```bash
+git log --oneline main -30 | grep -i "phase.4\|canonical-cleanup-phase-4"
+```
+Expected: at least one commit.
+
+- [ ] **P2: Cut Phase 5 branch**
+
+Run:
+```bash
+git checkout main && git pull
+git checkout -b data-model-canonical-cleanup-phase-5
+```
+
+- [ ] **P3: Wipe dev database**
+
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS patchhound;"
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "CREATE DATABASE patchhound;"
+```
+
+- [ ] **P4: Baseline green build**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx
+(cd frontend && npm run typecheck && npm test -- --run)
+```
+Expected: all green. If anything is red on a fresh Phase 4 main, stop and fix main first.
+
+- [ ] **P5: Audit the current stub scope**
+
+Run:
+```bash
+grep -rn "TODO.*phase.5\|phase5\|PHASE_5_STUB" src/PatchHound.Infrastructure/Services/RiskScoreService.cs src/PatchHound.Infrastructure/Services/EmailNotificationService.cs src/PatchHound.Api/Services/DashboardQueryService.cs src/PatchHound.Api/Controllers/DashboardController.cs
+```
+Expected: a non-zero list of stubs pointing at the read paths this phase replaces. Record the list in a short note committed as `docs/superpowers/plans/2026-04-10-phase-5-stub-inventory.md` so the reviewer knows exactly what Phase 5 is filling in.
+
+---
+
+### Task 1: Add canonical read-model unit tests for `RiskScoreService`
+
+**Files:**
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceCanonicalTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create the file with:
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure.TestInfrastructure;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class RiskScoreServiceCanonicalTests
+{
+    [Fact]
+    public async Task Device_score_comes_from_exposure_assessment_env_cvss()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var seed = CanonicalSeed.TwoDevicesOneVulnerability(ctx, tenantId,
+            deviceAEnvCvss: 9.5m,
+            deviceBEnvCvss: 4.2m);
+        await ctx.SaveChangesAsync();
+
+        var sut = new RiskScoreService(ctx, NullLogger.For<RiskScoreService>());
+        await sut.RecalculateForTenantAsync(tenantId, CancellationToken.None);
+
+        var scoreA = ctx.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id);
+        var scoreB = ctx.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceB.Id);
+
+        Assert.Equal(9.5m, scoreA.MaxExposureScore);
+        Assert.Equal(4.2m, scoreB.MaxExposureScore);
+        Assert.True(scoreA.OverallScore > scoreB.OverallScore);
+    }
+
+    [Fact]
+    public async Task Software_score_is_keyed_by_tenant_and_software_product_id()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var seed = CanonicalSeed.TwoDevicesOneVulnerability(ctx, tenantId);
+        await ctx.SaveChangesAsync();
+
+        var sut = new RiskScoreService(ctx, NullLogger.For<RiskScoreService>());
+        await sut.RecalculateForTenantAsync(tenantId, CancellationToken.None);
+
+        var softwareScore = ctx.SoftwareRiskScores.Single();
+        Assert.Equal(tenantId, softwareScore.TenantId);
+        Assert.Equal(seed.SoftwareProduct.Id, softwareScore.SoftwareProductId);
+        Assert.Equal(2, softwareScore.AffectedDeviceCount);
+    }
+
+    [Fact]
+    public async Task Resolved_exposures_are_excluded_from_open_counts()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var seed = CanonicalSeed.TwoDevicesOneVulnerability(ctx, tenantId);
+        seed.ExposureB.Resolve(DateTimeOffset.UtcNow);
+        await ctx.SaveChangesAsync();
+
+        var sut = new RiskScoreService(ctx, NullLogger.For<RiskScoreService>());
+        await sut.RecalculateForTenantAsync(tenantId, CancellationToken.None);
+
+        var softwareScore = ctx.SoftwareRiskScores.Single();
+        Assert.Equal(1, softwareScore.OpenExposureCount);
+    }
+}
+```
+
+Note: `CanonicalSeed.TwoDevicesOneVulnerability` is a new shared fixture helper created in the next step. Its shape: seeds one `SoftwareProduct`, one canonical `Vulnerability`, two `Device` rows each with the product installed, two `DeviceVulnerabilityExposure` rows, and two `ExposureAssessment` rows with caller-specified env CVSS scores.
+
+- [ ] **Step 2: Create the shared fixture helper**
+
+Create `tests/PatchHound.Tests/Infrastructure/TestInfrastructure/CanonicalSeed.cs`:
+```csharp
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Tests.Infrastructure.TestInfrastructure;
+
+public static class CanonicalSeed
+{
+    public record TwoDeviceSeed(
+        SoftwareProduct SoftwareProduct,
+        Vulnerability Vulnerability,
+        Device DeviceA,
+        Device DeviceB,
+        DeviceVulnerabilityExposure ExposureA,
+        DeviceVulnerabilityExposure ExposureB,
+        ExposureAssessment AssessmentA,
+        ExposureAssessment AssessmentB);
+
+    public static TwoDeviceSeed TwoDevicesOneVulnerability(
+        PatchHoundDbContext ctx,
+        Guid tenantId,
+        decimal deviceAEnvCvss = 9.0m,
+        decimal deviceBEnvCvss = 5.0m)
+    {
+        var product = TestData.Product();
+        var vuln = TestData.Vulnerability(baseCvss: 7.5m);
+        var deviceA = TestData.Device(tenantId, name: "device-a");
+        var deviceB = TestData.Device(tenantId, name: "device-b");
+        var installA = TestData.InstalledSoftware(tenantId, deviceA.Id, product.Id);
+        var installB = TestData.InstalledSoftware(tenantId, deviceB.Id, product.Id);
+        var exposureA = DeviceVulnerabilityExposure.Observe(
+            tenantId, deviceA.Id, vuln.Id, product.Id, installA.Id,
+            "1.0.0", DeviceExposureMatchSource.Product, DateTimeOffset.UtcNow);
+        var exposureB = DeviceVulnerabilityExposure.Observe(
+            tenantId, deviceB.Id, vuln.Id, product.Id, installB.Id,
+            "1.0.0", DeviceExposureMatchSource.Product, DateTimeOffset.UtcNow);
+        var assessmentA = ExposureAssessment.Create(
+            tenantId, exposureA.Id, securityProfileId: null,
+            baseCvss: 7.5m, environmentalCvss: deviceAEnvCvss,
+            reason: "test-a", calculatedAt: DateTimeOffset.UtcNow);
+        var assessmentB = ExposureAssessment.Create(
+            tenantId, exposureB.Id, securityProfileId: null,
+            baseCvss: 7.5m, environmentalCvss: deviceBEnvCvss,
+            reason: "test-b", calculatedAt: DateTimeOffset.UtcNow);
+
+        ctx.SoftwareProducts.Add(product);
+        ctx.Vulnerabilities.Add(vuln);
+        ctx.Devices.AddRange(deviceA, deviceB);
+        ctx.InstalledSoftware.AddRange(installA, installB);
+        ctx.DeviceVulnerabilityExposures.AddRange(exposureA, exposureB);
+        ctx.ExposureAssessments.AddRange(assessmentA, assessmentB);
+
+        return new TwoDeviceSeed(product, vuln, deviceA, deviceB, exposureA, exposureB, assessmentA, assessmentB);
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RiskScoreServiceCanonicalTests"`
+Expected: FAIL — `DeviceRiskScores` / `SoftwareRiskScores` are empty because `RiskScoreService.RecalculateForTenantAsync` is still a stub.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceCanonicalTests.cs tests/PatchHound.Tests/Infrastructure/TestInfrastructure/CanonicalSeed.cs
+git commit -m "test(phase-5): add canonical risk score tests driving RiskScoreService rewrite"
+```
+
+---
+
+### Task 2: Rewrite `RiskScoreService` against canonical rows
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/RiskScoreService.cs`
+- Modify: `src/PatchHound.Core/Entities/DeviceRiskScore.cs` (ensure it has `MaxExposureScore`, `OpenExposureCount` fields; if missing, add in this task)
+- Modify: `src/PatchHound.Core/Entities/SoftwareRiskScore.cs` (verify `TenantId`, `SoftwareProductId`, `AffectedDeviceCount`, `OpenExposureCount`)
+
+- [ ] **Step 1: Verify the target entities**
+
+Run: `grep -n "MaxExposureScore\|SoftwareProductId" src/PatchHound.Core/Entities/DeviceRiskScore.cs src/PatchHound.Core/Entities/SoftwareRiskScore.cs`
+If either field is missing, extend the entity with a mutator `Update(decimal overall, decimal maxExposure, int critical, int high, int medium, int low, int openExposureCount, string factorsJson, string calculationVersion)` — mirror the existing shape; commit the entity change as its own small commit before proceeding.
+
+- [ ] **Step 2: Rewrite `CalculateAssetScoresAsync` → `CalculateDeviceScoresAsync`**
+
+New body:
+```csharp
+private async Task<List<DeviceRiskResult>> CalculateDeviceScoresAsync(
+    Guid tenantId, CancellationToken ct)
+{
+    var exposures = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+        .Where(e => e.TenantId == tenantId && e.Status == DeviceExposureStatus.Open)
+        .Select(e => new
+        {
+            e.Id,
+            e.DeviceId,
+            e.VulnerabilityId,
+            e.SoftwareProductId,
+            BaseCvss = (decimal?)dbContext.Vulnerabilities
+                .Where(v => v.Id == e.VulnerabilityId)
+                .Select(v => v.CvssScore)
+                .FirstOrDefault(),
+            EnvCvss = (decimal?)dbContext.ExposureAssessments
+                .Where(a => a.DeviceVulnerabilityExposureId == e.Id)
+                .Select(a => a.EnvironmentalCvss)
+                .FirstOrDefault(),
+        })
+        .ToListAsync(ct);
+
+    return exposures
+        .GroupBy(x => x.DeviceId)
+        .Select(grp =>
+        {
+            var maxScore = grp.Max(e => e.EnvCvss ?? e.BaseCvss ?? 0m);
+            var critical = grp.Count(e => (e.EnvCvss ?? e.BaseCvss ?? 0m) >= 9.0m);
+            var high = grp.Count(e => (e.EnvCvss ?? e.BaseCvss ?? 0m) is >= 7.0m and < 9.0m);
+            var medium = grp.Count(e => (e.EnvCvss ?? e.BaseCvss ?? 0m) is >= 4.0m and < 7.0m);
+            var low = grp.Count(e => (e.EnvCvss ?? e.BaseCvss ?? 0m) is < 4.0m);
+            var overall = ComputeDeviceOverallScore(maxScore, critical, high, medium, low);
+            var factors = SerializeFactors(maxScore, critical, high, medium, low);
+            return new DeviceRiskResult(
+                grp.Key, overall, maxScore, critical, high, medium, low, grp.Count(), factors);
+        })
+        .ToList();
+}
+```
+
+Define `ComputeDeviceOverallScore` as: `max(maxScore, weighted(0.6*critical + 0.3*high + 0.1*medium))` (preserve the existing algorithm shape if it was reasonable; the spec allows user-visible score shifts per §8 risk table, but don't change the formula gratuitously).
+
+- [ ] **Step 3: Rewrite `CalculateSoftwareScoresAsync`**
+
+Key on `(TenantId, SoftwareProductId)`:
+```csharp
+private async Task<List<SoftwareRiskResult>> CalculateSoftwareScoresAsync(
+    Guid tenantId, CancellationToken ct)
+{
+    var rows = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+        .Where(e => e.TenantId == tenantId && e.Status == DeviceExposureStatus.Open)
+        .Select(e => new
+        {
+            e.SoftwareProductId,
+            e.DeviceId,
+            EnvOrBase = dbContext.ExposureAssessments
+                .Where(a => a.DeviceVulnerabilityExposureId == e.Id)
+                .Select(a => (decimal?)a.EnvironmentalCvss)
+                .FirstOrDefault()
+                ?? dbContext.Vulnerabilities
+                    .Where(v => v.Id == e.VulnerabilityId)
+                    .Select(v => (decimal?)v.CvssScore)
+                    .FirstOrDefault()
+                ?? 0m,
+        })
+        .ToListAsync(ct);
+
+    return rows
+        .Where(r => r.SoftwareProductId.HasValue)
+        .GroupBy(r => r.SoftwareProductId!.Value)
+        .Select(grp => new SoftwareRiskResult(
+            SoftwareProductId: grp.Key,
+            OverallScore: ComputeSoftwareOverallScore(grp.Max(r => r.EnvOrBase), grp.Count()),
+            MaxExposureScore: grp.Max(r => r.EnvOrBase),
+            CriticalExposureCount: grp.Count(r => r.EnvOrBase >= 9.0m),
+            HighExposureCount: grp.Count(r => r.EnvOrBase is >= 7.0m and < 9.0m),
+            MediumExposureCount: grp.Count(r => r.EnvOrBase is >= 4.0m and < 7.0m),
+            LowExposureCount: grp.Count(r => r.EnvOrBase < 4.0m),
+            AffectedDeviceCount: grp.Select(r => r.DeviceId).Distinct().Count(),
+            OpenExposureCount: grp.Count(),
+            FactorsJson: "{}"))
+        .ToList();
+}
+```
+
+Replace the `SoftwareRiskResult` record shape accordingly (drop `TenantSoftwareId`, `SnapshotId`; add `SoftwareProductId`, `MaxExposureScore`).
+
+- [ ] **Step 4: Rewrite `CalculateDeviceGroupScoresAsync` / `CalculateTeamScoresAsync`**
+
+Both now read `Device` → `DeviceGroup` and `Device` → `OwnerTeam` mappings (canonical Phase 1 entities) and aggregate the device scores computed in Step 2. No changes to shape, just the source.
+
+- [ ] **Step 5: Rewrite `RecalculateForTenantAsync` orchestration**
+
+The top-level method becomes:
+```csharp
+public async Task RecalculateForTenantAsync(Guid tenantId, CancellationToken ct)
+{
+    var deviceResults = await CalculateDeviceScoresAsync(tenantId, ct);
+    var softwareResults = await CalculateSoftwareScoresAsync(tenantId, ct);
+    var deviceGroupResults = await CalculateDeviceGroupScoresAsync(tenantId, deviceResults, ct);
+    var teamResults = await CalculateTeamScoresAsync(tenantId, deviceResults, ct);
+
+    await UpsertDeviceScoresAsync(tenantId, deviceResults, ct);
+    await UpsertSoftwareScoresAsync(tenantId, softwareResults, ct);
+    await UpsertDeviceGroupScoresAsync(tenantId, deviceGroupResults, ct);
+    await UpsertTeamScoresAsync(tenantId, teamResults, ct);
+    await UpsertTenantSnapshotAsync(tenantId, deviceResults, ct);
+
+    await dbContext.SaveChangesAsync(ct);
+}
+```
+
+Each `Upsert*` helper compares existing rows by the canonical key and calls `Update(...)` or `Add(Create(...))`.
+
+- [ ] **Step 6: Delete every stale reference**
+
+Run: `grep -n "AssetRiskScore\|TenantSoftwareRiskScore\|VulnerabilityAssetEpisode\|TenantVulnerability\|TenantSoftwareId" src/PatchHound.Infrastructure/Services/RiskScoreService.cs`
+Expected: no matches.
+
+- [ ] **Step 7: Run the Phase 5 tests**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~RiskScoreServiceCanonicalTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/RiskScoreService.cs src/PatchHound.Core/Entities/DeviceRiskScore.cs src/PatchHound.Core/Entities/SoftwareRiskScore.cs
+git commit -m "refactor(phase-5): rewrite RiskScoreService against canonical exposure data"
+```
+
+---
+
+### Task 3: Add canonical read-model unit tests for `DashboardQueryService`
+
+**Files:**
+- Test: `tests/PatchHound.Tests/Api/Services/DashboardQueryServiceCanonicalTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using PatchHound.Api.Services;
+using PatchHound.Tests.Infrastructure.TestInfrastructure;
+using Xunit;
+
+namespace PatchHound.Tests.Api.Services;
+
+public class DashboardQueryServiceCanonicalTests
+{
+    [Fact]
+    public async Task Security_manager_summary_counts_open_exposures_from_canonical()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        CanonicalSeed.TwoDevicesOneVulnerability(ctx, tenantId);
+        await ctx.SaveChangesAsync();
+
+        var sut = new DashboardQueryService(ctx);
+        var result = await sut.BuildSecurityManagerSummaryAsync(tenantId, CancellationToken.None);
+
+        Assert.Equal(2, result.OpenExposureCount);
+        Assert.Equal(1, result.AffectedVulnerabilityCount);
+        Assert.Equal(2, result.AffectedDeviceCount);
+    }
+
+    [Fact]
+    public async Task Technical_manager_summary_groups_by_software_product()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var seed = CanonicalSeed.TwoDevicesOneVulnerability(ctx, tenantId);
+        await ctx.SaveChangesAsync();
+
+        var sut = new DashboardQueryService(ctx);
+        var result = await sut.BuildTechnicalManagerSummaryAsync(tenantId, CancellationToken.None);
+
+        Assert.Single(result.TopSoftwareByRisk);
+        Assert.Equal(seed.SoftwareProduct.Id, result.TopSoftwareByRisk[0].SoftwareProductId);
+        Assert.Equal(2, result.TopSoftwareByRisk[0].AffectedDeviceCount);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~DashboardQueryServiceCanonicalTests"`
+Expected: FAIL — `BuildSecurityManagerSummaryAsync` and `BuildTechnicalManagerSummaryAsync` are still stubs.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/PatchHound.Tests/Api/Services/DashboardQueryServiceCanonicalTests.cs
+git commit -m "test(phase-5): add canonical dashboard query tests"
+```
+
+---
+
+### Task 4: Rewrite `DashboardQueryService` against canonical rows
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/DashboardQueryService.cs`
+- Modify: corresponding DTOs under `src/PatchHound.Api/Models/Dashboard/`
+
+- [ ] **Step 1: Replace the vulnerability list block**
+
+The current method `.VulnerabilityAssetEpisodes.AsNoTracking().GroupBy(...)` is replaced with a query against `DeviceVulnerabilityExposure`:
+```csharp
+var openExposures = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+    .Where(e => e.TenantId == tenantId && e.Status == DeviceExposureStatus.Open)
+    .Select(e => new
+    {
+        e.Id,
+        e.DeviceId,
+        e.VulnerabilityId,
+        e.SoftwareProductId,
+        EnvCvss = dbContext.ExposureAssessments
+            .Where(a => a.DeviceVulnerabilityExposureId == e.Id)
+            .Select(a => (decimal?)a.EnvironmentalCvss)
+            .FirstOrDefault(),
+        BaseCvss = dbContext.Vulnerabilities
+            .Where(v => v.Id == e.VulnerabilityId)
+            .Select(v => v.CvssScore)
+            .FirstOrDefault(),
+    })
+    .ToListAsync(ct);
+```
+
+- [ ] **Step 2: Build the summary DTOs from that projection**
+
+- `SecurityManagerSummary`: `OpenExposureCount`, `AffectedVulnerabilityCount` (`openExposures.Select(e => e.VulnerabilityId).Distinct().Count()`), `AffectedDeviceCount`, `CriticalExposureCount`, `HighExposureCount`, `MediumExposureCount`, `LowExposureCount`.
+- `TechnicalManagerSummary`: `TopSoftwareByRisk` (top 10 by max env cvss then count), joined to `RemediationCase` so each row carries `RemediationCaseId?` if a case exists.
+- `OwnerSummary`: group by `OwnerTeam` via `Device.OwnerTeamId` → device score aggregation, joined to `RemediationCase` the same way.
+
+- [ ] **Step 3: Update DTOs to drop legacy IDs**
+
+`TopSoftwareRow` now carries `SoftwareProductId`, `ProductName`, `Vendor`, `RemediationCaseId?` — not `TenantSoftwareId`. Every DTO touched by the dashboard similarly drops `TenantSoftwareId`, `TenantVulnerabilityId`, `AssetId` and picks up canonical IDs.
+
+- [ ] **Step 4: Grep sweep**
+
+Run: `grep -n "VulnerabilityAssetEpisode\|TenantVulnerability\|TenantSoftware\|AssetRiskScore" src/PatchHound.Api/Services/DashboardQueryService.cs`
+Expected: no matches.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~DashboardQueryServiceCanonicalTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Api/Services/DashboardQueryService.cs src/PatchHound.Api/Models/Dashboard/
+git commit -m "refactor(phase-5): rewrite DashboardQueryService against canonical exposures"
+```
+
+---
+
+### Task 5: Rewrite `DashboardController` endpoint queries
+
+**Files:**
+- Modify: `src/PatchHound.Api/Controllers/DashboardController.cs`
+
+- [ ] **Step 1: Replace every inline `VulnerabilityAssetEpisodes`/`TenantVulnerability` query**
+
+The controller has numerous inline projections used by per-role dashboard endpoints. Each inline projection is replaced with a call into `DashboardQueryService` or rewritten directly against `DeviceVulnerabilityExposures` + `ExposureAssessments`. Keep business rules (priority tiers, SLA buckets, etc.) unchanged; only the source tables change.
+
+- [ ] **Step 2: Update deep links**
+
+Wherever the controller constructed a URL like `/software/{tenantSoftwareId}/remediation`, replace with `/remediation/cases/{caseId}`. The case id is loaded alongside the software product in the same query.
+
+- [ ] **Step 3: Grep sweep**
+
+Run: `grep -n "VulnerabilityAssetEpisode\|TenantVulnerability\|TenantSoftwareId\|SoftwareAssetId" src/PatchHound.Api/Controllers/DashboardController.cs`
+Expected: no matches.
+
+- [ ] **Step 4: Run controller-level tests**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~DashboardController"`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/DashboardController.cs
+git commit -m "refactor(phase-5): rewrite DashboardController inline queries against canonical"
+```
+
+---
+
+### Task 6: Rewrite `RiskScoreController` surface
+
+**Files:**
+- Modify: `src/PatchHound.Api/Controllers/RiskScoreController.cs`
+
+- [ ] **Step 1: Verify `DeviceRiskScore` / `SoftwareRiskScore` DbSets are used**
+
+The controller should expose `GET /api/risk-score/devices`, `/risk-score/software` (keyed `(TenantId, SoftwareProductId)`), `/risk-score/teams`, `/risk-score/groups`, `/risk-score/tenant-snapshot`. Replace any lingering `AssetRiskScore` / `TenantSoftwareRiskScore` references.
+
+- [ ] **Step 2: Update DTOs**
+
+`SoftwareRiskScoreDto` carries `SoftwareProductId`, `ProductName`, `Vendor`, `RemediationCaseId?`, not `TenantSoftwareId`. `DeviceRiskScoreDto` carries `DeviceId`, `DeviceName`, not `AssetId`.
+
+- [ ] **Step 3: Grep sweep**
+
+Run: `grep -n "AssetRiskScore\|TenantSoftwareRiskScore\|TenantSoftwareId\|SoftwareAssetId" src/PatchHound.Api/Controllers/RiskScoreController.cs`
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Api/Controllers/RiskScoreController.cs src/PatchHound.Api/Models/RiskScore/
+git commit -m "refactor(phase-5): point RiskScoreController at canonical score entities"
+```
+
+---
+
+### Task 7: Rewrite `EmailNotificationService` against canonical + cases
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/EmailNotificationService.cs`
+- Modify: Razor / Scriban templates under `src/PatchHound.Infrastructure/EmailTemplates/` (if present)
+
+- [ ] **Step 1: Replace every `TenantSoftware` / `dbContext.TenantSoftware` lookup**
+
+Replace with a join to `RemediationCase` (by `CaseId` held on the triggering `PatchingTask` / `RemediationDecision`) → `SoftwareProduct` for the product name and vendor. Example:
+```csharp
+var caseInfo = await dbContext.RemediationCases.AsNoTracking()
+    .Where(c => c.Id == task.RemediationCaseId && c.TenantId == tenantId)
+    .Select(c => new
+    {
+        c.Id,
+        ProductName = c.SoftwareProduct.Name,
+        Vendor = c.SoftwareProduct.Vendor,
+    })
+    .FirstAsync(ct);
+```
+
+- [ ] **Step 2: Replace every frontend deep link**
+
+- `{origin}/software/{tenantSoftwareId}/remediation` → `{origin}/remediation/cases/{caseId}`
+- `{origin}/remediation/tasks?tenantSoftwareId={id}` → `{origin}/remediation/cases/{caseId}`
+
+- [ ] **Step 3: Replace severity fetching**
+
+Any query that previously walked `task.RemediationDecision.TenantSoftwareId` → `TenantSoftwareRiskScores` now walks `task.RemediationCaseId` → `RemediationCase.SoftwareProductId` → `SoftwareRiskScores`.
+
+- [ ] **Step 4: Grep sweep**
+
+Run: `grep -n "TenantSoftware\|SoftwareAssetId\|TenantVulnerability\|VulnerabilityAsset" src/PatchHound.Infrastructure/Services/EmailNotificationService.cs`
+Expected: no matches.
+
+- [ ] **Step 5: Verify email templates render**
+
+Run existing email-rendering tests:
+```bash
+dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~EmailNotification"
+```
+Expected: green. If any template still has `{{ tenantSoftwareId }}`, replace with `{{ case_id }}` and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/EmailNotificationService.cs src/PatchHound.Infrastructure/EmailTemplates/
+git commit -m "refactor(phase-5): rewrite EmailNotificationService against canonical + case links"
+```
+
+---
+
+### Task 8: Rewrite frontend dashboard + risk views
+
+**Files:**
+- Modify: `frontend/src/components/features/dashboard/{AssetOwnerOverview,SecurityManagerOverview,TechnicalManagerOverview}.tsx`
+- Modify: any risk score pages under `frontend/src/routes/_authed/risk/*` and `frontend/src/components/features/risk/*`
+
+- [ ] **Step 1: Update dashboard DTO consumers**
+
+Each component currently expects rows with `tenantSoftwareId`. Switch to `softwareProductId` + `remediationCaseId`. "Open in remediation" CTAs route to `/remediation/cases/$caseId` directly when `remediationCaseId` is present, otherwise call `useOpenRemediationCase(softwareProductId)` from Phase 4.
+
+- [ ] **Step 2: Update risk score tables**
+
+Risk score table columns display `productName`, `vendor`, `maxExposureScore`, `affectedDeviceCount`, `openExposureCount`, and link to `/remediation/cases/$caseId` when set.
+
+- [ ] **Step 3: Grep sweep**
+
+Run: `grep -rn "tenantSoftwareId\|softwareAssetId\|tenantVulnerabilityId" frontend/src/components/features/dashboard frontend/src/components/features/risk 2>/dev/null`
+Expected: no matches.
+
+- [ ] **Step 4: Run frontend tests**
+
+```bash
+cd frontend && npm run typecheck && npm test -- --run && cd ..
+```
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/features/dashboard frontend/src/components/features/risk frontend/src/routes/_authed/risk 2>/dev/null
+git commit -m "refactor(phase-5): dashboard + risk views consume canonical IDs"
+```
+
+---
+
+### Task 9: Extend `TenantIsolationEndToEndTests` with read-side assertions
+
+**Files:**
+- Modify: `tests/PatchHound.Tests/Api/Tests/TenantIsolationEndToEndTests.cs`
+
+- [ ] **Step 1: Seed risk + dashboard data per tenant**
+
+Extend the fixture so each tenant gets a `DeviceRiskScore`, a `SoftwareRiskScore`, and a `TenantRiskScoreSnapshot` row populated by running `RiskScoreService.RecalculateForTenantAsync` against the seeded exposures.
+
+- [ ] **Step 2: Add assertions**
+
+```csharp
+[Fact]
+public async Task Risk_score_device_list_isolates_tenants()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var response = await tenantAClient.GetAsync("/api/risk-score/devices?page=1&pageSize=100");
+    response.EnsureSuccessStatusCode();
+    var page = await response.Content.ReadFromJsonAsync<PagedResponse<DeviceRiskScoreDto>>();
+    Assert.NotNull(page);
+    Assert.All(page!.Items, r => Assert.Equal(TenantA.Id, r.TenantId));
+}
+
+[Fact]
+public async Task Risk_score_software_list_isolates_tenants()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var response = await tenantAClient.GetAsync("/api/risk-score/software?page=1&pageSize=100");
+    response.EnsureSuccessStatusCode();
+    var page = await response.Content.ReadFromJsonAsync<PagedResponse<SoftwareRiskScoreDto>>();
+    Assert.NotNull(page);
+    Assert.All(page!.Items, r => Assert.Equal(TenantA.Id, r.TenantId));
+}
+
+[Fact]
+public async Task Dashboard_security_manager_summary_counts_only_tenant_rows()
+{
+    var tenantAClient = await CreateAuthenticatedClientAsync(TenantA);
+    var response = await tenantAClient.GetAsync("/api/dashboard/security-manager");
+    response.EnsureSuccessStatusCode();
+    var summary = await response.Content.ReadFromJsonAsync<SecurityManagerSummaryDto>();
+    Assert.NotNull(summary);
+    Assert.Equal(TenantASeed.ExpectedOpenExposureCount, summary!.OpenExposureCount);
+}
+
+[Fact]
+public async Task Email_rendering_does_not_cross_tenants()
+{
+    // Spec §7: email notification rendering pipelines do not join across tenants.
+    using var scope = _factory.Services.CreateScope();
+    var emailSvc = scope.ServiceProvider.GetRequiredService<EmailNotificationService>();
+    var payload = await emailSvc.RenderPatchingTaskAssignedAsync(
+        TenantASeed.PatchingTask.Id, CancellationToken.None);
+    Assert.Contains(TenantASeed.SoftwareProduct.Name, payload.Body);
+    Assert.DoesNotContain(TenantBSeed.SoftwareProduct.Name, payload.Body);
+    Assert.Contains($"/remediation/cases/{TenantASeed.RemediationCase.Id}", payload.Body);
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `dotnet test tests/PatchHound.Tests --filter "FullyQualifiedName~TenantIsolationEndToEndTests"`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/PatchHound.Tests/Api/Tests/TenantIsolationEndToEndTests.cs
+git commit -m "test(phase-5): extend tenant isolation e2e with dashboard/risk/email assertions"
+```
+
+---
+
+### Task 10: Final grep sweep
+
+- [ ] **Step 1: Legacy identifier sweep**
+
+Run:
+```bash
+grep -rn "TenantSoftware\|SoftwareAsset\|TenantVulnerability\|VulnerabilityAsset\|NormalizedSoftware\|AssetRiskScore\|TenantSoftwareRiskScore" src/ frontend/src/ 2>/dev/null | grep -v "\.Migrations/" | head -40
+```
+Expected: empty.
+
+- [ ] **Step 2: Legacy route sweep**
+
+```bash
+grep -rn "/api/software/.*remediation\|/software/.*/remediation\b" src/ frontend/src/ 2>/dev/null
+```
+Expected: empty.
+
+- [ ] **Step 3: `IgnoreQueryFilters` audit**
+
+Run: `grep -rn "IgnoreQueryFilters" src/`
+Expected: same allow-list from Phase 1, no Phase 5 additions.
+
+- [ ] **Step 4: Stub inventory sweep**
+
+Run: `grep -rn "TODO.*phase.5\|phase5\|PHASE_5_STUB" src/`
+Expected: empty. Delete `docs/superpowers/plans/2026-04-10-phase-5-stub-inventory.md` since the stubs are filled.
+
+- [ ] **Step 5: Commit cleanup**
+
+```bash
+git add -A
+git commit -m "chore(phase-5): remove stub inventory and lingering legacy references"
+```
+
+---
+
+### Task 11: Final build, test, PR
+
+- [ ] **Step 1: Full build**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx
+(cd frontend && npm run typecheck && npm test -- --run)
+```
+Expected: all green.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin data-model-canonical-cleanup-phase-5
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "Phase 5: canonical risk/dashboard/email rewrites" --body "$(cat <<'EOF'
+## Summary
+- Rewrite `RiskScoreService` to compute `DeviceRiskScore`, `SoftwareRiskScore(TenantId, SoftwareProductId)`, `TeamRiskScore`, `DeviceGroupRiskScore`, `TenantRiskScoreSnapshot` from canonical `DeviceVulnerabilityExposure` + `ExposureAssessment`.
+- Rewrite `DashboardQueryService` and `DashboardController` inline queries to read canonical exposure data and link to remediation cases.
+- Rewrite `RiskScoreController` DTOs/surfaces to expose canonical IDs only.
+- Rewrite `EmailNotificationService` to build emails from canonical rows and `/remediation/cases/{caseId}` deep links.
+- Frontend dashboard and risk views consume canonical IDs.
+- Tenant isolation e2e extended with dashboard/risk/email assertions.
+
+## Tenant scope audit
+No new entities. Every read-side service now honors `IsSystemContext || AccessibleTenantIds.Contains(e.TenantId)` via the normal EF query filters on `DeviceVulnerabilityExposure`, `ExposureAssessment`, `DeviceRiskScore`, `SoftwareRiskScore`, `TeamRiskScore`, `DeviceGroupRiskScore`, `TenantRiskScoreSnapshot`, and `RemediationCase`.
+
+## IgnoreQueryFilters audit
+No new entries. Allow-list unchanged from Phase 1.
+
+## Spec §4.10 rule compliance
+- R1/R2/R3: unchanged — every read-side query honors the existing filters.
+- R5: no new `IgnoreQueryFilters()` calls.
+- R6: dashboard queries that join `SoftwareProduct` (global) with tenant-scoped exposures reveal only public product identity; tenant-specific context comes from `TenantSoftwareProductInsight`.
+
+## Deleted scope
+No new entity deletions in Phase 5. This phase is entirely read-side cleanup.
+
+## Risk note
+Per spec §8, this phase may shift user-visible risk score numbers. The change is documented here and accepted.
+
+## Test plan
+- [ ] `dotnet build` clean
+- [ ] `dotnet test` green (new: `RiskScoreServiceCanonicalTests`, `DashboardQueryServiceCanonicalTests`, extended `TenantIsolationEndToEndTests`)
+- [ ] `npm run typecheck` clean
+- [ ] `npm test` green
+- [ ] Manual smoke: load each dashboard role view; open email preview for a patching-task-assigned notification; confirm deep links point at `/remediation/cases/$caseId`
+
+EOF
+)"
+```
+
+- [ ] **Step 4: Confirm PR URL**
+
+Expected: `https://github.com/frodehus/PatchHound/pull/<n>`
+
+---
+
+## Plan self-review
+
+**Spec coverage (spec §5.5):**
+- `RiskScoreService` rewritten against canonical exposure data — Tasks 1–2.
+- `DeviceRiskScore`, `SoftwareRiskScore(TenantId, SoftwareProductId)`, `TeamRiskScore`, `DeviceGroupRiskScore`, `TenantRiskScoreSnapshot` written — Task 2.
+- Dashboard queries (owner, security manager, technical manager) read canonical — Tasks 3–5.
+- Email notifications derive from canonical rows + case links — Task 7.
+- Tenant isolation test extended with dashboard + notification assertions — Task 9.
+- Single-path canonical read with no dual paths remaining — Task 10 sweep.
+
+**Placeholder scan:** no `TBD`/`TODO` entries. Every step shows the code or command to run.
+
+**Type consistency:** every new fixture call uses the same `CanonicalSeed.TwoDevicesOneVulnerability` helper defined in Task 1 Step 2. `DeviceRiskResult` / `SoftwareRiskResult` record shapes defined in Task 2 match the `DeviceRiskScore` / `SoftwareRiskScore` entity fields verified in Step 1.
+
+**Cross-phase dependency check:** Phase 5 assumes Phase 4 already landed `RemediationCase` and the `/api/remediation/cases/{caseId}` route surface. The plan header and every deep link replacement call this out.

--- a/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-6.md
+++ b/docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-6.md
@@ -1,0 +1,724 @@
+# Data Model Canonical Cleanup — Phase 6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reset the EF Core migration history to a single `Initial` migration generated against the final canonical entity set, verify the application boots and tests pass against a freshly-created database, and replace the historical `docs/data-model-refactor.md` with a concise reference document describing the final model.
+
+**Architecture:** Phase 6 is purely housekeeping. No entity shape changes, no service rewrites, no controller changes, no frontend changes. The only code-adjacent work is: (a) deleting every file under `src/PatchHound.Infrastructure/Data/Migrations/`, (b) running `dotnet ef migrations add Initial` so EF generates both a fresh migration and a fresh `PatchHoundDbContextModelSnapshot.cs` against the entity set that Phases 1–5 have left behind, (c) confirming the backend + frontend suites are still green when run against a database built from scratch via `dotnet ef database update`. The documentation work is: archive the 1743-line historical doc to `docs/superpowers/archive/`, then rewrite `docs/data-model-refactor.md` as a ≤200-line reference describing the final model, the tenant isolation rules from §4.10, and pointers to canonical services.
+
+**Tech Stack:** .NET 10 / EF Core 10 / PostgreSQL / xUnit / React + Vitest.
+
+**Prerequisites:**
+- Phases 1–5 merged to `main`.
+- The workspace builds clean and `dotnet test` / `npm test` are green on `main`.
+- The abandoned branch `data-model-refactor-clean-reset` still exists locally or on `origin/` — it holds the 1743-line historical `docs/data-model-refactor.md` that Phase 6 archives. (If the branch has been pruned, fall back to `git log --all --diff-filter=A -- docs/data-model-refactor.md` to find the commit SHA the file was added in, and `git show <sha>:docs/data-model-refactor.md` to retrieve it.)
+- PostgreSQL is reachable from the dev machine at `localhost:5432` and the `postgres` superuser can create/drop the `patchhound` database. The connection string in `src/PatchHound.Api/appsettings.Development.json` points at the same instance.
+- `dotnet-ef` tool is installed globally or restored as a local tool. If not, `dotnet tool install --global dotnet-ef` first.
+
+**Scope note:** This plan touches zero `src/PatchHound.Core/` entity files and zero `src/PatchHound.Api` / `src/PatchHound.Infrastructure` service files. If a task below would require an entity-shape change to succeed, the fix belongs in an earlier phase, not here. Stop and escalate if that happens.
+
+---
+
+## Preflight
+
+- [ ] **P1: Confirm Phases 1–5 merged**
+
+Run:
+```bash
+git log --oneline main -30 | grep -E "canonical-cleanup-phase-[1-5]"
+```
+Expected: five distinct commits, one per phase. If any are missing, stop and merge them first.
+
+- [ ] **P2: Cut Phase 6 branch**
+
+```bash
+git checkout main && git pull
+git checkout -b data-model-canonical-cleanup-phase-6
+```
+
+- [ ] **P3: Baseline green build on `main` state**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx
+(cd frontend && npm run typecheck && npm test -- --run)
+```
+Expected: all green. If any are red on fresh Phase 5 `main`, stop and fix `main` first — Phase 6 cannot interpret a red baseline as "migration reset regression."
+
+- [ ] **P4: Confirm `dotnet-ef` is available**
+
+```bash
+dotnet ef --version
+```
+Expected: a version number is printed (EF 9.x). If the command is not found, run `dotnet tool install --global dotnet-ef` and re-run the check.
+
+- [ ] **P5: Confirm the historical doc can be retrieved**
+
+```bash
+git show data-model-refactor-clean-reset:docs/data-model-refactor.md | wc -l
+```
+Expected: around 1743 lines. If the branch is gone, fall back to:
+```bash
+git log --all --oneline --diff-filter=A -- docs/data-model-refactor.md
+```
+Note the commit SHA — later tasks will reference it instead of the branch name. Record the SHA or branch name in the PR description under "historical doc source".
+
+- [ ] **P6: Snapshot the current migration folder count**
+
+```bash
+ls src/PatchHound.Infrastructure/Data/Migrations/ | wc -l
+```
+Expected: a non-zero count (roughly 180+ if each migration has both a `.cs` and a `.Designer.cs` companion plus the `PatchHoundDbContextModelSnapshot.cs`). Record the exact count in the PR description so the reviewer can verify the delete + regenerate swing.
+
+- [ ] **P7: Verify PostgreSQL reachable**
+
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "SELECT 1;"
+```
+Expected: `1` returned. If this fails, start the dev database before proceeding.
+
+---
+
+### Task 1: Archive the historical data-model-refactor doc
+
+**Files:**
+- Create: `docs/superpowers/archive/2026-04-10-data-model-refactor-history.md`
+
+- [ ] **Step 1: Create the archive directory**
+
+```bash
+mkdir -p docs/superpowers/archive
+```
+
+- [ ] **Step 2: Copy the historical document out of the abandoned branch**
+
+```bash
+git show data-model-refactor-clean-reset:docs/data-model-refactor.md \
+  > docs/superpowers/archive/2026-04-10-data-model-refactor-history.md
+```
+
+If `data-model-refactor-clean-reset` is gone, use the commit SHA recorded in P5 instead:
+```bash
+git show <sha>:docs/data-model-refactor.md \
+  > docs/superpowers/archive/2026-04-10-data-model-refactor-history.md
+```
+
+- [ ] **Step 3: Verify the archive is non-empty and has the expected shape**
+
+```bash
+wc -l docs/superpowers/archive/2026-04-10-data-model-refactor-history.md
+head -5 docs/superpowers/archive/2026-04-10-data-model-refactor-history.md
+```
+Expected: around 1743 lines. Head should show the original title/heading of the historical doc — confirm it looks like the old data model refactor narrative and not some unrelated file.
+
+- [ ] **Step 4: Prepend an archive banner**
+
+Open `docs/superpowers/archive/2026-04-10-data-model-refactor-history.md` and insert the following block at the very top of the file (before the existing first line):
+
+```markdown
+> **ARCHIVED 2026-04-10.** This document is the historical working draft that
+> preceded the canonical data model cleanup refactor. It is preserved verbatim
+> for future archaeology. **Do not treat any statement in this file as current
+> architectural guidance.** The authoritative reference is
+> `docs/data-model-refactor.md` (≤200 lines) which describes the final model
+> shipped at the end of the 6-phase canonical cleanup. The design rationale
+> for the cleanup itself lives at
+> `docs/superpowers/specs/2026-04-10-data-model-canonical-cleanup-design.md`.
+
+---
+
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/archive/2026-04-10-data-model-refactor-history.md
+git commit -m "docs: archive historical data-model-refactor.md as pre-cleanup reference"
+```
+
+---
+
+### Task 2: Delete every existing EF Core migration file
+
+**Files:**
+- Delete: all files under `src/PatchHound.Infrastructure/Data/Migrations/`
+
+> **Scope guard.** Only `src/PatchHound.Infrastructure/Data/Migrations/` is touched. Do **not** delete anything under `src/PatchHound.Infrastructure/Data/` that is not in the `Migrations/` subdirectory (the `DesignTimeDbContextFactory.cs`, `PatchHoundDbContext.cs`, and any seed/config files live as siblings and must survive). Do **not** delete any `*.csproj` reference — the folder is included by glob, so removing the files alone is sufficient.
+
+- [ ] **Step 1: List what is about to be deleted**
+
+```bash
+ls src/PatchHound.Infrastructure/Data/Migrations/
+```
+Expected: a list ending with `PatchHoundDbContextModelSnapshot.cs` and including dozens of `YYYYMMDDHHMMSS_*.cs` and matching `*.Designer.cs` files. Copy this list into the PR description under "deleted migration files" for the reviewer.
+
+- [ ] **Step 2: Delete the migration files**
+
+```bash
+rm -rf src/PatchHound.Infrastructure/Data/Migrations/
+```
+
+- [ ] **Step 3: Verify the folder is gone**
+
+```bash
+ls src/PatchHound.Infrastructure/Data/ | grep -i Migrations || echo "ok: Migrations/ absent"
+```
+Expected: `ok: Migrations/ absent`.
+
+- [ ] **Step 4: Verify the project still builds (without migrations)**
+
+```bash
+dotnet build PatchHound.slnx
+```
+Expected: clean build, 0 warnings, 0 errors. If the build fails because some code explicitly referenced a migration class by name (e.g. a test that `new`-s a migration type), that is a pre-existing leak that should be fixed in a tiny follow-up commit before proceeding — do not work around it by recreating migration files.
+
+- [ ] **Step 5: Commit the deletion**
+
+```bash
+git add -A src/PatchHound.Infrastructure/Data/Migrations/
+git commit -m "chore(db): delete legacy migrations prior to canonical baseline reset"
+```
+
+Note: `git add -A` on a removed directory records the deletions. Verify with `git status` first that only files under `src/PatchHound.Infrastructure/Data/Migrations/` are staged.
+
+---
+
+### Task 3: Regenerate a single `Initial` migration against the canonical model
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Data/Migrations/<timestamp>_Initial.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Migrations/<timestamp>_Initial.Designer.cs`
+- Create: `src/PatchHound.Infrastructure/Data/Migrations/PatchHoundDbContextModelSnapshot.cs`
+
+- [ ] **Step 1: Generate the baseline migration**
+
+```bash
+dotnet ef migrations add Initial \
+  --project src/PatchHound.Infrastructure \
+  --startup-project src/PatchHound.Api \
+  --context PatchHoundDbContext \
+  --output-dir Data/Migrations
+```
+Expected output from EF: "Done. To undo this action, use 'ef migrations remove'." Three new files land under `src/PatchHound.Infrastructure/Data/Migrations/`.
+
+- [ ] **Step 2: Verify the three new files exist**
+
+```bash
+ls src/PatchHound.Infrastructure/Data/Migrations/
+```
+Expected: exactly three files — `<timestamp>_Initial.cs`, `<timestamp>_Initial.Designer.cs`, and `PatchHoundDbContextModelSnapshot.cs`. If there are more than three files, something misfired — delete the folder again and re-run Step 1.
+
+- [ ] **Step 3: Scan the generated migration for legacy table names**
+
+The generated migration is the ground truth for what the final model actually contains. It must not mention any of the tables deleted during Phases 1–5:
+
+```bash
+grep -E "Asset|TenantSoftware|NormalizedSoftware|VulnerabilityDefinition|TenantVulnerability|VulnerabilityAsset" \
+  src/PatchHound.Infrastructure/Data/Migrations/*.cs \
+  | grep -v -E "DeviceVulnerabilityExposure|SoftwareAlias|StagedDeviceSoftwareInstallation|VulnerabilityApplicability|VulnerabilityReference|AssetTag|AssetRule"
+```
+Expected: empty output. (The exclusions above are legitimate tokens from canonical entity names that happen to share a substring. Adjust only if a legitimate canonical entity introduced in Phases 1–5 also matches — in that case, add it to the `grep -v` list and document why in the PR description.)
+
+If the grep returns any legacy entity name, **stop.** The entity was not actually deleted in the earlier phase that claimed to delete it. Escalate with the entity name and the earlier phase PR — this is an earlier-phase bug that must be fixed at its source, not papered over by hand-editing the generated migration.
+
+- [ ] **Step 4: Scan the migration for the canonical entity set**
+
+Every entity introduced or retained by Phases 1–5 must appear in the new baseline. The grep below is a smoke test, not an exhaustive audit:
+
+```bash
+for t in Devices SoftwareProducts SoftwareAliases InstalledSoftwares TenantSoftwareProductInsights \
+         DeviceBusinessLabels DeviceRiskScores DeviceRules DeviceTags SecurityProfiles \
+         Vulnerabilities VulnerabilityReferences VulnerabilityApplicabilities ThreatAssessments \
+         DeviceVulnerabilityExposures ExposureEpisodes ExposureAssessments \
+         RemediationCases RemediationWorkflows RemediationDecisions PatchingTasks ApprovalTasks \
+         RiskAcceptances AnalystRecommendations AIReports RemediationAiJobs SoftwareDescriptionJobs \
+         SoftwareRiskScores TeamRiskScores DeviceGroupRiskScores TenantRiskScoreSnapshots; do
+  if ! grep -q "\"$t\"" src/PatchHound.Infrastructure/Data/Migrations/*_Initial.cs; then
+    echo "MISSING: $t"
+  fi
+done
+```
+Expected: no `MISSING:` lines. Table names are EF's default pluralization — if a specific entity uses `HasTable("...")` to override, adjust the grep to match the override. If a name is genuinely missing, the entity was never registered as a `DbSet<T>` on `PatchHoundDbContext` and Phase 6 has uncovered a pre-existing bug that belongs back in the phase that introduced that entity.
+
+- [ ] **Step 5: Build with the new migration in place**
+
+```bash
+dotnet build PatchHound.slnx
+```
+Expected: clean build, 0 warnings, 0 errors.
+
+- [ ] **Step 6: Commit the regenerated baseline**
+
+```bash
+git add src/PatchHound.Infrastructure/Data/Migrations/
+git commit -m "feat(db): regenerate single Initial migration against canonical model"
+```
+
+---
+
+### Task 4: Verify the database boots cleanly from scratch
+
+**Files:** (none modified; verification only)
+
+- [ ] **Step 1: Drop and recreate the dev database**
+
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS patchhound;"
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "CREATE DATABASE patchhound;"
+```
+
+- [ ] **Step 2: Apply the Initial migration from empty**
+
+```bash
+dotnet ef database update \
+  --project src/PatchHound.Infrastructure \
+  --startup-project src/PatchHound.Api \
+  --context PatchHoundDbContext
+```
+Expected: EF prints `Applying migration '<timestamp>_Initial'.` followed by `Done.` No errors, no warnings about pending changes, no "model differs from snapshot" messages.
+
+- [ ] **Step 3: Sanity-check the resulting schema**
+
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -d patchhound -c "\dt" | wc -l
+```
+Expected: a table count consistent with the canonical entity set (roughly 35–45 tables depending on join tables). Record the exact number in the PR description.
+
+Then, explicitly confirm none of the legacy tables exist:
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -d patchhound -c "\dt" \
+  | grep -E "assets|tenant_software|normalized_software|vulnerability_definition|tenant_vulnerabilities|vulnerability_assets" \
+  || echo "ok: no legacy tables"
+```
+Expected: `ok: no legacy tables`.
+
+- [ ] **Step 4: Confirm `__EFMigrationsHistory` shows exactly one row**
+
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -d patchhound \
+  -c "SELECT migration_id FROM \"__EFMigrationsHistory\";"
+```
+Expected: exactly one row, ending in `_Initial`. If there are zero or more than one, something is wrong — do not proceed.
+
+- [ ] **Step 5: Confirm EF sees the model as up-to-date**
+
+```bash
+dotnet ef migrations has-pending-model-changes \
+  --project src/PatchHound.Infrastructure \
+  --startup-project src/PatchHound.Api \
+  --context PatchHoundDbContext
+```
+Expected: "No changes have been made to the model since the last migration." (exit code 0). If EF reports pending changes, the snapshot and the live model disagree — re-run Task 3 Step 1 (which will refuse because a migration already exists) or, more commonly, fix the disagreement by deleting the freshly generated migration and re-running `migrations add Initial` after investigating why the second run sees changes.
+
+---
+
+### Task 5: Run the full backend test suite against the fresh baseline
+
+**Files:** (none modified; verification only)
+
+- [ ] **Step 1: Run the full backend test suite**
+
+```bash
+dotnet test PatchHound.slnx
+```
+Expected: green. If any test fails, inspect whether the failure is (a) a test that leaked shared database state from a previous Phase 5 run, or (b) a real regression against the new baseline.
+
+For (a): ensure the test fixtures clean up after themselves (`Respawner`, `DatabaseFixture`, or per-test-run containers). Re-run in isolation:
+```bash
+dotnet test tests/PatchHound.Tests/Infrastructure
+dotnet test tests/PatchHound.Tests/Api
+```
+
+For (b): stop and escalate. A red backend test against the canonical baseline means Phase 6 has uncovered an earlier-phase correctness bug — the fix belongs in that earlier phase's branch or a targeted hotfix, not in Phase 6.
+
+- [ ] **Step 2: Run the frontend test suite**
+
+```bash
+cd frontend && npm run typecheck && npm test -- --run
+```
+Expected: green. Frontend does not touch migrations directly, so a failure here is almost certainly unrelated to the reset; investigate and fix before merging.
+
+- [ ] **Step 3: Commit nothing yet**
+
+No code changes were made in Task 5 — it is a verification gate. Proceed to Task 6.
+
+---
+
+### Task 6: Author the new `docs/data-model-refactor.md` reference
+
+**Files:**
+- Create: `docs/data-model-refactor.md`
+
+The rewritten document is a **reference**, not a history. It describes the final canonical model, the tenant isolation rules, and pointers to the services. It must be ≤200 lines total. Use tables aggressively. Do not include migration history, "why we did this", rationale, or decision logs — those live in the spec and the archived historical doc.
+
+- [ ] **Step 1: Create the reference doc**
+
+Create `docs/data-model-refactor.md` with the following content verbatim:
+
+```markdown
+# Data Model Reference
+
+> **Scope.** This document is the current, authoritative reference for the
+> canonical PatchHound data model. It replaces the 1743-line historical
+> working document (archived at
+> `docs/superpowers/archive/2026-04-10-data-model-refactor-history.md`). The
+> design rationale for the refactor that produced this model lives in
+> `docs/superpowers/specs/2026-04-10-data-model-canonical-cleanup-design.md`.
+
+## 1. Model overview
+
+The model is partitioned into four domains:
+
+| Domain | Authoritative entities | Scope |
+| --- | --- | --- |
+| Inventory | `Device`, `InstalledSoftware`, `TenantSoftwareProductInsight` | Tenant-scoped |
+| Software identity | `SoftwareProduct`, `SoftwareAlias`, `SourceSystem` | Global |
+| Vulnerability knowledge | `Vulnerability`, `VulnerabilityReference`, `VulnerabilityApplicability`, `ThreatAssessment` | Global |
+| Exposure + remediation | `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment`, `RemediationCase`, `RemediationWorkflow`, `RemediationDecision`, `PatchingTask`, `ApprovalTask`, `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob`, `SoftwareDescriptionJob` | Tenant-scoped |
+| Risk scoring | `DeviceRiskScore`, `SoftwareRiskScore`, `TeamRiskScore`, `DeviceGroupRiskScore`, `TenantRiskScoreSnapshot` | Tenant-scoped |
+| Device policy | `DeviceBusinessLabel`, `DeviceRule`, `DeviceTag`, `SecurityProfile` | Tenant-scoped |
+
+Globals are writable only by system-context ingestion
+(`IsSystemContext = true`). Every tenant-scoped entity carries a direct
+`TenantId` column and an EF Core global query filter of the form
+`HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId))`.
+
+## 2. Key identity and scope keys
+
+| Entity | Primary identity | Notes |
+| --- | --- | --- |
+| `Device` | `(TenantId, SourceSystemId, ExternalId)` | Source-owned. No cross-source correlation. |
+| `SoftwareProduct` | canonical CPE / normalized vendor+product | Global. One row per real-world product. |
+| `SoftwareAlias` | `(SourceSystemId, ExternalId)` → `SoftwareProductId` | Global mapping from source IDs to products. |
+| `InstalledSoftware` | `(TenantId, DeviceId, SoftwareProductId)` | Tenant-scoped installation record. |
+| `Vulnerability` | canonical CVE / source ID | Global. |
+| `VulnerabilityApplicability` | `(VulnerabilityId, SoftwareProductId, version predicate)` | Global. Joins vuln knowledge to product identity. |
+| `DeviceVulnerabilityExposure` | `(TenantId, DeviceId, VulnerabilityId)` | Tenant-scoped. Exists iff a live `InstalledSoftware` on `DeviceId` matches a `VulnerabilityApplicability` for `VulnerabilityId`. |
+| `ExposureEpisode` | `(ExposureId, OpenedAt)` | Tracks open → resolve → reopen lifecycle. |
+| `ExposureAssessment` | per exposure, carries env-CVSS from `SecurityProfile` | Tenant-scoped. |
+| `RemediationCase` | `(TenantId, SoftwareProductId)` | Aggregate root for all remediation process records on a product. Stable across snapshot churn. |
+| `DeviceRiskScore` | `DeviceId` | Tenant-scoped via `Device`. |
+| `SoftwareRiskScore` | `(TenantId, SoftwareProductId)` | Tenant-scoped. |
+
+## 3. Tenant isolation rules
+
+These rules are the hard invariants of the model. Every new query, service,
+and entity must satisfy all of them. They are lifted verbatim from §4.10 of
+the design spec.
+
+1. **Direct `TenantId` on every tenant-scoped entity.** No transitive-only
+   scoping. Even rows whose tenant owner is reachable through a foreign key
+   carry their own `TenantId` column.
+2. **Mandatory EF Core global query filter** on every tenant-scoped entity:
+   `HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId))`.
+3. **Global entities carry no `TenantId` and no tenant filter.** Only the
+   entities listed in §1 as "Global" are exempt.
+4. **`TenantId` is always derived from `TenantContext.CurrentTenantId` at
+   write time.** Services never accept `tenantId` from request bodies.
+5. **`IgnoreQueryFilters()` is banned outside explicitly system-context code
+   paths.** Uses must be justified in the PR description.
+6. **Joins between tenant-scoped and global rows never reveal cross-tenant
+   state.** Global lookups return only publicly-derivable data.
+7. **Tenant-specific product context lives on
+   `TenantSoftwareProductInsight`,** never on `SoftwareProduct`.
+8. **Cross-entity foreign keys within the tenant domain must agree on
+   `TenantId`.** E.g. `RemediationCase.TenantId` must equal the
+   `Device.TenantId` of every `DeviceVulnerabilityExposure` the case covers.
+9. **Global entity writes come from system-context ingestion only.** A
+   normal authenticated request cannot create a `SoftwareProduct`,
+   `Vulnerability`, `VulnerabilityApplicability`, `VulnerabilityReference`,
+   `ThreatAssessment`, or `SourceSystem` row.
+10. **Verification is not optional.** Every change must include a
+    tenant-isolation assertion in `TenantIsolationEndToEndTests` covering
+    any new query path it introduces.
+
+## 4. Canonical service pointers
+
+| Concern | Service | Path |
+| --- | --- | --- |
+| Ingestion (Defender + general) | `IngestionService`, `StagedDeviceMergeService` | `src/PatchHound.Infrastructure/Services/Ingestion/` |
+| Authenticated scan ingestion | `AuthenticatedScanIngestionService` | `src/PatchHound.Infrastructure/Services/AuthenticatedScans/` |
+| Software alias resolution | `SoftwareAliasResolver` | `src/PatchHound.Infrastructure/Services/Software/` |
+| Exposure derivation | `ExposureDerivationService` | `src/PatchHound.Infrastructure/Services/Exposure/` |
+| Environmental assessment | `ExposureAssessmentService` | `src/PatchHound.Infrastructure/Services/Exposure/` |
+| Remediation case lifecycle | `RemediationCaseService` | `src/PatchHound.Infrastructure/Services/Remediation/` |
+| Remediation workflow progression | `RemediationWorkflowService` | `src/PatchHound.Infrastructure/Services/Remediation/` |
+| Remediation decision creation | `RemediationDecisionService` | `src/PatchHound.Infrastructure/Services/Remediation/` |
+| Risk scoring (all levels) | `RiskScoreService` | `src/PatchHound.Infrastructure/Services/RiskScoreService.cs` |
+| Dashboard read models | `DashboardQueryService` | `src/PatchHound.Api/Services/DashboardQueryService.cs` |
+| Email notifications | `EmailNotificationService` | `src/PatchHound.Infrastructure/Services/EmailNotificationService.cs` |
+
+All of the above services respect the tenant isolation rules in §3 and
+depend only on the canonical entity set in §1–§2. There are no "canonical
+first, legacy fallback" dual paths anywhere in the codebase — if you see
+one, it is a bug.
+
+## 5. Migrations
+
+The database baseline is a single EF Core migration named `Initial`, generated
+against the final canonical entity set and living at
+`src/PatchHound.Infrastructure/Data/Migrations/<timestamp>_Initial.cs`. The
+`PatchHoundDbContextModelSnapshot.cs` beside it is the authoritative record
+of the model that `Initial` builds.
+
+To create a fresh dev database:
+
+```bash
+dotnet ef database update \
+  --project src/PatchHound.Infrastructure \
+  --startup-project src/PatchHound.Api \
+  --context PatchHoundDbContext
+```
+
+New schema changes go through the normal EF workflow (`dotnet ef migrations
+add <name>`). Do **not** hand-edit `Initial` or its snapshot; generate a new
+migration on top.
+
+## 6. Testing gates
+
+Every PR that touches the data model must keep these gates green:
+
+- `TenantIsolationEndToEndTests` — two-tenant seed + per-endpoint assertions
+  that tenant A cannot observe tenant B rows.
+- Env-severity regression test — `SecurityProfile` environmental modifiers
+  must reach `ExposureAssessment.Score`.
+- Ingestion idempotency — re-running ingestion against the same observations
+  produces no duplicates.
+- Global-entity write protection — non-system requests get 403/404 when
+  attempting to create global rows.
+- Remediation case stability — `(TenantId, SoftwareProductId)` is stable
+  across snapshot publish/discard cycles.
+
+See §7 of the design spec for the full verification matrix.
+```
+
+- [ ] **Step 2: Verify the file is ≤200 lines**
+
+```bash
+wc -l docs/data-model-refactor.md
+```
+Expected: ≤200. If over, tighten §1–§6 until it fits — do not drop whole sections. The §3 isolation rules list is non-negotiable.
+
+- [ ] **Step 3: Verify the file renders as valid markdown**
+
+```bash
+head -3 docs/data-model-refactor.md
+```
+Expected: heading `# Data Model Reference` on line 1 and the archive-pointer blockquote starting on line 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/data-model-refactor.md
+git commit -m "docs: rewrite data-model-refactor.md as canonical reference"
+```
+
+---
+
+### Task 7: Final legacy-reference grep sweep across the workspace
+
+**Files:** (none modified; verification only)
+
+Phase 6 is the last phase. By this point, every reference to any legacy entity, service, or route should be gone from the codebase. This task confirms that.
+
+- [ ] **Step 1: Grep for legacy entity names in source**
+
+```bash
+grep -rn -E "\b(TenantSoftware|SoftwareAsset|TenantVulnerability|VulnerabilityAsset|NormalizedSoftware|AssetRiskScore|TenantSoftwareRiskScore|VulnerabilityDefinition|DeviceSoftwareInstallation|SoftwareCpeBinding|StagedAsset|AssetBusinessLabel|AssetRule|AssetTag|AssetSecurityProfile|AssetType)\b" \
+  src/ frontend/src/ \
+  --include="*.cs" --include="*.ts" --include="*.tsx" 2>/dev/null \
+  | grep -v "src/PatchHound.Infrastructure/Data/Migrations/" \
+  | grep -v "docs/superpowers/archive/"
+```
+Expected: empty output.
+
+If the grep returns anything, inspect each hit. Acceptable exceptions:
+- String literals inside **tests** that describe the old behavior explicitly (e.g. `"asset"` as a route path that is being asserted 404). Rare; flag each in the PR description.
+- None others. If a `.cs` or `.tsx` file still references a legacy type, it was missed in an earlier phase — escalate, fix at source, do not paper over.
+
+- [ ] **Step 2: Grep for legacy API routes**
+
+```bash
+grep -rn -E "/api/assets|/api/software/[^/]+/remediation|/api/remediation/[^c]" \
+  src/PatchHound.Api/ frontend/src/ \
+  --include="*.cs" --include="*.ts" --include="*.tsx" 2>/dev/null
+```
+Expected: empty for `/api/assets` and for the software-scoped remediation route. The third pattern (`/api/remediation/[^c]`) is a fuzzy check to catch any leftover `/api/remediation/{workflowId}` style route that should have collapsed into `/api/remediation/cases/{caseId}` in Phase 4. Inspect each hit; expected to be empty.
+
+- [ ] **Step 3: Grep for `IgnoreQueryFilters()` outside system-context paths**
+
+```bash
+grep -rn "IgnoreQueryFilters" src/ --include="*.cs" 2>/dev/null \
+  | grep -v -E "Ingestion|SystemContext|HealthCheck|AdminHousekeeping"
+```
+Expected: empty. Per Rule 5, `IgnoreQueryFilters()` is banned outside explicitly system-context paths. Any hit is a tenant isolation risk and must be fixed before merging Phase 6.
+
+- [ ] **Step 4: Grep for `TODO.*phase.[1-5]` markers**
+
+```bash
+grep -rn -E "TODO.*phase.?[1-5]|PHASE_[1-5]_STUB" src/ frontend/src/ 2>/dev/null
+```
+Expected: empty. Any hits indicate a Phase-N stub was never filled in.
+
+- [ ] **Step 5: Confirm the Phase 5 stub-inventory note is obsolete and delete it**
+
+```bash
+ls docs/superpowers/plans/2026-04-10-phase-5-stub-inventory.md 2>/dev/null \
+  && git rm docs/superpowers/plans/2026-04-10-phase-5-stub-inventory.md \
+  || echo "ok: already absent"
+```
+
+If the note existed and was removed, commit it:
+```bash
+git commit -m "docs: remove phase-5 stub inventory now that phase 6 has landed"
+```
+
+---
+
+### Task 8: Final green build + test run on fresh DB
+
+**Files:** (none modified; verification only)
+
+- [ ] **Step 1: Drop and recreate the dev database one more time**
+
+```bash
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS patchhound;"
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres -c "CREATE DATABASE patchhound;"
+```
+
+- [ ] **Step 2: Apply migrations**
+
+```bash
+dotnet ef database update \
+  --project src/PatchHound.Infrastructure \
+  --startup-project src/PatchHound.Api \
+  --context PatchHoundDbContext
+```
+Expected: `Applying migration '<timestamp>_Initial'.` then `Done.`
+
+- [ ] **Step 3: Full backend suite**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx
+```
+Expected: 0 warnings, 0 errors, all tests green.
+
+- [ ] **Step 4: Full frontend suite**
+
+```bash
+cd frontend && npm run typecheck && npm test -- --run
+```
+Expected: clean typecheck, all tests green.
+
+- [ ] **Step 5: Smoke-test the API boots against the fresh DB**
+
+```bash
+dotnet run --project src/PatchHound.Api --no-build &
+API_PID=$!
+sleep 10
+curl -sf http://localhost:5000/health || echo "API did not respond"
+kill $API_PID
+```
+Expected: the `/health` endpoint responds successfully. If it does not, inspect the API startup logs for schema/model mismatches — a common failure mode is that a seed-on-startup routine is still trying to read a legacy table.
+
+If there is no `/health` endpoint, substitute any anonymous GET that the API exposes (e.g. `/api/version` or the root `/`). Record which endpoint was used in the PR description.
+
+---
+
+### Task 9: Open the Phase 6 PR
+
+**Files:** (none modified; PR body only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin data-model-canonical-cleanup-phase-6
+```
+
+- [ ] **Step 2: Open the PR**
+
+Use `gh pr create` with the title `Data model canonical cleanup — Phase 6: baseline migration + docs` and the body below. Substitute the bracketed placeholders with the values recorded during the preflight and tasks.
+
+```markdown
+## Summary
+
+- Deletes every file under `src/PatchHound.Infrastructure/Data/Migrations/`
+  (previous count: **[P6 count]**) and regenerates a single `Initial`
+  migration + model snapshot against the final canonical entity set.
+- Verifies the database boots cleanly from empty via
+  `dotnet ef database update` and that the full backend + frontend test
+  suites pass against the freshly-created baseline.
+- Archives the historical 1743-line `docs/data-model-refactor.md` to
+  `docs/superpowers/archive/2026-04-10-data-model-refactor-history.md` and
+  rewrites `docs/data-model-refactor.md` as a ≤200-line reference describing
+  the final model, the tenant isolation rules from §4.10, and pointers to
+  the canonical services.
+- Completes the 6-phase canonical data model cleanup.
+
+## Historical doc source
+
+`[branch name or SHA recorded in preflight P5]`
+
+## Migration swing
+
+- Legacy migration files deleted: **[P6 count]**
+- New migration files added: **3** (`<timestamp>_Initial.cs`,
+  `<timestamp>_Initial.Designer.cs`, `PatchHoundDbContextModelSnapshot.cs`)
+- Tables in the resulting schema: **[count from Task 4 Step 3]**
+- `__EFMigrationsHistory` rows after apply: **1**
+
+## Tenant scope audit
+
+No new entities were introduced in this phase. The tenant scope table from
+Phase 5 is unchanged.
+
+## Legacy reference grep results
+
+- Legacy entity name grep (Task 7 Step 1): empty.
+- Legacy API route grep (Task 7 Step 2): empty.
+- `IgnoreQueryFilters()` outside system-context grep (Task 7 Step 3): empty.
+- `TODO.*phase.[1-5]` marker grep (Task 7 Step 4): empty.
+
+## Verification matrix
+
+- [x] `dotnet build` clean — 0 warnings, 0 errors
+- [x] `dotnet test` green against fresh DB
+- [x] `npm run typecheck` clean
+- [x] `npm test` green
+- [x] Fresh `dotnet ef database update` from empty PostgreSQL succeeds
+- [x] `__EFMigrationsHistory` contains exactly one `Initial` row
+- [x] API boots against fresh DB (health/smoke endpoint used: **[endpoint]**)
+- [x] `TenantIsolationEndToEndTests` still green (inherited from Phase 5)
+- [x] `docs/data-model-refactor.md` ≤200 lines
+- [x] Archive at
+      `docs/superpowers/archive/2026-04-10-data-model-refactor-history.md`
+      carries the archive banner
+
+## Out of scope
+
+- No entity shape changes. No service rewrites. No controller or frontend
+  changes. Phase 6 is pure housekeeping.
+- If a Phase 6 step surfaced an earlier-phase bug (e.g. an entity missing
+  from the baseline), that fix lives in its own targeted hotfix PR against
+  the phase that introduced the bug, not in this PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 3: Return the PR URL**
+
+After `gh pr create` succeeds, print the PR URL back to the user and stop.
+
+---
+
+## Self-review checklist (run before handoff)
+
+- [ ] Every task above has concrete file paths and exact commands.
+- [ ] No task depends on a file, entity, or service that Phase 6 itself is meant to create.
+- [ ] The reference doc content in Task 6 Step 1 is complete (no "TBD" or "add here").
+- [ ] Task 2 (delete migrations) comes **before** Task 3 (regenerate), not after.
+- [ ] Task 4 verifies the fresh DB boot **before** Task 5 runs the test suite — because a broken migration surfaces as a startup error, not as a test failure.
+- [ ] Task 7 grep sweeps exclude `docs/superpowers/archive/` and the new `Migrations/` folder so historical references and the generated baseline do not spuriously fail the check.
+- [ ] The PR body in Task 9 includes the tenant isolation audit gate from §4.10 Rule 10 (inherited from Phase 5; no new assertions required in Phase 6).
+- [ ] No task silently hand-edits a generated migration file. Any disagreement between the snapshot and the live model must be resolved by regeneration, not by patching EF's output.

--- a/docs/superpowers/specs/2026-04-01-approval-task-detail-redesign.md
+++ b/docs/superpowers/specs/2026-04-01-approval-task-detail-redesign.md
@@ -1,0 +1,98 @@
+# ApprovalTaskDetail Redesign
+
+Restructure `ApprovalTaskDetail.tsx` from a single-column stacked layout to a two-column layout with a context sidebar, matching the provided design mockup.
+
+## Layout
+
+Two-column CSS grid: `lg:grid-cols-[1fr_320px]`, gap-5. Stacks vertically on mobile (sidebar below main content).
+
+### Left Column
+
+#### 1. Header
+
+Keep the existing gradient card and breadcrumb. Changes:
+
+- Title format: "Remediation Approval: {softwareName}" (prefix added)
+- Status badges, severity badge, and expiry countdown all render inline in a single `flex-wrap` row beneath the title
+- Remove the current metadata sidebar box from the header (its data moves to the right-column cards)
+- Remove the "Requested decision" sub-section from the header (moves to Requested Action sidebar card)
+- Keep the mark-as-read button for non-pending resolved tasks
+
+#### 2. Reviewer Verdict Card (pending only)
+
+Standalone card below the header (not nested inside it). Structure:
+
+- Card header row: shield icon (`ShieldCheck` from lucide) + "Reviewer Verdict" title, large checkmark icon on the right
+- "APPROVAL JUSTIFICATION" label (uppercase tracking)
+- Rich text editor (existing `Textarea` component with toolbar)
+- Placeholder: "Provide technical rationale for this decision..."
+- Validation errors inline below the editor (existing logic)
+- Maintenance window date input above the editor when `maintenanceWindowRequired` (existing logic)
+- Two action buttons side by side:
+  - "Approve Remediation" — primary/success style with `CheckCircle` icon
+  - "Deny Request" — destructive/outline style with `XCircle` icon
+
+#### 3. Tabs Section
+
+Same four tabs (Justification, Vulnerabilities, Affected Devices, Timeline). All existing tab content stays.
+
+**Justification tab addition**: Add a footer card at the bottom with:
+- "REQUESTED BY" — derived from the audit trail "Created" event's `userDisplayName`, fallback to `decidedByName`
+- "REQUEST DATE" — `createdAt` formatted as date + time
+
+### Right Column (Sidebar)
+
+#### 1. Requested Action Card
+
+- Section label: "REQUESTED ACTION" (uppercase tracking)
+- Outcome text: "{outcomeLabel} for this software scope" (e.g., "Patch this software for this software scope")
+- Vulnerable versions list: compact list of all `deviceVersionCohorts` where `activeVulnerabilityCount > 0`, each showing version string + vuln count (e.g., "1.10.0 — 3 vulns"). If none, show "No vulnerable versions".
+- Software name displayed with a package-style icon (`Package` from lucide) + "Software Library" subtitle
+
+#### 2. Risk Context Card
+
+- Section label: "RISK CONTEXT" (uppercase tracking)
+- Large risk score number (text-4xl font-bold)
+- Risk band label below the number (e.g., "HIGH RISK SCORE"), colored by `riskBandTone`
+- Semicircular gauge using recharts `RadialBarChart`:
+  - `startAngle={180}` `endAngle={0}` for a 180-degree arc
+  - Single `RadialBar` filled proportionally (`riskScore / 10`)
+  - Bar color derived from `riskBandTone`
+  - Centered to the right of the score number
+- Two stat boxes below in a 2-column grid:
+  - Open vulnerabilities count (`vulnerabilities.totalCount`)
+  - Affected devices count (sum of `deviceVersionCohorts[].deviceCount`)
+- If `riskScore` is null, show "No risk data" placeholder instead of gauge
+
+#### 3. Threat Intelligence Card
+
+- Section label: "THREAT INTELLIGENCE" (uppercase tracking)
+- Dark-toned card (`bg-background/40`)
+- Placeholder text: "Threat intelligence summary will appear here when available."
+- Styled to match the dark card aesthetic from the mockup
+
+## Styling
+
+All cards use existing design system patterns:
+- `rounded-2xl border border-border/70 bg-background/60 p-5`
+- Section labels: `text-[10px] uppercase tracking-[0.14em] text-muted-foreground`
+- Stat boxes: bordered sub-cards with large number + small label
+
+The header retains its existing `rounded-[28px]` gradient style.
+
+## Data
+
+No schema changes. All data derived from existing `ApprovalTaskDetail` type:
+- Requester name: `auditTrail.find(e => e.action === 'Created')?.userDisplayName ?? decidedByName`
+- Software version list: `deviceVersionCohorts.filter(c => c.activeVulnerabilityCount > 0)`
+- Risk gauge: `riskScore` (0-10 scale), `riskBand`
+- Vuln/device counts: existing computed values
+
+## Component Changes
+
+Only `ApprovalTaskDetail.tsx` is modified. No new files, no new components, no schema changes. The recharts `RadialBarChart` and `RadialBar` are imported directly into the component.
+
+## Responsive Behavior
+
+- `lg:` breakpoint: two-column grid
+- Below `lg`: single column, sidebar cards stack below the tabs section

--- a/docs/superpowers/specs/2026-04-05-authenticated-scans-design.md
+++ b/docs/superpowers/specs/2026-04-05-authenticated-scans-design.md
@@ -1,0 +1,459 @@
+# Authenticated Scans — Design Spec
+
+**Date:** 2026-04-05
+**Status:** Approved (pending user review of this document)
+**Scope:** v1 of authenticated scanning feature — SSH-based, on-prem runner, tenant-scoped, single supported output model (`DetectedSoftware`).
+
+---
+
+## 1. Purpose
+
+PatchHound needs to connect directly to individual hosts to perform scans for data that Defender does not surface (e.g. locally-installed software on Linux). This spec defines the configuration surface, execution pipeline, data flow, and admin UX for authenticated scans.
+
+---
+
+## 2. High-level decisions (confirmed)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Hybrid topology** — central SaaS + on-prem `PatchHound.ScanRunner` binary | Customer hosts are not reachable from central; runner lives inside customer network. |
+| 2 | **Pull-based protocol** — runner polls HTTPS for jobs | Firewall-friendly (outbound HTTPS only); matches existing worker patterns; scan jobs not latency-sensitive. |
+| 3 | **Credentials in central OpenBao**, delivered JIT per job | Matches existing secret posture; simplest admin UX. |
+| 4 | **Tenant-scoped everything**, tenant Admin role gates access | Consistent with existing admin entities (`AssetRule`, `TenantSourceConfiguration`). |
+| 5 | **Reuse staging+merge pipeline** with per-source precedence (last-writer-wins per source) | Auth-scan data flows into canonical inventory, participates in vuln matching + risk scoring automatically. |
+| 6 | **Cron schedule + manual trigger** (empty schedule = manual-only) | Consistent with existing `SyncSchedule`; supports on-demand runs from the Sources admin tab. |
+| 7 | **Admin pre-creates runner**, UI shows bearer secret once | Named runners visible before they connect; matches mental model. |
+| 8 | SFTP upload + file + cleanup; per-tool timeout (default 300s); bounded parallel execution (default 10); **JSON on stdout required** | Most flexible, safest, minimal forensic footprint. |
+| 9 | Runner assignment **on scan profile** (single runner per profile) | Explicit, no mystery about which runner hits which host; no multi-runner load balancing in v1. |
+| 10 | **SSH everywhere** (Windows via OpenSSH); **script versioning with 10-version rolling window** | Uniform protocol; auditability without unbounded storage. |
+
+---
+
+## 3. Architecture
+
+```
+┌─────────────── CENTRAL (SaaS) ────────────────┐        ┌──────── ON-PREM ─────────┐
+│  PatchHound.Api                               │        │   PatchHound.ScanRunner  │
+│   ├─ ScanProfilesController                   │        │   (new dotnet binary)    │
+│   ├─ ScanningToolsController                  │        │                          │
+│   ├─ ConnectionProfilesController             │        │   - Pulls jobs HTTPS     │
+│   ├─ ScanRunnersController (enroll, heartbeat)│  HTTPS │   - SSH.NET client       │
+│   └─ ScanRunnerJobsController (pull/result) ◄─┼────────┤   - Executes scripts     │
+│                                               │        │   - Posts results back   │
+│  PatchHound.Core — new entities               │        │   - Heartbeats           │
+│                                               │        └──────────────────────────┘
+│  PatchHound.Infrastructure                    │                    │ SSH
+│   ├─ Secrets/OpenBao (existing)               │                    ▼
+│   └─ AuthenticatedScans/                      │        ┌──────── TARGET HOSTS ────┐
+│      ├─ ScanSchedulerWorker (cron tick)       │        │  /tmp/ph-<id>.py etc.    │
+│      ├─ ScanJobDispatcher                     │        │  stdout → JSON          │
+│      └─ AuthenticatedScanIngestionService     │        └──────────────────────────┘
+│                                               │
+│  PatchHound.Worker (existing process host)    │
+│   └─ hosts ScanSchedulerWorker                │
+└───────────────────────────────────────────────┘
+```
+
+**Boundaries:**
+
+- **Central Api** owns configuration, job queue, results, ingestion, UI. Never talks SSH.
+- **ScanRunner** is a small on-prem binary. Only HTTPS (to central) + SSH (to target hosts). No DB, no UI; state = a local config file (tenant id, runner id, bearer secret, central URL).
+- **`ScanSchedulerWorker`** lives in the existing `PatchHound.Worker` process — reuses worker host, DI, EF context, OpenBao access.
+- **Job queue** is a DB-backed `ScanJob` table keyed by runner id.
+
+---
+
+## 4. Data model
+
+All entities are tenant-scoped (`TenantId` column + tenant filter). Follow existing encapsulation pattern (private setters, static `Create`, update methods, EF configuration under `Infrastructure/Data/Configurations`).
+
+### 4.1 Configuration entities
+
+**`ConnectionProfile`** — how to connect to a host.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| TenantId | Guid | |
+| Name | string | |
+| Description | string | |
+| Kind | string | `"ssh"` in v1 (generic for expansion) |
+| SshHost | string | |
+| SshPort | int | default 22 |
+| SshUsername | string | |
+| AuthMethod | string | `"password"` \| `"privateKey"` |
+| SecretRef | string | OpenBao path; plaintext never stored in DB |
+| HostKeyFingerprint | string? | optional, TOFU-pinned |
+| CreatedAt / UpdatedAt | DateTimeOffset | |
+
+**`ScanningTool`** — a configured script that produces structured output.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| TenantId | Guid | |
+| Name / Description | string | |
+| ScriptType | string | `"python"` \| `"bash"` \| `"powershell"` |
+| InterpreterPath | string | e.g. `/usr/bin/python3` |
+| TimeoutSeconds | int | default 300 |
+| OutputModel | string | `"DetectedSoftware"` in v1 |
+| CurrentVersionId | Guid? | FK → `ScanningToolVersion` |
+| CreatedAt / UpdatedAt | DateTimeOffset | |
+
+**`ScanningToolVersion`** — immutable snapshot of script text. Retain newest 10 per tool.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| ScanningToolId | Guid, FK | |
+| VersionNumber | int | auto-increment per tool |
+| ScriptContent | text | |
+| EditedBy | Guid (UserId) | |
+| EditedAt | DateTimeOffset | |
+
+**`ScanProfile`** — a bundle of tools + schedule + connection + runner.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| TenantId | Guid | |
+| Name / Description | string | |
+| CronSchedule | string | `""` means manual-only |
+| ConnectionProfileId | Guid, FK | |
+| ScanRunnerId | Guid, FK | |
+| Enabled | bool | |
+| ManualRequestedAt | DateTimeOffset? | |
+| LastRunStartedAt | DateTimeOffset? | |
+| CreatedAt / UpdatedAt | DateTimeOffset | |
+
+**`ScanProfileTool`** (join) — tools assigned to a profile with execution order.
+
+| ScanProfileId | ScanningToolId | ExecutionOrder | PK=(ScanProfileId, ScanningToolId) |
+|---|---|---|---|
+
+**`ScanRunner`** — on-prem runner identity.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| TenantId | Guid | |
+| Name / Description | string | |
+| SecretHash | string | SHA-256 of bearer token |
+| LastSeenAt | DateTimeOffset? | |
+| Version | string | runner build info |
+| Enabled | bool | |
+| CreatedAt / UpdatedAt | DateTimeOffset | |
+
+**`DeviceScanProfileAssignment`** — written by device-rule evaluation.
+
+| TenantId | DeviceId | ScanProfileId | AssignedByRuleId | AssignedAt | PK=(DeviceId, ScanProfileId) |
+|---|---|---|---|---|---|
+
+### 4.2 Run / execution entities
+
+**`AuthenticatedScanRun`** — one firing of a scan profile.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| TenantId | Guid | |
+| ScanProfileId | Guid | |
+| TriggerKind | string | `"scheduled"` \| `"manual"` |
+| TriggeredByUserId | Guid? | |
+| StartedAt / CompletedAt | DateTimeOffset(?) | |
+| Status | string | `Queued` \| `Running` \| `Succeeded` \| `PartiallyFailed` \| `Failed` |
+| TotalDevices / SucceededCount / FailedCount | int | |
+| EntriesIngested | int | |
+
+**`ScanJob`** — unit of work per target device.
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | Guid, PK | |
+| TenantId | Guid | |
+| RunId | Guid, FK → AuthenticatedScanRun | |
+| ScanRunnerId | Guid, FK | |
+| DeviceId | Guid, FK | target device |
+| ConnectionProfileId | Guid, FK | snapshot at dispatch |
+| ScanningToolVersionIds | json | array of tool version FKs, snapshotted at dispatch |
+| Status | string | `Pending` \| `Dispatched` \| `Running` \| `Succeeded` \| `Failed` \| `TimedOut` |
+| LeaseExpiresAt | DateTimeOffset? | |
+| AttemptCount | int | default 0 |
+| StartedAt / CompletedAt | DateTimeOffset(?) | |
+| ErrorMessage | string | |
+| StdoutBytes / StderrBytes | int | size only on the job itself |
+| EntriesIngested | int | |
+
+**`ScanJobResult`** — raw + parsed output.
+
+| Id | ScanJobId | RawStdout (truncated) | RawStderr (truncated) | ParsedJson | CapturedAt |
+|---|---|---|---|---|---|
+
+**`ScanJobValidationIssue`** — per-entry ingestion issues.
+
+| ScanJobId | FieldPath | Message | EntryIndex |
+|---|---|---|---|
+
+### 4.3 Enum + existing-model changes
+
+- **New enum value** `SoftwareIdentitySourceSystem.AuthenticatedScan`.
+- **New `DeviceRuleOperation` type** `"AssignScanProfile"` with parameters `{"scanProfileId": "<guid>"}`.
+
+---
+
+## 5. Runner protocol & enrollment
+
+### 5.1 Enrollment
+
+1. Admin creates a runner record in the UI: `POST /api/scan-runners` with name/description.
+2. Api generates a random 32-byte bearer secret, stores `SHA-256(secret)` in `ScanRunner.SecretHash`, returns the plaintext once.
+3. UI shows the secret once ("won't see this again") plus central Api URL, tenant id, runner id, and a ready-to-paste `runner.yaml`.
+4. Admin deploys the runner binary with that config. Runner calls `POST /api/scan-runner/heartbeat` with `Authorization: Bearer <secret>`.
+5. Api verifies hash → updates `LastSeenAt`, `Version`.
+6. Rotation via `POST /api/scan-runners/{id}/rotate-secret`; old secret invalidated immediately.
+
+### 5.2 HTTP endpoints (central Api)
+
+```
+POST /api/scan-runner/heartbeat
+  body: { version, hostname }
+  → 200 { ok: true }
+
+GET  /api/scan-runner/jobs/next
+  → 204 (empty) OR
+  → 200 {
+      jobId, deviceId,
+      hostTarget:   { host, port, username, authMethod },
+      credentials:  { password? | privateKey? | privateKeyPassphrase? },
+      hostKeyFingerprint?: "SHA256:...",
+      tools: [ { id, name, scriptType, interpreterPath,
+                 timeoutSeconds, scriptContent, outputModel } ],
+      leaseExpiresAt
+    }
+
+POST /api/scan-runner/jobs/{jobId}/heartbeat
+  → renews lease (expected every 30s)
+
+POST /api/scan-runner/jobs/{jobId}/result
+  body: {
+    status: "Succeeded"|"Failed"|"TimedOut",
+    toolResults: [ { toolId, stdout, stderr, exitCode, durationMs, parsedEntries? } ],
+    errorMessage?
+  }
+  → 200 { ok: true }
+```
+
+### 5.3 Credential delivery
+
+Credentials are fetched JIT from OpenBao at `jobs/next` time, embedded in the 200 response over TLS, held in runner memory only for the job's lifetime, never persisted runner-side.
+
+### 5.4 Leases & safety
+
+- Jobs have a 10-minute lease at dispatch; runner heartbeats every 30s to renew.
+- Expired lease → job returns to `Pending`, `AttemptCount++`, eligible for re-dispatch.
+- After `AttemptCount == 3`, job is marked `Failed` with `"runner unreachable"`.
+- Runner-side concurrency: at most M concurrent jobs (default 10, `runner.yaml` configurable).
+
+### 5.5 Runner binary internals
+
+- New project `PatchHound.ScanRunner`, single-file publish.
+- Uses `SSH.NET` for SSH + SFTP.
+- Loads `runner.yaml`, backoff retries on central HTTP errors, logs to stdout (systemd-friendly).
+- Execution sequence: SFTP script → `<interpreter> <scriptpath>` → capture stdout/stderr → delete script. Timeout enforced via cancellation token + SSH channel close.
+
+---
+
+## 6. Scan orchestration
+
+### 6.1 `ScanSchedulerWorker` (in `PatchHound.Worker`, 60s tick)
+
+1. Load all `ScanProfile` where `Enabled = true` and (`CronSchedule != ""` or `ManualRequestedAt != null`).
+2. For cron profiles: compute next-due time from `CronSchedule` and `LastRunStartedAt`. Skip if not due.
+3. For each due profile (or with `ManualRequestedAt`): call `ScanJobDispatcher.StartRun(profileId, triggerKind)`.
+4. **Stale-job sweep:** any `Pending` job whose parent `AuthenticatedScanRun.StartedAt` is >2 hours old → mark `Failed` with `"runner offline (never picked up)"`.
+
+### 6.2 `ScanJobDispatcher.StartRun(profileId, triggerKind)`
+
+1. Reject if profile has a non-terminal active run (409 Conflict for manual trigger).
+2. Create `AuthenticatedScanRun` (`Status = Queued`, `StartedAt = now`).
+3. Query `DeviceScanProfileAssignment` for all devices assigned to this profile.
+4. Snapshot each `ScanningTool`'s current `CurrentVersionId`.
+5. For each device, insert `ScanJob` (`Status = Pending`, `ScanRunnerId = profile.ScanRunnerId`, `ScanningToolVersionIds = snapshot`).
+6. Set run `TotalDevices = count`, `Status = Running`. If `count == 0`, immediately mark `Succeeded`.
+7. Commit transaction.
+
+### 6.3 Manual trigger
+
+`POST /api/scan-profiles/{id}/trigger-run` writes `ManualRequestedAt`. Scheduler picks up on next tick, `TriggerKind = "manual"`, `TriggeredByUserId = current user`.
+
+### 6.4 Run completion
+
+On `jobs/{id}/result`:
+
+1. Mark the job terminal (`Succeeded` / `Failed` / `TimedOut`).
+2. If `Succeeded`, invoke `AuthenticatedScanIngestionService.Ingest(jobId)` (see §7).
+3. If all jobs for the parent run are now terminal:
+   - All succeeded → `Run.Status = Succeeded`
+   - Mix → `Run.Status = PartiallyFailed`
+   - All failed → `Run.Status = Failed`
+   - Set `CompletedAt`, sum `EntriesIngested`, `SucceededCount`, `FailedCount`.
+
+### 6.5 Concurrency guardrails
+
+- One active `AuthenticatedScanRun` per profile at a time.
+- Runner-side concurrency capped by runner config.
+- Optional central-side cap on `Dispatched` jobs per runner.
+
+---
+
+## 7. Ingestion (validate → stage → merge)
+
+### 7.1 Tool output contract — `DetectedSoftware` model
+
+Script must print to stdout a single JSON object:
+
+```json
+{
+  "software": [
+    {
+      "canonicalName":       "nginx",              // required, string, non-empty
+      "canonicalProductKey": "nginx:nginx",        // required, string, non-empty
+      "detectedVersion":     "1.24.0",             // optional, string
+      "canonicalVendor":     "F5 Networks",        // optional, string
+      "category":            "web-server",         // optional, string
+      "primaryCpe23Uri":     "cpe:2.3:a:..."       // optional, CPE 2.3
+    }
+  ]
+}
+```
+
+The **"Show expected output JSON" button** in the Scanning Tool editor renders this with a legend (green = required, grey = optional) and inline descriptions, syntax-highlighted by CodeMirror's JSON language.
+
+The runner detects software and returns `DetectedSoftware` entries.
+The central service persists those entries into canonical inventory entities:
+
+- `SoftwareProduct`
+- `InstalledSoftware`
+
+### 7.2 `AuthenticatedScanIngestionService.Ingest(ScanJobId)`
+
+1. Load job + `ScanJobResult.ParsedJson`.
+2. **Validate**:
+   - `software` must be an array (may be empty).
+   - Each entry: `canonicalName` and `canonicalProductKey` required non-empty strings; optional fields are strings when present.
+   - Soft limits: entry count ≤ 5000, string length ≤ 1024. Exceeded → entire job fails with explicit message.
+3. Per-entry validation issues are recorded as `ScanJobValidationIssue` rows with `FieldPath`, `Message`, `EntryIndex`. Invalid entries **skipped**; valid entries still ingest.
+4. ≥1 valid entry → stage + merge (§7.3); job → `Succeeded`, `EntriesIngested = validCount`. Issues still surface in the report.
+5. 0 valid entries → job → `Failed`, `ErrorMessage = "all {N} entries failed validation"`.
+
+### 7.3 Staging + merge
+
+Write to **new dedicated table `StagedDetectedSoftware`** (isolated from Defender's snapshot-lifecycle staging). Merge logic shared with existing pipeline via a helper.
+
+Key fields per staged entry:
+
+- `TenantId`, `DeviceId` (the job target), `SourceKey = "AuthScan:<profileId>"`, `SourceSystem = SoftwareIdentitySourceSystem.AuthenticatedScan`, plus `canonical*` fields and `detectedVersion`.
+
+Merge logic:
+
+- **Upsert** `SoftwareProduct` by `CanonicalProductKey` (shared across sources).
+- **Upsert** `InstalledSoftware` by `(DeviceId, SoftwareProductId, DetectedVersion, SourceSystem)`.
+- **Deactivate** any `InstalledSoftware` rows for `(device, SourceSystem=AuthenticatedScan)` that were NOT in this run. Authoritative-for-source behavior, matches Defender's pattern.
+- Optionally update `SoftwareAlias` if authenticated-scan-specific identifiers are introduced later.
+
+**Precedence:** rows are source-owned at the installation level. Each source owns its own `InstalledSoftware` rows for a given device. Dashboards and vulnerability matching see the union of active installations across sources. Vulnerability matching joins through canonical `SoftwareProduct`.
+
+---
+
+## 8. Admin UI
+
+### 8.1 Workbench page
+
+Route: **`/admin/authenticated-scans`** — full-page workbench with tabs, deep-linkable via `?tab=`:
+
+- `?tab=profiles` (default)
+- `?tab=tools`
+- `?tab=connections`
+- `?tab=runners`
+
+Gated on tenant Admin role. Matches existing `components.json` shadcn/ui patterns.
+
+**Tab 1 — Scan Profiles (default):**
+- Data table: Name, Schedule (cron → human), Runner, Connection, Tool count, Enabled, Last run status, Actions.
+- Create/edit dialog: name, description, cron input with preview, runner dropdown, connection profile dropdown, multi-select tools with drag-to-reorder.
+- Detail drawer: assigned devices (read-only, populated by device rules).
+
+**Tab 2 — Scanning Tools:**
+- Data table: Name, Script type, Output model, Current version, Last edited.
+- Multi-step editor (matching Advanced Tool Workbench): name/description, script type, interpreter path, timeout, output model dropdown, **CodeMirror editor** with syntax highlighting per language, **"Show expected output JSON" button** → side panel with schema + required/optional legend.
+- Version history panel: last 10 versions (EditedBy/EditedAt, view button).
+
+**Tab 3 — Connection Profiles:**
+- Data table: Name, Kind, Host, Username, Auth method.
+- Create/edit dialog: name, kind=ssh, host, port, username, auth method radio (password/privateKey), secret fields (password OR private key textarea + optional passphrase), optional host key fingerprint.
+- Secrets stored in OpenBao on save; `SecretRef` stored on entity. On edit: secrets shown as `••••••` with "Replace" button; never echoed back.
+
+**Tab 4 — Scan Runners:**
+- Data table: Name, Last seen, Version, Status (online if LastSeenAt < 2min).
+- Create dialog: name, description → on save, modal shows bearer secret once + runner ID + central URL + ready-to-paste `runner.yaml`.
+- Row action "Rotate secret" (shows new secret once).
+
+### 8.2 Asset rule integration
+
+In existing `/admin/asset-rules/` UI, add operation "Assign scan profile" with a scan-profile dropdown. Maps to `DeviceRuleOperation { Type="AssignScanProfile", Parameters={"scanProfileId":"..."} }`. The existing rule evaluation service writes `DeviceScanProfileAssignment` rows.
+
+### 8.3 Sources admin — new "Authenticated Scans" tab
+
+On `/admin/sources`, add a new tab "Authenticated Scans":
+
+- Data table: Profile, Last start, Last stop, Status, Entries ingested, Host count, Actions (Trigger manual run, View report).
+- **Run report dialog:** two data tables —
+  - *Successful hosts* (count + expandable list).
+  - *Failed hosts*: hostname, device id, error message, attempt count, duration. Groups validation issues per host (field path + message + entry index).
+
+---
+
+## 9. Security
+
+- **Credentials** in OpenBao at `secrets/tenants/{tenantId}/auth-scan-connections/{profileId}`, never in DB. `ConnectionProfile.SecretRef` holds only the path. Delivered JIT over TLS, runner-memory-only.
+- **Runner auth:** bearer secret, hashed SHA-256 in DB, shown once. Runner API scoped to its owning tenant; can only call `/api/scan-runner/*`.
+- **Authorization:** all scan-config + scan-run endpoints require tenant Admin. Readers of the Sources admin "Authenticated Scans" tab also Admin.
+- **Host-key pinning:** optional `HostKeyFingerprint` on ConnectionProfile. First successful scan records fingerprint (TOFU). Subsequent mismatches fail with clear error.
+- **Script injection guardrails:** interpreter path + script content controlled by tenant admins only. Runner executes `<interpreter> <scriptpath>` (no shell interpolation of untrusted data). Script deleted post-execution.
+- **Size caps:** stdout 2 MB, stderr 256 KB, entries ≤ 5000, string length ≤ 1024. Truncation flagged on result.
+- **Audit:** all create/edit/delete + manual trigger logged via existing `AuditSaveChangesInterceptor` with `TriggeredByUserId`.
+- **Secret rotation:** `POST /scan-runners/{id}/rotate-secret`, old secret immediately invalidated.
+
+---
+
+## 10. Testing strategy
+
+Aligned with `docs/testing-conventions.md`.
+
+**Unit tests:**
+- `AuthenticatedScanIngestionService` — validation rules (required fields, type checks, size caps, per-entry issues), staging+merge, per-source precedence (Defender + AuthScan coexistence).
+- `ScanJobDispatcher` — run creation, empty-device-set, no-duplicate-active-run guardrail, version snapshotting.
+- `ScanSchedulerWorker` — cron due calculation, manual trigger pickup, stale-job sweeping.
+- `ScriptVersionStore` — 10-version rolling window.
+- `ScanRunnerAuth` — bearer hashing, rotation, tenant scoping.
+
+**Integration tests (EF Core + real DB):**
+- End-to-end: create profile → assign devices → trigger → mock runner pulls → posts result → verify ingestion, run completion, `InstalledSoftware` rows, coexistence with synthetic Defender rows.
+- Partial-failure path → `Status=PartiallyFailed`, correct report data.
+- Validation-failure path → issues recorded, partial ingest.
+- Runner-offline path → sweeper marks jobs failed.
+
+**Runner binary tests:** SSH execution via local `sshd` test container — script upload, timeout kill, cleanup, stdout capture.
+
+**UI tests (Playwright/Vitest):** form validation, secret-once-visible modal, cron preview, schema-viewer button, manual trigger flow.
+
+---
+
+## 11. Out of scope for v1
+
+- WinRM connection type (SSH only; Windows via OpenSSH).
+- Runner tagging / device tagging / load-balancing across runners.
+- Additional output models beyond `DetectedSoftware`.
+- Script diff UI between versions (view-only list in v1).
+- mTLS runner auth.
+- Multi-tenant scan runners.

--- a/docs/superpowers/specs/2026-04-10-data-model-canonical-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-10-data-model-canonical-cleanup-design.md
@@ -1,0 +1,355 @@
+# Data Model Canonical Cleanup — Design
+
+**Date:** 2026-04-10
+**Status:** Approved design, ready for implementation planning
+**Supersedes:** the in-flight §21.2/§21.3 work tracked in `docs/data-model-refactor.md`
+
+## 1. Context
+
+PatchHound has been migrating from a legacy data model (`Asset`, `NormalizedSoftware*`, `TenantSoftware*`, `VulnerabilityDefinition*`, `VulnerabilityAsset*`) to a canonical model (`Device`, `SoftwareProduct`, `InstalledSoftware`, `Vulnerability`, `VulnerabilityApplicability`, `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment`, `RemediationCase`). The in-progress branch `data-model-refactor-clean-reset` introduced most of those canonical entities and then spent its last ~10 commits layering compatibility bridges — "canonical-first, legacy-fallback" reads on roughly 40+ query paths across every remediation, risk, dashboard, and software service. Each bridge exists only to preserve legacy DTO shapes, legacy URLs, or legacy ID continuity.
+
+The constraints that made those bridges necessary no longer apply:
+
+- The database can be treated as greenfield. A single new baseline migration is acceptable; no data preservation is required.
+- Legacy URLs (`/api/software/{tenantSoftwareId}`, `/software/{tenantSoftwareId}/remediation`, `/assets/{assetId}`) can break. The product is still in testing; no user deep links, bookmarks, or email deep-links need to survive.
+- DTO shapes can drop `tenantSoftwareId`, `softwareAssetId`, `normalizedSoftwareId` fields.
+- Risk score numbers may shift slightly when the aggregation source changes from legacy projections to canonical exposure reads.
+- Rewriting canonical code that already exists on the abandoned branch is acceptable if it produces a cleaner final model.
+
+Given those freedoms, the cleanup is not "finish the migration as-planned." The cleanup is a fresh ground-up introduction of the canonical model alongside deletion of every legacy entity, with no compatibility bridges. The existing `data-model-refactor-clean-reset` branch is abandoned in favor of a new branch cut from `main`.
+
+## 2. Goals
+
+- Introduce the canonical data model directly on top of `main`, without dual-write, without legacy fallback.
+- Delete the legacy data model entirely.
+- Enforce strict tenant isolation on every tenant-scoped entity; keep global reference data global.
+- Unify device representation under one `Device` entity. `Asset` goes away.
+- Unify software representation under `SoftwareProduct` + `SoftwareAlias` + `InstalledSoftware`. The tenant-scoped `TenantSoftware` layer goes away.
+- Unify vulnerability representation under `Vulnerability` + `VulnerabilityApplicability` + `DeviceVulnerabilityExposure` + `ExposureEpisode` + `ExposureAssessment`. The `VulnerabilityDefinition*` / `VulnerabilityAsset*` chain goes away.
+- Re-anchor every remediation process record on `RemediationCase`. `TenantSoftwareId` and `SoftwareAssetId` columns on remediation tables go away.
+- Regenerate a single clean baseline migration at the end.
+- Rewrite `docs/data-model-refactor.md` as a short reference of the final model; archive the milestone history.
+
+## 3. Non-goals
+
+- Runner transport protocol changes.
+- Tenant authorization model changes.
+- AI provider strategy changes.
+- Workflow engine internals.
+- Adding new features (remediation scopes beyond `SoftwareProductId`, software-scoped rule engine, cross-source device correlation, tenant-level vulnerability severity overrides). Those are deferred to their own work.
+
+## 4. Target data model
+
+### 4.1 Inventory / identity
+
+| Entity | Tenant scope | Notes |
+| --- | --- | --- |
+| `SourceSystem` | Global | Reference data (e.g. "defender", "tanium"). No `TenantId`. |
+| `Device` | Tenant-scoped | Direct `TenantId`. Unique on `(TenantId, SourceSystemId, ExternalId)`. Absorbs every field on `Asset`-with-type-`Device`. |
+| `SoftwareProduct` | Global | Canonical product identity. No `TenantId`. Unique on `CanonicalProductKey`. Carries `PrimaryCpe23Uri`. |
+| `SoftwareAlias` | Global | Source-observed product names/IDs mapped back to `SoftwareProduct`. Unique on `(SourceSystemId, ExternalId)`. |
+| `InstalledSoftware` | Tenant-scoped | Direct `TenantId`. Fact: this `Device` has this `SoftwareProduct` at this version from this `SourceSystem`. Current-state unique key does not depend on nullable columns. |
+| `TenantSoftwareProductInsight` | Tenant-scoped | Direct `TenantId`. Tenant-scoped description and supply-chain evidence per `SoftwareProduct`. Keeps global product fields clean. |
+
+### 4.2 Vulnerability knowledge
+
+| Entity | Tenant scope | Notes |
+| --- | --- | --- |
+| `Vulnerability` | Global | CVE/advisory record. No `TenantId`. |
+| `VulnerabilityReference` | Global | External links. |
+| `VulnerabilityApplicability` | Global | "This vuln affects this product/version range", keyed by `SoftwareProductId` or CPE criteria. |
+| `ThreatAssessment` | Global | Global threat intel / EPSS / KEV. |
+
+### 4.3 Exposure (always tenant-scoped)
+
+| Entity | Tenant scope | Notes |
+| --- | --- | --- |
+| `DeviceVulnerabilityExposure` | Tenant-scoped | Direct `TenantId`. Current-state row: this `Device` is currently exposed to this `Vulnerability`. |
+| `ExposureEpisode` | Tenant-scoped | Direct `TenantId`. Open/reopen/resolve history for an exposure. |
+| `ExposureAssessment` | Tenant-scoped | Direct `TenantId`. Contextualized score. Carries `SecurityProfileId` so environmental CVSS modifiers are honored. |
+
+`VulnerabilitySeverityOverride` as a tenant-level override table was in the original §10.1 plan but will **not** be created. Environmental severity stays driven by `SecurityProfile` through `ExposureAssessment`. See §7 (verification gates). The existing `RemediationDecisionVulnerabilityOverride` is a different, per-decision concept and stays (see §4.6).
+
+### 4.4 Device ownership & attributes
+
+All tenant-scoped with direct `TenantId`. Renamed from `Asset*` because they are device-only:
+
+| New | Old | Tenant scope |
+| --- | --- | --- |
+| `DeviceBusinessLabel` | `AssetBusinessLabel` | Via parent `Device`, plus own `TenantId` column for query filter safety |
+| `DeviceRiskScore` | `AssetRiskScore` | Direct `TenantId` |
+| `DeviceRule` | `AssetRule` | Direct `TenantId` |
+| `DeviceTag` | `AssetTag` | Via parent `Device`, plus own `TenantId` column for query filter safety |
+| `SecurityProfile` | `AssetSecurityProfile` | Direct `TenantId` (it's a tenant policy, not an asset) |
+
+`BusinessLabel` (the definition of a label) stays unchanged — tenant-scoped.
+
+A future `SoftwareProductRule` for software-scoped rules is **deferred**. Not built until it is actually needed.
+
+### 4.5 Risk scoring
+
+All rebuildable from canonical exposures. All tenant-scoped with direct `TenantId`:
+
+- `DeviceRiskScore` — keyed on `Device.Id`, carries `TenantId`.
+- `SoftwareRiskScore` — keyed on `(TenantId, SoftwareProductId)`. Software risk is per-tenant because different tenants have different install bases.
+- `TeamRiskScore` — direct `TenantId`.
+- `DeviceGroupRiskScore` — direct `TenantId`.
+- `TenantRiskScoreSnapshot` — direct `TenantId`.
+
+Exact numbers may shift from today's values because the aggregation source changes. Accepted.
+
+### 4.6 Remediation
+
+All tenant-scoped with direct `TenantId`:
+
+| Entity | Tenant scope | Notes |
+| --- | --- | --- |
+| `RemediationCase` | Direct `TenantId` | Aggregate root. **Requires non-null `SoftwareProductId`.** No observed-product fallback. Scope is `(TenantId, SoftwareProductId)`, optionally narrowed by version. |
+| `RemediationWorkflow` | Direct `TenantId` | `RemediationCaseId` required. `TenantSoftwareId` column dropped. |
+| `RemediationDecision` | Direct `TenantId` | `RemediationCaseId` required. `TenantSoftwareId`, `SoftwareAssetId` dropped. |
+| `PatchingTask` | Direct `TenantId` | `RemediationCaseId` required. `TenantSoftwareId`, `SoftwareAssetId` dropped. |
+| `ApprovalTask` | Direct `TenantId` | References `RemediationDecisionId`; case reachable through the decision. |
+| `RemediationDecisionVulnerabilityOverride` | Direct `TenantId` | Per-decision override of severity for a specific vulnerability inside a workflow. Target is the canonical exposure. |
+| `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob`, `SoftwareDescriptionJob`, `RemediationWorkflowStageRecord` | Direct `TenantId` | Re-anchored on `RemediationCase` where they referenced legacy software IDs. `SoftwareDescriptionJob` targets `SoftwareProductId` directly. |
+
+### 4.7 Authenticated scans
+
+All tenant-scoped with direct `TenantId`. Renamed to canonical naming:
+
+`ConnectionProfile`, `ScanningTool`, `ScanningToolVersion`, `ScanProfile`, `ScanProfileTool`, `DeviceScanProfileAssignment` (from `AssetScanProfileAssignment`), `ScanRunner`, `AuthenticatedScanRun`, `ScanJob` (with `DeviceId`, not `AssetId`), `ScanJobResult`, `ScanJobValidationIssue`, `StagedDetectedSoftware` (from `StagedAuthenticatedScanSoftware`).
+
+### 4.8 Ingestion / operational
+
+All tenant-scoped unless noted:
+
+`IngestionRun`, `IngestionCheckpoint`, `EnrichmentJob`, `EnrichmentRun`, `EnrichmentSourceConfiguration`, `TenantSourceConfiguration`, `TenantSlaConfiguration`, `TenantAiProfile`, `SentinelConnectorConfiguration`, `Tenant` (self-filtered), `User` (cross-cutting; filtered via `UserTenantRole`), `UserTenantRole`, `Team`, `TeamMember`, `TeamMembershipRule`, `BusinessLabel`, `OrganizationalSeverity`, `Notification`, `Comment`, `AuditLogEntry`, `AdvancedTool`, `WorkflowDefinition`, `WorkflowInstance`, `WorkflowNodeExecution`, `WorkflowAction`.
+
+Staged observation tables (`StagedVulnerability`, `StagedVulnerabilityExposure`, `StagedDetectedSoftware`) are tenant-scoped with direct `TenantId`.
+
+### 4.9 Deleted entities
+
+**Inventory legacy:**
+- `Asset`
+- `AssetBusinessLabel`, `AssetRiskScore`, `AssetRule`, `AssetTag` — renamed to `Device*`
+- `AssetSecurityProfile` — renamed to `SecurityProfile`
+- `AssetType` enum — `CloudResource` was aspirational/unused, `Software`/`Device` collapse into their canonical homes
+- `StagedAsset` — renamed to `StagedDevice`
+- `StagedDeviceSoftwareInstallation` — replaced by staged detected-software flow
+
+**Software legacy:**
+- `TenantSoftware`, `TenantSoftwareRiskScore`
+- `NormalizedSoftware`, `NormalizedSoftwareAlias`, `NormalizedSoftwareInstallation`, `NormalizedSoftwareVulnerabilityProjection`
+- `DeviceSoftwareInstallation`, `DeviceSoftwareInstallationEpisode`
+- `SoftwareCpeBinding`
+- `SoftwareVulnerabilityMatch`
+
+**Vulnerability legacy:**
+- `VulnerabilityDefinition`, `VulnerabilityDefinitionReference`, `VulnerabilityDefinitionAffectedSoftware`
+- `TenantVulnerability`
+- `VulnerabilityThreatAssessment`
+- `VulnerabilityAsset`, `VulnerabilityAssetEpisode`, `VulnerabilityAssetAssessment`
+- `VulnerabilityEpisodeRiskAssessment`
+
+**Operational legacy:**
+- `IngestionSnapshot` — temporal markers come from `IngestionRun` instead
+
+**Compatibility / legacy services (none of these are introduced from main; they are named here so implementers know not to re-create them):**
+- `LegacySoftwareCompatibilitySyncService`
+- `NormalizedSoftwareProjectionService`
+- `NormalizedSoftwareResolver`
+- Any "canonical-first, legacy-fallback" dual read path
+
+### 4.10 Tenant isolation rules
+
+Tenant separation is a hard invariant of this refactor. The rules below apply to every entity and every query added during phases 1–6.
+
+**Rule 1 — Every tenant-scoped entity carries its own `TenantId` column.**
+No transitive-only tenant scoping. Even entities whose "natural" tenant owner is reachable through a foreign key (e.g. `InstalledSoftware.DeviceId → Device.TenantId`) carry their own `TenantId` column. This eliminates the risk that an EF global filter silently fails because the join was not materialized. It also makes cross-tenant queries trivially grepable.
+
+**Rule 2 — Every tenant-scoped entity has an EF Core global query filter.**
+`modelBuilder.Entity<X>().HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId))` for every tenant-scoped entity, matching the pattern already used in `PatchHoundDbContext` for legacy tables. The filter is registered during phase 1 EF configuration reviews; every new entity introduced in later phases must add its filter in the same commit as the entity class.
+
+**Rule 3 — Global entities carry no `TenantId` and no tenant filter.**
+Only the entities listed as "Global" in §4.1 and §4.2 are exempt. These hold publicly-derivable data (CVE definitions, product identity, source system catalog, applicability rules). They are readable by every authenticated context. They are writable only by system-context operations (ingestion service with `IsSystemContext = true`).
+
+**Rule 4 — `TenantId` on tenant-scoped rows is always derived from `TenantContext.CurrentTenantId` at write time.**
+No controller or service accepts `tenantId` as a request-body field for create/update operations. `TenantId` is stamped by the service layer from the authenticated context. Scan runners authenticating via `ScanRunnerBearer` stamp `TenantId` from the runner's `tenant_id` claim, never from the payload.
+
+**Rule 5 — `IgnoreQueryFilters()` is banned outside system-context code paths.**
+Uses of `IgnoreQueryFilters()` must appear only inside services explicitly marked as system-context (ingestion, cross-tenant admin housekeeping, migration health checks). Any such call is reviewed by the implementer in the phase PR description and justified. A grep in each phase exit check ensures new `IgnoreQueryFilters()` calls do not appear in request-scoped controllers/services.
+
+**Rule 6 — Writes that link a tenant-scoped row to a global row never reveal cross-tenant state.**
+Example: when creating an `InstalledSoftware` row, the service resolves the `SoftwareProduct` (global) by canonical key and the `Device` (tenant-scoped) by `(TenantId, SourceSystemId, ExternalId)`. The `Device` lookup is tenant-filtered. The `SoftwareProduct` lookup is unfiltered but returns only public product identity data. There is no code path where resolving a `SoftwareProduct` leaks that a different tenant has installed it.
+
+**Rule 7 — Tenant-specific product context lives on `TenantSoftwareProductInsight`, never on `SoftwareProduct`.**
+`SoftwareProduct.Description`, AI-generated summaries, supply-chain evidence, and any other tenant-contextual evidence go into `TenantSoftwareProductInsight` (tenant-scoped). The global `SoftwareProduct` row carries only lifecycle metadata that is truly global (product name, vendor, primary CPE, end-of-life dates).
+
+**Rule 8 — Foreign keys from tenant-scoped rows to tenant-scoped rows must belong to the same tenant.**
+Example: `RemediationCase.TenantId` must equal the `Device.TenantId` of every `DeviceVulnerabilityExposure` the case covers. This is enforced in service-layer invariants and covered by tests. No row may be orphaned or cross-tenant-joined.
+
+**Rule 9 — Global entity writes come from system-context ingestion only.**
+A normal user request (even a GlobalAdmin) cannot directly create a `SoftwareProduct`, `Vulnerability`, `VulnerabilityApplicability`, `VulnerabilityReference`, `ThreatAssessment`, or `SourceSystem` row. Those are written by ingestion/enrichment services running with `IsSystemContext = true`. Admin UI surfaces that *appear* to edit these values (e.g. a curated product description) actually write to `TenantSoftwareProductInsight` or similar tenant-scoped shadow tables.
+
+**Rule 10 — Verification is not optional.**
+Every phase PR must include (a) a per-entity scope table in the PR description listing new entities and their `TenantId` status, and (b) an end-to-end isolation test that asserts tenant A cannot observe tenant B's data through any new query path added by the phase. See §7.
+
+## 5. Approach
+
+Fresh branch `data-model-canonical-cleanup` cut from the tip of `main`. The existing `data-model-refactor-clean-reset` branch is abandoned wholesale. Canonical entities, services, and migrations that exist on that branch are **intentionally rewritten** on the new branch — the user has approved this because the final model is cleaner when built from scratch under the rules in §4.10 than when layered on top of accumulated compatibility bridges.
+
+Six phases. **One PR per phase.** Every phase exits on a fully green build and test run. No phase leaves a dual-write or fallback path. Every phase is a vertical slice of one domain: introduce the canonical entities for that domain, rewrite every consumer, delete the legacy entities for that domain, all in the same PR.
+
+**Migration strategy across phases.** No EF Core migrations are generated during phases 1–5. Phases 1–5 mutate entities, `DbSet`s, EF configurations, and model snapshot state directly; the existing migration files under `src/PatchHound.Infrastructure/Migrations/` are left untouched and will not match the evolving model. Developers wipe their local dev database between phases instead of running migrations. Tests run against an in-memory or per-test-run provider, so CI is unaffected. Phase 6 is the **only** phase that touches migrations: it deletes every existing migration file, regenerates a single `Initial` migration against the final entity set, and verifies the resulting database boots cleanly.
+
+### 5.1 Phase 1 — Canonical inventory + delete inventory legacy
+
+**Introduce:** `SourceSystem` (global), `Device`, `SoftwareProduct` (global), `SoftwareAlias` (global), `InstalledSoftware`, `TenantSoftwareProductInsight`, `DeviceBusinessLabel`, `DeviceRiskScore`, `DeviceRule`, `DeviceTag`, `SecurityProfile`. Add EF configurations with tenant query filters per §4.10 Rule 2 on all tenant-scoped entities. Global entities carry no filter.
+
+**Authenticated-scan renames:** `AssetScanProfileAssignment` → `DeviceScanProfileAssignment`, `ScanJob.AssetId` → `DeviceId`, `StagedAuthenticatedScanSoftware` → `StagedDetectedSoftware`. Scan runner payloads use `deviceId`/`deviceName`.
+
+**Rewrite:** Defender/general ingestion (`IngestionService`, `StagedAssetMergeService` → `StagedDeviceMergeService`) and authenticated-scan ingestion to write canonical entities only. Asset rules evaluation → device rules. Security profile assignment → direct `Device.SecurityProfileId`. Risk scoring baseline keys off `Device.Id`.
+
+**Frontend:** `AssetsController` → `DevicesController`, `/api/assets` → `/api/devices`, `/assets` route → `/devices` route. Asset rule admin UI → device rule admin UI. Asset business label/tag admin → device equivalents.
+
+**Delete:** `Asset`, `AssetType` enum, `StagedAsset`, `StagedDeviceSoftwareInstallation`, `AssetBusinessLabel`, `AssetRiskScore`, `AssetRule`, `AssetTag`, `AssetSecurityProfile`, `TenantSoftware`, `TenantSoftwareRiskScore`, `NormalizedSoftware`, `NormalizedSoftwareAlias`, `NormalizedSoftwareInstallation`, `NormalizedSoftwareVulnerabilityProjection`, `DeviceSoftwareInstallation`, `DeviceSoftwareInstallationEpisode`, `SoftwareCpeBinding`, `StagedAssetMergeService` (replaced), `NormalizedSoftwareProjectionService`, `NormalizedSoftwareResolver`. Any "canonical-first, legacy-fallback" pattern is simply not created in this phase.
+
+**Exit:** `Asset*`, `TenantSoftware*`, `NormalizedSoftware*`, `SoftwareCpeBinding`, `DeviceSoftwareInstallation*` gone from the workspace. Ingestion writes only canonical. No `tenantSoftwareId` or `softwareAssetId` references anywhere. Frontend `/devices` works. Tenant isolation audit in PR description lists the 11 new entities with their scope. Tenant isolation end-to-end test passes (see §7). `dotnet test` and `npm test` green.
+
+### 5.2 Phase 2 — Canonical vulnerability knowledge + delete vuln legacy
+
+**Introduce:** `Vulnerability`, `VulnerabilityReference`, `VulnerabilityApplicability`, `ThreatAssessment`. All global; no tenant filters. Writes come from ingestion with `IsSystemContext = true`.
+
+**Rewrite:** Vulnerability ingestion (`DefenderVulnerabilitySource` and any other vulnerability source) writes `Vulnerability`, `VulnerabilityReference`, `VulnerabilityApplicability`, `ThreatAssessment` only. `VulnerabilitiesController` and `VulnerabilityDetailQueryService` query canonical and join through `DeviceVulnerabilityExposure` (introduced in Phase 3) once Phase 3 lands — until then, vulnerability read endpoints return global vulnerability data without per-tenant exposure counts. This temporary gap is acceptable because Phase 3 lands in the same merge train.
+
+Actually: to keep Phase 2 exit criteria green without depending on Phase 3, vulnerability list/detail endpoints in Phase 2 return global vulnerability data plus an empty "affected devices" section (explicitly marked as "populated after exposure phase"). Phase 3 fills that section. The frontend behind the feature shows an empty state during the brief window between Phase 2 and Phase 3.
+
+**Delete:** `VulnerabilityDefinition`, `VulnerabilityDefinitionReference`, `VulnerabilityDefinitionAffectedSoftware`, `TenantVulnerability`, `VulnerabilityThreatAssessment`.
+
+**Exit:** `VulnerabilityDefinition*`, `TenantVulnerability`, `VulnerabilityThreatAssessment` gone. Vulnerability ingestion writes canonical. Global-entity write audit in PR description confirms no controller accepts vulnerability creation from non-system context. `dotnet test` and `npm test` green.
+
+### 5.3 Phase 3 — Canonical exposure + delete exposure legacy
+
+**Introduce:** `DeviceVulnerabilityExposure`, `ExposureEpisode`, `ExposureAssessment`. All tenant-scoped with direct `TenantId` and EF global filter.
+
+**Rewrite:** Exposure derivation service reads `InstalledSoftware` and joins to `VulnerabilityApplicability` (through `SoftwareProductId` first, CPE fallback second) to produce `DeviceVulnerabilityExposure` rows. Lifecycle (open/reopen/resolve) attached to `ExposureEpisode`. `ExposureAssessment` computes environmental severity via `Device.SecurityProfileId` → `SecurityProfile` modifiers.
+
+Fill in the Phase 2 gap: vulnerability list/detail now populates "affected devices" and "active exposures" counts from `DeviceVulnerabilityExposure`.
+
+**Hard gate:** a dedicated test seeds (a) a `SecurityProfile` with non-default environmental CVSS modifiers, (b) a `Device` with that profile assigned, (c) an `InstalledSoftware` + matching `VulnerabilityApplicability`, then runs the exposure derivation + assessment services and asserts that:
+- `ExposureAssessment.SecurityProfileId` equals the seeded profile
+- `ExposureAssessment.Score` is not equal to the base CVSS from `Vulnerability`
+- `ExposureAssessment.Reason` references the environmental modifier
+
+No legacy deletions merge until that test exists and is green.
+
+**Delete:** `VulnerabilityAsset`, `VulnerabilityAssetEpisode`, `VulnerabilityAssetAssessment`, `VulnerabilityEpisodeRiskAssessment`, `SoftwareVulnerabilityMatch`, `SoftwareVulnerabilityMatchService`.
+
+**Exit:** Legacy exposure chain gone. Env-severity hard-gate test green. Tenant isolation test extended: tenant A cannot see tenant B's exposures, episodes, or assessments. `dotnet test` and `npm test` green.
+
+### 5.4 Phase 4 — RemediationCase + case-first remediation
+
+**Introduce:** `RemediationCase` (tenant-scoped, requires non-null `SoftwareProductId`).
+
+**Rewrite:** `RemediationWorkflow`, `RemediationDecision`, `PatchingTask`, `ApprovalTask` use `RemediationCaseId` as the scope key. `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob`, `SoftwareDescriptionJob`, `RemediationWorkflowStageRecord` re-anchored: each either references `RemediationCaseId` or, for `SoftwareDescriptionJob`, references `SoftwareProductId` directly. Drop `TenantSoftwareId` and `SoftwareAssetId` columns from every remediation table.
+
+**API:** Delete `/api/remediation/{workflowId}` and tenant-software-scoped remediation routes. Only `/api/remediation/cases/{caseId}/*` exists. Decision, approval, patching-task, AI report, supply-chain, description generation, work notes — all case-first.
+
+**Frontend:** Remediation routes use case IDs. Remediation workbench, decision context, approval task detail, patching task detail, dashboard remediation deep links all use case IDs.
+
+**Exit:** No `TenantSoftwareId`/`SoftwareAssetId` references in any remediation service, sidecar record, controller, DTO, or frontend component. `/api/remediation` surface is case-first only. Tenant isolation test extended: a case in tenant A cannot be addressed by a tenant B user, and remediation actions inside the case write `TenantId` from the authenticated context, never the payload. `dotnet test` and `npm test` green.
+
+### 5.5 Phase 5 — Risk scoring + dashboard + email notifications
+
+**Rewrite:** `RiskScoreService` computes `DeviceRiskScore`, `SoftwareRiskScore` (keyed `(TenantId, SoftwareProductId)`), `TeamRiskScore`, `DeviceGroupRiskScore`, `TenantRiskScoreSnapshot` from canonical `DeviceVulnerabilityExposure` and `ExposureAssessment` rows. Dashboard queries (owner, security manager, technical manager summaries) read canonical. Email notifications (`EmailNotificationService`) derive severity, device counts, product names from canonical rows and case links.
+
+**Delete:** Any remaining dual-path code in dashboards, risk scoring, and notifications. This phase is primarily a read-side cleanup after the write-side is already canonical from phases 1–4.
+
+**Exit:** No remaining references to deleted legacy entities in any service. All read paths are single-path canonical. Tenant isolation test extended with dashboard and notification assertions. `dotnet test` and `npm test` green.
+
+### 5.6 Phase 6 — Baseline migration reset + doc cleanup
+
+Delete every file under `src/PatchHound.Infrastructure/Migrations/`. Generate one new `Initial` migration + model snapshot against the final entity set. Verify the resulting database boots cleanly, runs the full backend and frontend test suite green, and produces a usable `dotnet ef database update` from scratch.
+
+Rewrite `docs/data-model-refactor.md` as a ≤200-line reference describing the final model, the tenant isolation rules from §4.10 of this spec, and pointers to the canonical services. Archive the 1739-line historical document under `docs/superpowers/archive/2026-04-10-data-model-refactor-history.md`.
+
+**Exit:** Single `Initial` migration. Doc rewritten. Full backend + frontend suites green against a freshly-created database.
+
+## 6. Per-phase exit criteria (apply to every phase)
+
+- `dotnet build` clean (0 warnings, 0 errors)
+- `dotnet test` green
+- `npm run typecheck` clean (frontend)
+- `npm test` green (frontend)
+- Grep check: no references to deleted types, services, or routes remain in the workspace
+- No new dual-path / fallback code introduced
+- Phase PR description includes:
+  - List of every entity, service, route, and DTO deleted in that phase
+  - Tenant scope table for every new entity (name, direct `TenantId` yes/no, EF global filter yes/no, justification if global)
+  - Tenant isolation test output showing the two-tenant assertion added by the phase
+
+## 7. Verification gates (end-to-end)
+
+**Tenant isolation gate (Phase 1, extended every phase thereafter):**
+A single end-to-end test called `TenantIsolationEndToEndTests` is introduced in Phase 1 and grows with every subsequent phase. It seeds two tenants with disjoint data and asserts that, for every API surface touched by the phase, requests authenticated as tenant A cannot observe any tenant B row. Each phase adds its new entities and routes to the test. A phase PR does not merge if this test is missing the phase's assertions.
+
+Minimum assertions the test covers by the end of Phase 5:
+- `GET /api/devices` scoped to tenant A returns no tenant B devices
+- `GET /api/software/canonical` returns global product rows but no tenant-scoped fields leak across tenants
+- `GET /api/vulnerabilities` returns global CVE rows; exposure counts are scoped to tenant A devices only
+- `GET /api/vulnerabilities/{id}` affected-devices section contains only tenant A devices
+- `GET /api/remediation/cases/...` scoped to tenant A returns no tenant B cases
+- `GET /api/dashboard/*` summaries for tenant A contain no tenant B metrics
+- Email notification rendering pipelines do not join across tenants
+- Risk score queries (`GET /api/risk-score/*`) for tenant A do not include tenant B data
+- Scan runners for tenant A's runner cannot enqueue jobs targeting tenant B devices
+
+**Env-severity gate (Phase 3):** the `SecurityProfile` → `ExposureAssessment` environmental severity test described in §5.3.
+
+**Ingestion idempotency:** re-running ingestion against the same upstream observations does not create duplicate `Device`, `InstalledSoftware`, `Vulnerability`, or `DeviceVulnerabilityExposure` rows.
+
+**Source-collision protection:** same external device ID from two different `SourceSystem`s produces two distinct `Device` rows.
+
+**Software canonicalization determinism:** the same observed software from two sources resolves to the same `SoftwareProduct` via `SoftwareAlias`.
+
+**Global-entity write protection:** an authenticated non-system request that attempts to write a `SoftwareProduct`, `Vulnerability`, `VulnerabilityApplicability`, `VulnerabilityReference`, `ThreatAssessment`, or `SourceSystem` row returns 403 or 404. Tested explicitly.
+
+**Exposure lifecycle:** open → resolve when software is removed → reopen when software returns, covered by integration tests against canonical tables only.
+
+**Remediation case stability:** a `RemediationCase` key `(TenantId, SoftwareProductId)` is stable across snapshot publish/discard cycles.
+
+**Representative queries run without legacy joins:**
+- list devices
+- list software on a device
+- list devices affected by a vulnerability
+- list vulnerabilities affecting a software product
+- list open remediation cases
+
+## 8. Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Phase 1 touches ~100+ files (inventory is wide); high merge conflict risk | One PR, no other branches parallel to Phase 1 |
+| Rewriting canonical work that already exists on the abandoned branch is wasteful | Accepted by user; final model clarity outweighs the rewrite cost |
+| Env-severity regression when introducing the canonical assessment path | Hard-gate test in Phase 3 blocks deletion of legacy assessment until canonical path is proven |
+| Risk score numbers shift user-visible values | Accepted; documented in Phase 5 PR description |
+| Cross-tenant data leak via a missed EF global filter | Rule 1 (direct `TenantId` on every tenant-scoped entity), Rule 2 (mandatory global filter), Rule 5 (ban on `IgnoreQueryFilters()`), and the per-phase tenant isolation test |
+| Cross-tenant leak via a service that joins global and tenant-scoped rows carelessly | Rule 6 (joins never reveal cross-tenant state), plus isolation test coverage on every new query path |
+| Rule 7 violated accidentally: AI writes tenant description onto global `SoftwareProduct` | Covered by the Phase 1 entity structure (`TenantSoftwareProductInsight` is the only writable description target) and by explicit test that asserts `SoftwareProduct.Description` is unchanged after a tenant AI description write |
+| Vulnerability list endpoint returns empty "affected devices" between Phase 2 merge and Phase 3 merge | Explicitly called out in §5.2 as acceptable temporary state; Phase 3 PR must land before the next release cut |
+| Migration regeneration forgets an entity | Phase 6 exit requires the env-severity test, tenant isolation test, and full test suite to pass on a fresh DB created from the new baseline |
+
+## 9. Out of scope clarifications
+
+- **`CloudResource` asset type:** aspirational, unused except for two incidental references. Deleted with `AssetType`. No replacement.
+- **Cross-source device correlation:** explicitly out of scope. Canonical `Device` is source-owned by `(TenantId, SourceSystemId, ExternalId)`. If the same physical device is reported by two sources, there will be two `Device` rows. Merging them belongs to a future feature.
+- **Software rule engine:** explicitly deferred. `DeviceRule` only for now.
+- **Tenant-level vulnerability severity overrides:** dropped. If a use case surfaces later, add it through `SecurityProfile` environmental modifiers, not as a separate override table.
+- **Sharing of `SoftwareAlias` across tenants:** `SoftwareAlias` is intentionally global. An alias is a `(SourceSystemId, ExternalId) → SoftwareProductId` mapping — the external ID identifies a product in the source system, not a tenant. Two tenants using the same source system benefit from the same alias resolution. This is not a tenant boundary violation because the alias carries no tenant-private data.
+
+## 10. Handoff
+
+After this spec is approved and committed:
+
+1. Invoke `superpowers:writing-plans` to produce per-phase implementation plans. Each phase becomes its own plan file under `docs/superpowers/plans/2026-04-10-data-model-canonical-cleanup-phase-{N}.md`.
+2. Plans contain exact file paths, code, test code, and commands as per the `writing-plans` skill contract.
+3. Phase 1 plan is the first to execute; phases ship in order. Every phase's PR must show the tenant-scope audit table and the tenant isolation test diff per §7.

--- a/frontend/src/api/approval-tasks.functions.ts
+++ b/frontend/src/api/approval-tasks.functions.ts
@@ -82,12 +82,12 @@ export const fetchDecisionAuditTrail = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      tenantSoftwareId: z.string().uuid(),
+      caseId: z.string().uuid(),
     })
   )
-  .handler(async ({ context, data: { tenantSoftwareId } }) => {
+  .handler(async ({ context, data: { caseId } }) => {
     const data = await apiGet(
-      `/software/${tenantSoftwareId}/remediation/audit-trail`,
+      `/remediation/cases/${caseId}/audit-trail`,
       context
     )
     return z.array(approvalAuditEntrySchema).parse(data)

--- a/frontend/src/api/approval-tasks.schemas.ts
+++ b/frontend/src/api/approval-tasks.schemas.ts
@@ -8,7 +8,7 @@ export const approvalAuditEntrySchema = z.object({
 })
 
 export const approvalVulnSchema = z.object({
-  tenantVulnerabilityId: z.string().uuid(),
+  vulnerabilityId: z.string().uuid(),
   externalId: z.string(),
   title: z.string(),
   vendorSeverity: z.string(),

--- a/frontend/src/api/dashboard.schemas.ts
+++ b/frontend/src/api/dashboard.schemas.ts
@@ -35,7 +35,7 @@ export const dashboardSummarySchema = z.object({
     appearedCount: z.number(),
     resolvedCount: z.number(),
     appeared: z.array(z.object({
-      tenantVulnerabilityId: z.string().uuid(),
+      vulnerabilityId: z.string().uuid(),
       externalId: z.string(),
       title: z.string(),
       severity: z.string(),
@@ -43,7 +43,7 @@ export const dashboardSummarySchema = z.object({
       changedAt: z.string(),
     })),
     resolved: z.array(z.object({
-      tenantVulnerabilityId: z.string().uuid(),
+      vulnerabilityId: z.string().uuid(),
       externalId: z.string(),
       title: z.string(),
       severity: z.string(),
@@ -153,7 +153,7 @@ export const ownerAssetSummarySchema = z.object({
 
 export const ownerActionSchema = z.object({
   tenantSoftwareId: z.string().uuid(),
-  tenantVulnerabilityId: z.string().uuid(),
+  vulnerabilityId: z.string().uuid(),
   taskId: z.string().uuid().nullable(),
   softwareName: z.string(),
   ownerTeamName: z.string(),

--- a/frontend/src/api/dashboard.schemas.ts
+++ b/frontend/src/api/dashboard.schemas.ts
@@ -185,7 +185,7 @@ export type OwnerAssetSummary = z.infer<typeof ownerAssetSummarySchema>
 export const approvalAttentionTaskSchema = z.object({
   approvalTaskId: z.string().uuid(),
   remediationDecisionId: z.string().uuid(),
-  tenantSoftwareId: z.string().uuid(),
+  remediationCaseId: z.string().uuid(),
   softwareName: z.string(),
   approvalType: z.string(),
   highestSeverity: z.string(),
@@ -198,7 +198,7 @@ export const approvalAttentionTaskSchema = z.object({
 
 export const approvedPolicyDecisionSchema = z.object({
   decisionId: z.string().uuid(),
-  tenantSoftwareId: z.string().uuid(),
+  remediationCaseId: z.string().uuid(),
   softwareName: z.string(),
   outcome: z.string(),
   justification: z.string().nullable(),
@@ -216,7 +216,7 @@ export const securityManagerDashboardSummarySchema = z.object({
 export const approvedPatchingTaskSchema = z.object({
   patchingTaskId: z.string().uuid(),
   remediationDecisionId: z.string().uuid(),
-  tenantSoftwareId: z.string().uuid(),
+  remediationCaseId: z.string().uuid(),
   softwareName: z.string(),
   ownerTeamName: z.string(),
   highestSeverity: z.string(),

--- a/frontend/src/api/remediation-tasks.functions.ts
+++ b/frontend/src/api/remediation-tasks.functions.ts
@@ -19,7 +19,7 @@ export const fetchRemediationTasks = createServerFn({ method: 'GET' })
       assetOwner: z.string().optional(),
       taskId: z.string().uuid().optional(),
       deviceAssetId: z.string().uuid().optional(),
-      tenantSoftwareId: z.string().uuid().optional(),
+      caseId: z.string().uuid().optional(),
       page: z.number().optional(),
       pageSize: z.number().optional(),
     }),
@@ -32,16 +32,16 @@ export const fetchRemediationTasks = createServerFn({ method: 'GET' })
 
 export const createRemediationTasksForSoftware = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ tenantSoftwareId: z.string().uuid() }))
-  .handler(async ({ context, data: { tenantSoftwareId } }) => {
-    const data = await apiPost(`/remediation/tasks/software/${tenantSoftwareId}`, context, {})
+  .inputValidator(z.object({ caseId: z.string().uuid() }))
+  .handler(async ({ context, data: { caseId } }) => {
+    const data = await apiPost(`/remediation/cases/${caseId}/tasks`, context, {})
     return remediationTaskCreateResultSchema.parse(data)
   })
 
 export const fetchRemediationTaskTeamStatuses = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ tenantSoftwareId: z.string().uuid() }))
-  .handler(async ({ context, data: { tenantSoftwareId } }) => {
-    const data = await apiGet(`/remediation/tasks/software/${tenantSoftwareId}/team-statuses`, context)
+  .inputValidator(z.object({ caseId: z.string().uuid() }))
+  .handler(async ({ context, data: { caseId } }) => {
+    const data = await apiGet(`/remediation/cases/${caseId}/team-statuses`, context)
     return z.array(remediationTaskTeamStatusSchema).parse(data)
   })

--- a/frontend/src/api/remediation-tasks.schemas.ts
+++ b/frontend/src/api/remediation-tasks.schemas.ts
@@ -10,8 +10,7 @@ export const remediationTaskSummarySchema = z.object({
 
 export const remediationTaskListItemSchema = z.object({
   id: z.string().uuid(),
-  softwareAssetId: z.string().uuid(),
-  tenantSoftwareId: z.string().uuid().nullable(),
+  remediationCaseId: z.string().uuid(),
   softwareName: z.string(),
   softwareVendor: z.string().nullable(),
   ownerTeamId: z.string().uuid(),

--- a/frontend/src/api/remediation.functions.ts
+++ b/frontend/src/api/remediation.functions.ts
@@ -1,18 +1,26 @@
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 import { authMiddleware } from '@/server/middleware'
-import { apiGet, apiPost, type ApiRequestContext } from '@/server/api'
+import { apiGet, apiPost } from '@/server/api'
 import {
-  decisionContextSchema,
-  decisionAiSummarySchema,
-  remediationDecisionSchema,
   analystRecommendationSchema,
-  vulnerabilityOverrideSchema,
+  decisionAiSummarySchema,
+  decisionContextSchema,
   pagedDecisionListSchema,
+  remediationDecisionSchema,
+  vulnerabilityOverrideSchema,
 } from './remediation.schemas'
 import { buildFilterParams } from './utils'
 
 export const fetchDecisionContext = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ caseId: z.string().uuid() }))
+  .handler(async ({ context, data: { caseId } }) => {
+    const data = await apiGet(`/remediation/cases/${caseId}/decision-context`, context)
+    return decisionContextSchema.parse(data)
+  })
+
+export const fetchTenantSoftwareDecisionContext = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
   .inputValidator(z.object({ tenantSoftwareId: z.string().uuid() }))
   .handler(async ({ context, data: { tenantSoftwareId } }) => {
@@ -20,20 +28,11 @@ export const fetchDecisionContext = createServerFn({ method: 'GET' })
     return decisionContextSchema.parse(data)
   })
 
-async function ensureRemediationWorkflowId(
-  tenantSoftwareId: string,
-  context: ApiRequestContext
-) {
-  const data = await apiPost(`/software/${tenantSoftwareId}/remediation/workflow`, context, {})
-  return z.object({ workflowId: z.string().uuid() }).parse(data).workflowId
-}
-
 export const createDecision = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      tenantSoftwareId: z.string().uuid(),
-      workflowId: z.string().uuid().nullable().optional(),
+      caseId: z.string().uuid(),
       outcome: z.string(),
       justification: z.string().optional(),
       maintenanceWindowDate: z.string().optional(),
@@ -41,9 +40,8 @@ export const createDecision = createServerFn({ method: 'POST' })
       reEvaluationDate: z.string().optional(),
     })
   )
-  .handler(async ({ context, data: { tenantSoftwareId, workflowId, ...body } }) => {
-    const resolvedWorkflowId = workflowId ?? (await ensureRemediationWorkflowId(tenantSoftwareId, context))
-    const data = await apiPost(`/remediation/${resolvedWorkflowId}/decision`, context, body)
+  .handler(async ({ context, data: { caseId, ...body } }) => {
+    const data = await apiPost(`/remediation/cases/${caseId}/decision`, context, body)
     return remediationDecisionSchema.parse(data)
   })
 
@@ -51,23 +49,20 @@ export const approveOrRejectDecision = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      tenantSoftwareId: z.string().uuid(),
-      workflowId: z.string().uuid().nullable().optional(),
+      caseId: z.string().uuid(),
       decisionId: z.string().uuid(),
       action: z.enum(['approve', 'reject', 'cancel']),
       justification: z.string().optional(),
       maintenanceWindowDate: z.string().optional(),
     })
   )
-  .handler(async ({ context, data: { tenantSoftwareId, workflowId, decisionId, action, justification, maintenanceWindowDate } }) => {
-    const resolvedWorkflowId = workflowId ?? (await ensureRemediationWorkflowId(tenantSoftwareId, context))
-
+  .handler(async ({ context, data: { caseId, decisionId, action, justification, maintenanceWindowDate } }) => {
     if (action === 'cancel') {
-      await apiPost(`/remediation/${resolvedWorkflowId}/decision/${decisionId}/cancel`, context, {})
+      await apiPost(`/remediation/cases/${caseId}/decision/${decisionId}/cancel`, context, {})
       return
     }
 
-    await apiPost(`/remediation/${resolvedWorkflowId}/approval`, context, {
+    await apiPost(`/remediation/cases/${caseId}/approval`, context, {
       action: action === 'reject' ? 'deny' : action,
       justification: justification || undefined,
       maintenanceWindowDate: maintenanceWindowDate || undefined,
@@ -78,16 +73,16 @@ export const addVulnerabilityOverride = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      tenantSoftwareId: z.string().uuid(),
+      caseId: z.string().uuid(),
       decisionId: z.string().uuid(),
-      tenantVulnerabilityId: z.string().uuid(),
+      vulnerabilityId: z.string().uuid(),
       outcome: z.string(),
       justification: z.string(),
     })
   )
-  .handler(async ({ context, data: { tenantSoftwareId, decisionId, ...body } }) => {
+  .handler(async ({ context, data: { caseId, decisionId, ...body } }) => {
     const data = await apiPost(
-      `/software/${tenantSoftwareId}/remediation/decisions/${decisionId}/overrides`,
+      `/remediation/cases/${caseId}/decisions/${decisionId}/overrides`,
       context,
       body
     )
@@ -98,17 +93,15 @@ export const addRecommendation = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      tenantSoftwareId: z.string().uuid(),
-      workflowId: z.string().uuid().nullable().optional(),
+      caseId: z.string().uuid(),
       recommendedOutcome: z.string(),
       rationale: z.string(),
       priorityOverride: z.string().optional(),
-      tenantVulnerabilityId: z.string().uuid().optional(),
+      vulnerabilityId: z.string().uuid().optional(),
     })
   )
-  .handler(async ({ context, data: { tenantSoftwareId, workflowId, ...body } }) => {
-    const resolvedWorkflowId = workflowId ?? (await ensureRemediationWorkflowId(tenantSoftwareId, context))
-    const data = await apiPost(`/remediation/${resolvedWorkflowId}/analysis`, context, body)
+  .handler(async ({ context, data: { caseId, ...body } }) => {
+    const data = await apiPost(`/remediation/cases/${caseId}/analysis`, context, body)
     return analystRecommendationSchema.parse(data)
   })
 
@@ -116,23 +109,19 @@ export const verifyRecurringRemediation = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      workflowId: z.string().uuid(),
+      caseId: z.string().uuid(),
       action: z.enum(['keepCurrentDecision', 'chooseNewDecision']),
     })
   )
-  .handler(async ({ context, data: { workflowId, action } }) => {
-    await apiPost(`/remediation/${workflowId}/verification`, context, { action })
+  .handler(async ({ context, data: { caseId, action } }) => {
+    await apiPost(`/remediation/cases/${caseId}/verification`, context, { action })
   })
 
 export const generateRemediationAiSummary = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
-  .inputValidator(
-    z.object({
-      tenantSoftwareId: z.string().uuid(),
-    })
-  )
-  .handler(async ({ context, data: { tenantSoftwareId } }) => {
-    const data = await apiPost(`/software/${tenantSoftwareId}/remediation/ai-summary`, context, {})
+  .inputValidator(z.object({ caseId: z.string().uuid() }))
+  .handler(async ({ context, data: { caseId } }) => {
+    const data = await apiPost(`/remediation/cases/${caseId}/ai-summary`, context, {})
     return decisionAiSummarySchema.parse(data)
   })
 
@@ -140,12 +129,12 @@ export const reviewRemediationAiSummary = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(
     z.object({
-      tenantSoftwareId: z.string().uuid(),
+      caseId: z.string().uuid(),
       action: z.enum(['accept', 'edit', 'reject']),
     })
   )
-  .handler(async ({ context, data: { tenantSoftwareId, action } }) => {
-    const data = await apiPost(`/software/${tenantSoftwareId}/remediation/ai-summary/review`, context, { action })
+  .handler(async ({ context, data: { caseId, action } }) => {
+    const data = await apiPost(`/remediation/cases/${caseId}/ai-summary/review`, context, { action })
     return decisionAiSummarySchema.parse(data)
   })
 

--- a/frontend/src/api/remediation.schemas.ts
+++ b/frontend/src/api/remediation.schemas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const vulnerabilityOverrideSchema = z.object({
   id: z.string().uuid(),
-  tenantVulnerabilityId: z.string().uuid(),
+  vulnerabilityId: z.string().uuid(),
   outcome: z.string(),
   justification: z.string(),
   createdAt: z.string(),
@@ -29,7 +29,7 @@ export const remediationDecisionSchema = z.object({
 
 export const analystRecommendationSchema = z.object({
   id: z.string().uuid(),
-  tenantVulnerabilityId: z.string().uuid().nullable(),
+  vulnerabilityId: z.string().uuid().nullable(),
   recommendedOutcome: z.string(),
   rationale: z.string(),
   priorityOverride: z.string().nullable(),
@@ -39,7 +39,7 @@ export const analystRecommendationSchema = z.object({
 })
 
 export const decisionVulnSchema = z.object({
-  tenantVulnerabilityId: z.string().uuid(),
+  vulnerabilityId: z.string().uuid(),
   vulnerabilityDefinitionId: z.string().uuid(),
   externalId: z.string(),
   title: z.string(),
@@ -141,7 +141,7 @@ export const decisionAiSummarySchema = z.object({
 })
 
 export const decisionContextSchema = z.object({
-  tenantSoftwareId: z.string().uuid(),
+  remediationCaseId: z.string().uuid(),
   softwareName: z.string(),
   criticality: z.string(),
   summary: decisionSummarySchema,
@@ -157,7 +157,7 @@ export const decisionContextSchema = z.object({
 })
 
 export const decisionListItemSchema = z.object({
-  tenantSoftwareId: z.string().uuid(),
+  remediationCaseId: z.string().uuid(),
   softwareName: z.string(),
   criticality: z.string(),
   outcome: z.string().nullable(),

--- a/frontend/src/api/risk-score.schemas.ts
+++ b/frontend/src/api/risk-score.schemas.ts
@@ -35,7 +35,7 @@ export const riskAssetScoreSummarySchema = z.object({
   lowCount: z.number(),
   openEpisodeCount: z.number(),
   episodeDrivers: z.array(z.object({
-    tenantVulnerabilityId: z.string().uuid(),
+    vulnerabilityId: z.string().uuid(),
     externalId: z.string(),
     title: z.string(),
     riskBand: z.string(),

--- a/frontend/src/api/software.schemas.ts
+++ b/frontend/src/api/software.schemas.ts
@@ -134,7 +134,7 @@ export const tenantSoftwareVulnerabilityEvidenceSchema = z.object({
 })
 
 export const tenantSoftwareVulnerabilitySchema = z.object({
-  tenantVulnerabilityId: z.string().uuid(),
+  vulnerabilityId: z.string().uuid(),
   vulnerabilityDefinitionId: z.string().uuid(),
   externalId: z.string(),
   title: z.string(),

--- a/frontend/src/api/software.schemas.ts
+++ b/frontend/src/api/software.schemas.ts
@@ -15,6 +15,7 @@ export const tenantSoftwareVersionCohortSchema = z.object({
 export const tenantSoftwareDetailSchema = z.object({
   id: z.string().uuid(),
   normalizedSoftwareId: z.string().uuid(),
+  softwareProductId: z.string().uuid().nullable(),
   primarySoftwareAssetId: z.string().uuid().nullable(),
   canonicalName: z.string(),
   canonicalVendor: z.string().nullable(),
@@ -80,6 +81,7 @@ export const tenantSoftwareDetailSchema = z.object({
 export const tenantSoftwareListItemSchema = z.object({
   id: z.string().uuid(),
   normalizedSoftwareId: z.string().uuid(),
+  softwareProductId: z.string().uuid().nullable(),
   canonicalName: z.string(),
   canonicalVendor: z.string().nullable(),
   category: z.string().nullable().optional(),
@@ -174,7 +176,7 @@ export const tenantSoftwareDescriptionSchema = z.object({
 
 export const tenantSoftwareDescriptionJobSchema = z.object({
   id: z.string().uuid(),
-  tenantSoftwareId: z.string().uuid(),
+  softwareProductId: z.string().uuid(),
   status: z.string(),
   error: z.string().nullable(),
   requestedAt: isoDateTimeSchema,

--- a/frontend/src/api/vulnerabilities.schemas.ts
+++ b/frontend/src/api/vulnerabilities.schemas.ts
@@ -124,7 +124,7 @@ export const vulnerabilityDetailSchema = z.object({
 
 export const aiReportSchema = z.object({
   id: z.string().uuid(),
-  tenantVulnerabilityId: z.string().uuid(),
+  vulnerabilityId: z.string().uuid(),
   content: z.string(),
   providerType: z.string(),
   profileName: z.string(),

--- a/frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
+++ b/frontend/src/components/features/approvals/ApprovalTaskDetail.tsx
@@ -380,7 +380,7 @@ export function ApprovalTaskDetail({
                       </tr>
                     ) : (
                       data.vulnerabilities.items.map((vuln) => (
-                        <tr key={vuln.tenantVulnerabilityId} className="align-top">
+                        <tr key={vuln.vulnerabilityId} className="align-top">
                           <td className="px-4 py-3 font-mono text-xs">
                             {vuln.externalId}
                           </td>

--- a/frontend/src/components/features/dashboard/DeviceOwnerOverview.tsx
+++ b/frontend/src/components/features/dashboard/DeviceOwnerOverview.tsx
@@ -153,7 +153,7 @@ export function DeviceOwnerOverview({ summary, isLoading }: Props) {
               </div>
             ) : (
               summary.actions.map((item) => (
-                <div key={`${item.tenantSoftwareId}-${item.tenantVulnerabilityId}`} className="rounded-[1.2rem] border border-border/60 bg-background/35 px-4 py-4">
+                <div key={`${item.tenantSoftwareId}-${item.vulnerabilityId}`} className="rounded-[1.2rem] border border-border/60 bg-background/35 px-4 py-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
@@ -208,7 +208,7 @@ export function DeviceOwnerOverview({ summary, isLoading }: Props) {
                         Open remediation task
                       </Button>
                     )}
-                    <Button size="sm" variant="outline" render={<Link to="/vulnerabilities/$id" params={{ id: item.tenantVulnerabilityId }} />}>
+                    <Button size="sm" variant="outline" render={<Link to="/vulnerabilities/$id" params={{ id: item.vulnerabilityId }} />}>
                       Vulnerability detail
                     </Button>
                   </div>

--- a/frontend/src/components/features/dashboard/RiskChangeBriefCard.tsx
+++ b/frontend/src/components/features/dashboard/RiskChangeBriefCard.tsx
@@ -157,9 +157,9 @@ function RiskChangeLane({ title, count, tone, emptyText, items }: RiskChangeLane
         ) : (
           items.map((item) => (
             <Link
-              key={item.tenantVulnerabilityId}
+              key={item.vulnerabilityId}
               to="/vulnerabilities/$id"
-              params={{ id: item.tenantVulnerabilityId }}
+              params={{ id: item.vulnerabilityId }}
               className="flex items-start justify-between gap-3 rounded-xl border border-border/60 bg-background px-3 py-3 transition-colors hover:bg-accent/20"
             >
               <div className="min-w-0">

--- a/frontend/src/components/features/dashboard/RiskScoreDetailDialog.tsx
+++ b/frontend/src/components/features/dashboard/RiskScoreDetailDialog.tsx
@@ -110,7 +110,7 @@ function RiskAssetRow({ asset }: { asset: RiskAssetScoreSummary }) {
           </p>
           <div className="space-y-2">
             {asset.episodeDrivers.map((driver) => (
-              <EpisodeDriverRow key={driver.tenantVulnerabilityId} driver={driver} />
+              <EpisodeDriverRow key={driver.vulnerabilityId} driver={driver} />
             ))}
           </div>
         </div>
@@ -128,7 +128,7 @@ function EpisodeDriverRow({ driver }: { driver: RiskAssetEpisodeDriver }) {
         <div className="min-w-0">
           <Link
             to="/vulnerabilities/$id"
-            params={{ id: driver.tenantVulnerabilityId }}
+            params={{ id: driver.vulnerabilityId }}
             className="truncate text-sm font-medium hover:underline"
           >
             {driver.externalId}

--- a/frontend/src/components/features/dashboard/SecurityManagerOverview.tsx
+++ b/frontend/src/components/features/dashboard/SecurityManagerOverview.tsx
@@ -116,8 +116,8 @@ export function SecurityManagerOverview({ summary, managerSummary, isLoading }: 
                         <span className="text-xs text-muted-foreground">{item.vulnerabilityCount} open vulnerabilities</span>
                       </div>
                       <Link
-                        to="/software/$id/remediation"
-                        params={{ id: item.tenantSoftwareId }}
+                        to="/remediation/cases/$caseId"
+                        params={{ caseId: item.remediationCaseId }}
                         className="mt-2 block text-base font-medium tracking-tight hover:text-primary"
                       >
                         {startCase(item.softwareName)}

--- a/frontend/src/components/features/dashboard/TechnicalManagerOverview.tsx
+++ b/frontend/src/components/features/dashboard/TechnicalManagerOverview.tsx
@@ -102,8 +102,8 @@ export function TechnicalManagerOverview({ summary, isLoading }: Props) {
                         <span className="text-xs text-muted-foreground">{item.affectedDeviceCount} affected devices</span>
                       </div>
                       <Link
-                        to="/software/$id/remediation"
-                        params={{ id: item.tenantSoftwareId }}
+                        to="/remediation/cases/$caseId"
+                        params={{ caseId: item.remediationCaseId }}
                         className="mt-2 block text-base font-medium tracking-tight hover:text-primary"
                       >
                         {startCase(item.softwareName)}

--- a/frontend/src/components/features/remediation/DecisionForm.tsx
+++ b/frontend/src/components/features/remediation/DecisionForm.tsx
@@ -14,8 +14,7 @@ import { createDecision } from '@/api/remediation.functions'
 import { outcomeLabel } from './remediation-utils'
 
 type DecisionFormProps = {
-  tenantSoftwareId: string
-  workflowId?: string | null
+  caseId: string
   queryKey: readonly unknown[]
   readOnly?: boolean
   initialOutcome?: string | null
@@ -50,8 +49,7 @@ const REQUIRES_EXPIRY = new Set<string>(['RiskAcceptance', 'AlternateMitigation'
 const REQUIRES_REEVALUATION = new Set<string>(['PatchingDeferred'])
 
 export function DecisionForm({
-  tenantSoftwareId,
-  workflowId,
+  caseId,
   queryKey,
   readOnly = false,
   initialOutcome = null,
@@ -117,10 +115,10 @@ export function DecisionForm({
     try {
       await createDecision({
         data: {
-          tenantSoftwareId,
-          workflowId,
+          caseId,
           outcome,
           justification: justification || undefined,
+          maintenanceWindowDate: undefined,
           expiryDate: needsExpiry && expiryMode === 'expires' ? toIsoDateBoundary(expiryDate) : undefined,
           reEvaluationDate: toIsoDateBoundary(reEvaluationDate),
         },

--- a/frontend/src/components/features/remediation/RecommendationPanel.tsx
+++ b/frontend/src/components/features/remediation/RecommendationPanel.tsx
@@ -16,8 +16,7 @@ import { formatDateTime } from '@/lib/formatting'
 import { outcomeLabel, outcomeTone } from './remediation-utils'
 
 type RecommendationPanelProps = {
-  tenantSoftwareId: string
-  workflowId?: string | null
+  caseId: string
   recommendations: AnalystRecommendation[]
   aiAnalystAssessment?: string | null
   aiRecommendedOutcome?: string | null
@@ -42,8 +41,7 @@ const OUTCOMES = [
 const PRIORITIES = ['Critical', 'High', 'Medium', 'Low'] as const
 
 export function RecommendationPanel({
-  tenantSoftwareId,
-  workflowId,
+  caseId,
   recommendations,
   aiAnalystAssessment,
   aiRecommendedOutcome,
@@ -77,8 +75,7 @@ export function RecommendationPanel({
     try {
       await addRecommendation({
         data: {
-          tenantSoftwareId,
-          workflowId,
+          caseId,
           recommendedOutcome: outcome,
           rationale: rationale.trim(),
           priorityOverride: priorityOverride || undefined,

--- a/frontend/src/components/features/remediation/RemediationTaskWorkbench.tsx
+++ b/frontend/src/components/features/remediation/RemediationTaskWorkbench.tsx
@@ -114,18 +114,13 @@ export function RemediationTaskWorkbench({
                   <tr key={task.id} className="align-top">
                     <td className="px-4 py-3">
                       <div className="space-y-1">
-                        {task.tenantSoftwareId ? (
-                          <Link
-                            to="/software/$id"
-                            params={{ id: task.tenantSoftwareId }}
-                            search={{ page: 1, pageSize: 25, version: '', tab: 'overview' }}
-                            className="font-medium hover:text-primary"
-                          >
-                            {startCase(task.softwareName)}
-                          </Link>
-                        ) : (
-                          <span className="font-medium">{startCase(task.softwareName)}</span>
-                        )}
+                        <Link
+                          to="/remediation/cases/$caseId"
+                          params={{ caseId: task.remediationCaseId }}
+                          className="font-medium hover:text-primary"
+                        >
+                          {startCase(task.softwareName)}
+                        </Link>
                         <p className="text-xs text-muted-foreground">
                           {task.deviceNames.length > 0
                             ? `Examples: ${task.deviceNames.join(', ')}`

--- a/frontend/src/components/features/remediation/RemediationVulnTable.tsx
+++ b/frontend/src/components/features/remediation/RemediationVulnTable.tsx
@@ -12,7 +12,7 @@ import { severityTone, outcomeLabel, outcomeTone } from './remediation-utils'
 type RemediationVulnTableProps = {
   vulnerabilities: DecisionVuln[]
   decisionId: string | null
-  tenantSoftwareId: string
+  caseId: string
   queryKey: readonly unknown[]
   onSelectVuln: (vuln: DecisionVuln) => void
 }
@@ -20,7 +20,7 @@ type RemediationVulnTableProps = {
 export function RemediationVulnTable({
   vulnerabilities,
   decisionId,
-  tenantSoftwareId,
+  caseId,
   queryKey,
   onSelectVuln,
 }: RemediationVulnTableProps) {
@@ -29,13 +29,13 @@ export function RemediationVulnTable({
 
   const handleOverride = useCallback(async (vuln: DecisionVuln, outcome: string) => {
     if (!decisionId) return
-    setOverridingId(vuln.tenantVulnerabilityId)
+    setOverridingId(vuln.vulnerabilityId)
     try {
       await addVulnerabilityOverride({
         data: {
-          tenantSoftwareId,
+          caseId,
           decisionId,
-          tenantVulnerabilityId: vuln.tenantVulnerabilityId,
+          vulnerabilityId: vuln.vulnerabilityId,
           outcome,
           justification: `Per-vulnerability override to ${outcome}`,
         },
@@ -44,7 +44,7 @@ export function RemediationVulnTable({
     } finally {
       setOverridingId(null)
     }
-  }, [decisionId, tenantSoftwareId, queryClient, queryKey])
+  }, [caseId, decisionId, queryClient, queryKey])
 
   const columns = useMemo<ColumnDef<DecisionVuln>[]>(
     () => [
@@ -141,7 +141,7 @@ export function RemediationVulnTable({
             )
           }
           if (!decisionId) return <span className="text-muted-foreground">-</span>
-          const isLoading = overridingId === v.tenantVulnerabilityId
+          const isLoading = overridingId === v.vulnerabilityId
           return (
             <Button
               variant="ghost"
@@ -163,7 +163,7 @@ export function RemediationVulnTable({
     <DataTable
       columns={columns}
       data={vulnerabilities}
-      getRowId={(row) => row.tenantVulnerabilityId}
+      getRowId={(row) => row.vulnerabilityId}
       emptyState={
         <div className="py-12 text-center text-muted-foreground">
           No vulnerabilities are currently linked to this software.

--- a/frontend/src/components/features/remediation/RemediationWorkbench.tsx
+++ b/frontend/src/components/features/remediation/RemediationWorkbench.tsx
@@ -309,13 +309,13 @@ export function RemediationWorkbench({
                 </tr>
               ) : (
                 data.items.map((item) => (
-                  <tr key={item.tenantSoftwareId} className="align-top">
+                  <tr key={item.remediationCaseId} className="align-top">
                     <td className="px-4 py-3">
                       <div className="space-y-1">
-                        {item.tenantSoftwareId ? (
+                        {item.remediationCaseId ? (
                           <Link
-                            to="/software/$id/remediation"
-                            params={{ id: item.tenantSoftwareId }}
+                            to="/remediation/cases/$caseId"
+                            params={{ caseId: item.remediationCaseId }}
                             className="font-medium hover:text-primary"
                           >
                             {startCase(item.softwareName)}
@@ -342,19 +342,13 @@ export function RemediationWorkbench({
                               Maintenance {formatDate(item.maintenanceWindowDate)}
                             </span>
                           ) : null}
-                          {item.tenantSoftwareId ? (
+                          {item.remediationCaseId ? (
                             <Link
-                              to="/software/$id"
-                              params={{ id: item.tenantSoftwareId }}
-                              search={{
-                                page: 1,
-                                pageSize: 25,
-                                version: "",
-                                tab: "overview",
-                              }}
+                              to="/remediation/cases/$caseId"
+                              params={{ caseId: item.remediationCaseId }}
                               className="text-[10px] text-muted-foreground hover:text-primary"
                             >
-                              Software detail
+                              Open case
                             </Link>
                           ) : null}
                         </div>

--- a/frontend/src/components/features/remediation/SoftwareRemediationView.tsx
+++ b/frontend/src/components/features/remediation/SoftwareRemediationView.tsx
@@ -101,7 +101,6 @@ export function SoftwareRemediationView({
     reEvaluationDate?: string | null
   } | null>(null)
   const [stageError, setStageError] = useState<string | null>(null)
-  const workflowId = data.workflowState.workflowId
   const currentStageId = data.workflowState.currentStage as RemediationStageId
   const stages: RemediationStage[] = data.workflowState.stages.map((stage) => ({
     id: stage.id as RemediationStageId,

--- a/frontend/src/components/features/remediation/SoftwareRemediationView.tsx
+++ b/frontend/src/components/features/remediation/SoftwareRemediationView.tsx
@@ -61,7 +61,8 @@ import {
 
 type SoftwareRemediationViewProps = {
   data: DecisionContext
-  tenantSoftwareId: string
+  caseId: string
+  tenantSoftwareId?: string
   embedded?: boolean
   initialSoftwareDetail?: TenantSoftwareDetail
   initialInstallations?: PagedTenantSoftwareInstallations
@@ -70,6 +71,7 @@ type SoftwareRemediationViewProps = {
 
 export function SoftwareRemediationView({
   data,
+  caseId,
   tenantSoftwareId,
   embedded = false,
   initialSoftwareDetail,
@@ -79,7 +81,7 @@ export function SoftwareRemediationView({
   const [selectedVuln, setSelectedVuln] = useState<DecisionVuln | null>(null)
   const { selectedTenantId } = useTenantScope()
   const queryClient = useQueryClient()
-  const queryKey = softwareQueryKeys.remediation(selectedTenantId, tenantSoftwareId)
+  const queryKey = ['remediation-case', selectedTenantId, caseId]
   const [deviceVersion, setDeviceVersion] = useState(initialDeviceVersion ?? '')
 
   const [approving, setApproving] = useState(false)
@@ -109,9 +111,10 @@ export function SoftwareRemediationView({
   }))
 
   const softwareDetailQuery = useQuery({
-    queryKey: softwareQueryKeys.detail(selectedTenantId, tenantSoftwareId),
-    queryFn: () => fetchTenantSoftwareDetail({ data: { id: tenantSoftwareId } }),
+    queryKey: softwareQueryKeys.detail(selectedTenantId, tenantSoftwareId ?? ''),
+    queryFn: () => fetchTenantSoftwareDetail({ data: { id: tenantSoftwareId! } }),
     initialData: initialSoftwareDetail,
+    enabled: Boolean(tenantSoftwareId),
   })
 
   const softwareDetail = softwareDetailQuery.data ?? initialSoftwareDetail
@@ -130,17 +133,17 @@ export function SoftwareRemediationView({
   }, [softwareDetail, deviceVersion])
 
   const installationsQuery = useQuery({
-    queryKey: softwareQueryKeys.installations(selectedTenantId, tenantSoftwareId, normalizedDeviceVersion, 1, 25),
+    queryKey: softwareQueryKeys.installations(selectedTenantId, tenantSoftwareId ?? '', normalizedDeviceVersion, 1, 25),
     queryFn: () => fetchTenantSoftwareInstallations({
       data: {
-        id: tenantSoftwareId,
+        id: tenantSoftwareId!,
         version: normalizedDeviceVersion || undefined,
         activeOnly: true,
         page: 1,
         pageSize: 25,
       },
     }),
-    enabled: Boolean(softwareDetail),
+    enabled: Boolean(softwareDetail) && Boolean(tenantSoftwareId),
     initialData:
       initialInstallations && (initialDeviceVersion ?? '') === normalizedDeviceVersion
         ? initialInstallations
@@ -149,8 +152,8 @@ export function SoftwareRemediationView({
 
   const remediationInstallations = installationsQuery.data ?? initialInstallations
   const teamStatusesQuery = useQuery({
-    queryKey: ['remediation-team-statuses', selectedTenantId, tenantSoftwareId],
-    queryFn: () => fetchRemediationTaskTeamStatuses({ data: { tenantSoftwareId } }),
+    queryKey: ['remediation-team-statuses', selectedTenantId, caseId],
+    queryFn: () => fetchRemediationTaskTeamStatuses({ data: { caseId } }),
   })
   const teamStatuses = teamStatusesQuery.data ?? []
 
@@ -161,8 +164,7 @@ export function SoftwareRemediationView({
     try {
       await approveOrRejectDecision({
         data: {
-          tenantSoftwareId,
-          workflowId,
+          caseId,
           decisionId: data.currentDecision.id,
           action,
           justification,
@@ -178,13 +180,12 @@ export function SoftwareRemediationView({
   }
 
   async function handleVerification(action: 'keepCurrentDecision' | 'chooseNewDecision') {
-    if (!workflowId) return
     setApproving(true)
     setStageError(null)
     try {
       await verifyRecurringRemediation({
         data: {
-          workflowId,
+          caseId,
           action,
         },
       })
@@ -202,7 +203,7 @@ export function SoftwareRemediationView({
     try {
       await generateRemediationAiSummary({
         data: {
-          tenantSoftwareId,
+          caseId,
         },
       })
       await queryClient.invalidateQueries({ queryKey })
@@ -228,7 +229,7 @@ export function SoftwareRemediationView({
     try {
       await reviewRemediationAiSummary({
         data: {
-          tenantSoftwareId,
+          caseId,
           action: 'edit',
         },
       })
@@ -259,7 +260,7 @@ export function SoftwareRemediationView({
     try {
       await reviewRemediationAiSummary({
         data: {
-          tenantSoftwareId,
+          caseId,
           action: 'edit',
         },
       })
@@ -275,15 +276,26 @@ export function SoftwareRemediationView({
         <header className="rounded-[28px] border border-border/70 bg-[linear-gradient(135deg,color-mix(in_oklab,var(--primary)_10%,transparent),transparent_52%),var(--color-card)] p-4">
           <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
             <div className="min-w-0 space-y-1.5">
-              <Link
-                to="/software/$id"
-                params={{ id: tenantSoftwareId }}
-                search={{ page: 1, pageSize: 25, version: '', tab: 'remediation' }}
-                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-              >
-                <ArrowLeft className="size-4" />
-                Back to software
-              </Link>
+              {tenantSoftwareId ? (
+                <Link
+                  to="/software/$id"
+                  params={{ id: tenantSoftwareId }}
+                  search={{ page: 1, pageSize: 25, version: '', tab: 'remediation' }}
+                  className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <ArrowLeft className="size-4" />
+                  Back to software
+                </Link>
+              ) : (
+                <Link
+                  to="/software"
+                  search={{ page: 1, pageSize: 25, search: '', category: '', vulnerableOnly: false, missedMaintenanceWindow: false }}
+                  className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <ArrowLeft className="size-4" />
+                  Back to software list
+                </Link>
+              )}
               <div className="flex flex-wrap items-center gap-2">
                 <h1 className="text-[2rem] font-semibold tracking-[-0.05em] leading-none">
                   {startCase(data.softwareName)}
@@ -337,7 +349,7 @@ export function SoftwareRemediationView({
       <div className="flex justify-end">
         <WorkNotesSheet
           entityType="remediations"
-          entityId={tenantSoftwareId}
+          entityId={caseId}
           title="Remediation work notes"
           description="Capture tenant-local notes for this remediation workflow."
         />
@@ -388,8 +400,7 @@ export function SoftwareRemediationView({
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.85fr)]">
             <CurrentActionSection
               data={data}
-              tenantSoftwareId={tenantSoftwareId}
-              workflowId={workflowId}
+              caseId={caseId}
               queryKey={queryKey}
               currentStageId={currentStageId}
               recommendationSeed={recommendationSeed}
@@ -420,8 +431,7 @@ export function SoftwareRemediationView({
         ) : (
           <CurrentActionSection
             data={data}
-            tenantSoftwareId={tenantSoftwareId}
-            workflowId={workflowId}
+            caseId={caseId}
             queryKey={queryKey}
             currentStageId={currentStageId}
             recommendationSeed={recommendationSeed}
@@ -545,7 +555,7 @@ export function SoftwareRemediationView({
             <RemediationVulnTable
               vulnerabilities={data.topVulnerabilities}
               decisionId={data.currentDecision?.id ?? null}
-              tenantSoftwareId={tenantSoftwareId}
+              caseId={caseId}
               queryKey={queryKey}
               onSelectVuln={setSelectedVuln}
             />
@@ -564,7 +574,7 @@ export function SoftwareRemediationView({
 
         <TabsContent value="history" className="pt-1">
           <DecisionHistorySection
-            tenantSoftwareId={tenantSoftwareId}
+            caseId={caseId}
             recommendations={data.recommendations}
           />
         </TabsContent>
@@ -898,8 +908,7 @@ function AiStatusBadge({ aiSummary }: { aiSummary: DecisionAiSummary }) {
 
 function CurrentActionSection({
   data,
-  tenantSoftwareId,
-  workflowId,
+  caseId,
   queryKey,
   currentStageId,
   recommendationSeed,
@@ -914,8 +923,7 @@ function CurrentActionSection({
   onUseExceptionDecision: _onUseExceptionDecision,
 }: {
   data: DecisionContext
-  tenantSoftwareId: string
-  workflowId: string | null
+  caseId: string
   queryKey: readonly unknown[]
   currentStageId: RemediationStageId
   recommendationSeed: {
@@ -1039,8 +1047,7 @@ function CurrentActionSection({
         ) : null}
         {currentStageId === 'securityAnalysis' ? (
           <RecommendationPanel
-            tenantSoftwareId={tenantSoftwareId}
-            workflowId={workflowId}
+            caseId={caseId}
             recommendations={data.recommendations}
             aiAnalystAssessment={data.aiSummary.analystAssessment}
             aiRecommendedOutcome={data.aiSummary.recommendedOutcome}
@@ -1093,8 +1100,7 @@ function CurrentActionSection({
             ) : null}
 
             <DecisionForm
-              tenantSoftwareId={tenantSoftwareId}
-              workflowId={workflowId}
+              caseId={caseId}
               queryKey={queryKey}
               readOnly={!data.workflowState.canActOnCurrentStage || currentStageId !== 'remediationDecision'}
               initialOutcome={data.currentDecision?.outcome}
@@ -1364,8 +1370,8 @@ function StageExecutionPanel({
   onApproveReject: (action: 'approve' | 'reject' | 'cancel', justification?: string, maintenanceWindowDate?: string) => Promise<void>
 }) {
   const auditQuery = useQuery({
-    queryKey: ['decision-audit-trail', data.tenantSoftwareId, 'execution-stage'],
-    queryFn: () => fetchDecisionAuditTrail({ data: { tenantSoftwareId: data.tenantSoftwareId } }),
+    queryKey: ['decision-audit-trail', data.remediationCaseId, 'execution-stage'],
+    queryFn: () => fetchDecisionAuditTrail({ data: { caseId: data.remediationCaseId } }),
     enabled: Boolean(data.currentDecision),
   })
 
@@ -1412,7 +1418,7 @@ function StageExecutionPanel({
               criticality: '',
               assetOwner: '',
               taskId: '',
-              tenantSoftwareId: data.tenantSoftwareId,
+              caseId: data.remediationCaseId,
               deviceAssetId: '',
             }}
             className="block rounded-2xl border border-border/70 bg-background/55 p-4 transition hover:border-foreground/20 hover:bg-muted/20"
@@ -1970,15 +1976,15 @@ function DevicesTab({
 
 
 function DecisionHistorySection({
-  tenantSoftwareId,
+  caseId,
   recommendations,
 }: {
-  tenantSoftwareId: string
+  caseId: string
   recommendations: DecisionContext['recommendations']
 }) {
   const auditQuery = useQuery({
-    queryKey: ['decision-audit-trail', tenantSoftwareId],
-    queryFn: () => fetchDecisionAuditTrail({ data: { tenantSoftwareId } }),
+    queryKey: ['decision-audit-trail', caseId],
+    queryFn: () => fetchDecisionAuditTrail({ data: { caseId } }),
   })
 
   const recommendationEvents: AuditTimelineEvent[] = recommendations.map((recommendation) => ({

--- a/frontend/src/components/features/software/SoftwareDetailPage.tsx
+++ b/frontend/src/components/features/software/SoftwareDetailPage.tsx
@@ -575,7 +575,7 @@ function OverviewTab({
               <div className="mt-5 space-y-3">
                 {vulnerabilities.map((item) => (
                   <details
-                    key={item.tenantVulnerabilityId}
+                    key={item.vulnerabilityId}
                     className="group overflow-hidden rounded-xl border border-border/70 bg-background"
                   >
                     <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-muted/20">
@@ -640,7 +640,7 @@ function OverviewTab({
                           </div>
                           <Link
                             to="/vulnerabilities/$id"
-                            params={{ id: item.tenantVulnerabilityId }}
+                            params={{ id: item.vulnerabilityId }}
                             className="font-medium text-primary hover:underline"
                           >
                             Open vulnerability

--- a/frontend/src/components/features/software/SoftwareDetailPage.tsx
+++ b/frontend/src/components/features/software/SoftwareDetailPage.tsx
@@ -371,6 +371,7 @@ export function SoftwareDetailPage({
         remediationData ? (
           <SoftwareRemediationView
             data={remediationData}
+            caseId={remediationData.remediationCaseId}
             tenantSoftwareId={tenantSoftwareId}
             embedded
             initialSoftwareDetail={detail}

--- a/frontend/src/components/features/vulnerabilities/RiskChangeWorkbench.tsx
+++ b/frontend/src/components/features/vulnerabilities/RiskChangeWorkbench.tsx
@@ -176,7 +176,7 @@ export function RiskChangeWorkbench({ brief }: RiskChangeWorkbenchProps) {
         cell: ({ row }) => (
           <Link
             to="/vulnerabilities/$id"
-            params={{ id: row.original.tenantVulnerabilityId }}
+            params={{ id: row.original.vulnerabilityId }}
             className="font-medium underline decoration-border/70 underline-offset-4 transition hover:text-primary hover:decoration-foreground"
           >
             {row.original.externalId}
@@ -337,7 +337,7 @@ export function RiskChangeWorkbench({ brief }: RiskChangeWorkbenchProps) {
       <DataTable
         columns={columns}
         data={filteredRows}
-        getRowId={(row) => `${row.changeType}:${row.tenantVulnerabilityId}`}
+        getRowId={(row) => `${row.changeType}:${row.vulnerabilityId}`}
         emptyState={
           <DataTableEmptyState
             title="No matching changes"

--- a/frontend/src/hooks/useOpenRemediationCase.ts
+++ b/frontend/src/hooks/useOpenRemediationCase.ts
@@ -1,0 +1,25 @@
+import { useRouter } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+import { authMiddleware } from '@/server/middleware'
+import { apiPost } from '@/server/api'
+
+const getOrCreateRemediationCase = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ softwareProductId: z.string().uuid() }))
+  .handler(async ({ context, data: { softwareProductId } }) => {
+    const data = await apiPost('/remediation/cases', context, { softwareProductId })
+    return z.object({ id: z.string().uuid() }).parse(data)
+  })
+
+export function useOpenRemediationCase() {
+  const router = useRouter()
+
+  return async function openRemediationCase(softwareProductId: string) {
+    const remediationCase = await getOrCreateRemediationCase({ data: { softwareProductId } })
+    await router.navigate({
+      to: '/remediation/cases/$caseId',
+      params: { caseId: remediationCase.id },
+    })
+  }
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -49,8 +49,8 @@ import { Route as AuthedAdminTenantsIndexRouteImport } from './routes/_authed/ad
 import { Route as AuthedAdminTeamsIndexRouteImport } from './routes/_authed/admin/teams/index'
 import { Route as AuthedAdminIntegrationsIndexRouteImport } from './routes/_authed/admin/integrations/index'
 import { Route as AuthedAdminDeviceRulesIndexRouteImport } from './routes/_authed/admin/device-rules/index'
-import { Route as AuthedSoftwareIdRemediationRouteImport } from './routes/_authed/software/$id_.remediation'
 import { Route as AuthedRemediationTaskIdRouteImport } from './routes/_authed/remediation/task.$id'
+import { Route as AuthedRemediationCasesCaseIdRouteImport } from './routes/_authed/remediation/cases.$caseId'
 import { Route as AuthedDashboardMyDevicesAttentionRouteImport } from './routes/_authed/dashboard/my-devices.attention'
 import { Route as AuthedAdminWorkflowsNewRouteImport } from './routes/_authed/admin/workflows/new'
 import { Route as AuthedAdminWorkflowsIdRouteImport } from './routes/_authed/admin/workflows/$id'
@@ -273,17 +273,17 @@ const AuthedAdminDeviceRulesIndexRoute =
     path: '/admin/device-rules/',
     getParentRoute: () => AuthedRoute,
   } as any)
-const AuthedSoftwareIdRemediationRoute =
-  AuthedSoftwareIdRemediationRouteImport.update({
-    id: '/software/$id_/remediation',
-    path: '/software/$id/remediation',
-    getParentRoute: () => AuthedRoute,
-  } as any)
 const AuthedRemediationTaskIdRoute = AuthedRemediationTaskIdRouteImport.update({
   id: '/remediation/task/$id',
   path: '/remediation/task/$id',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedRemediationCasesCaseIdRoute =
+  AuthedRemediationCasesCaseIdRouteImport.update({
+    id: '/remediation/cases/$caseId',
+    path: '/remediation/cases/$caseId',
+    getParentRoute: () => AuthedRoute,
+  } as any)
 const AuthedDashboardMyDevicesAttentionRoute =
   AuthedDashboardMyDevicesAttentionRouteImport.update({
     id: '/attention',
@@ -385,8 +385,8 @@ export interface FileRoutesByFullPath {
   '/admin/workflows/$id': typeof AuthedAdminWorkflowsIdRoute
   '/admin/workflows/new': typeof AuthedAdminWorkflowsNewRoute
   '/dashboard/my-devices/attention': typeof AuthedDashboardMyDevicesAttentionRoute
+  '/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
-  '/software/$id/remediation': typeof AuthedSoftwareIdRemediationRoute
   '/admin/device-rules/': typeof AuthedAdminDeviceRulesIndexRoute
   '/admin/integrations/': typeof AuthedAdminIntegrationsIndexRoute
   '/admin/teams/': typeof AuthedAdminTeamsIndexRoute
@@ -438,8 +438,8 @@ export interface FileRoutesByTo {
   '/admin/workflows/$id': typeof AuthedAdminWorkflowsIdRoute
   '/admin/workflows/new': typeof AuthedAdminWorkflowsNewRoute
   '/dashboard/my-devices/attention': typeof AuthedDashboardMyDevicesAttentionRoute
+  '/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
-  '/software/$id/remediation': typeof AuthedSoftwareIdRemediationRoute
   '/admin/device-rules': typeof AuthedAdminDeviceRulesIndexRoute
   '/admin/integrations': typeof AuthedAdminIntegrationsIndexRoute
   '/admin/teams': typeof AuthedAdminTeamsIndexRoute
@@ -493,8 +493,8 @@ export interface FileRoutesById {
   '/_authed/admin/workflows/$id': typeof AuthedAdminWorkflowsIdRoute
   '/_authed/admin/workflows/new': typeof AuthedAdminWorkflowsNewRoute
   '/_authed/dashboard/my-devices/attention': typeof AuthedDashboardMyDevicesAttentionRoute
+  '/_authed/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/_authed/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
-  '/_authed/software/$id_/remediation': typeof AuthedSoftwareIdRemediationRoute
   '/_authed/admin/device-rules/': typeof AuthedAdminDeviceRulesIndexRoute
   '/_authed/admin/integrations/': typeof AuthedAdminIntegrationsIndexRoute
   '/_authed/admin/teams/': typeof AuthedAdminTeamsIndexRoute
@@ -548,8 +548,8 @@ export interface FileRouteTypes {
     | '/admin/workflows/$id'
     | '/admin/workflows/new'
     | '/dashboard/my-devices/attention'
+    | '/remediation/cases/$caseId'
     | '/remediation/task/$id'
-    | '/software/$id/remediation'
     | '/admin/device-rules/'
     | '/admin/integrations/'
     | '/admin/teams/'
@@ -601,8 +601,8 @@ export interface FileRouteTypes {
     | '/admin/workflows/$id'
     | '/admin/workflows/new'
     | '/dashboard/my-devices/attention'
+    | '/remediation/cases/$caseId'
     | '/remediation/task/$id'
-    | '/software/$id/remediation'
     | '/admin/device-rules'
     | '/admin/integrations'
     | '/admin/teams'
@@ -655,8 +655,8 @@ export interface FileRouteTypes {
     | '/_authed/admin/workflows/$id'
     | '/_authed/admin/workflows/new'
     | '/_authed/dashboard/my-devices/attention'
+    | '/_authed/remediation/cases/$caseId'
     | '/_authed/remediation/task/$id'
-    | '/_authed/software/$id_/remediation'
     | '/_authed/admin/device-rules/'
     | '/_authed/admin/integrations/'
     | '/_authed/admin/teams/'
@@ -958,18 +958,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminDeviceRulesIndexRouteImport
       parentRoute: typeof AuthedRoute
     }
-    '/_authed/software/$id_/remediation': {
-      id: '/_authed/software/$id_/remediation'
-      path: '/software/$id/remediation'
-      fullPath: '/software/$id/remediation'
-      preLoaderRoute: typeof AuthedSoftwareIdRemediationRouteImport
-      parentRoute: typeof AuthedRoute
-    }
     '/_authed/remediation/task/$id': {
       id: '/_authed/remediation/task/$id'
       path: '/remediation/task/$id'
       fullPath: '/remediation/task/$id'
       preLoaderRoute: typeof AuthedRemediationTaskIdRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/remediation/cases/$caseId': {
+      id: '/_authed/remediation/cases/$caseId'
+      path: '/remediation/cases/$caseId'
+      fullPath: '/remediation/cases/$caseId'
+      preLoaderRoute: typeof AuthedRemediationCasesCaseIdRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/dashboard/my-devices/attention': {
@@ -1096,8 +1096,8 @@ interface AuthedRouteChildren {
   AuthedAdminTenantsIdRoute: typeof AuthedAdminTenantsIdRoute
   AuthedAdminWorkflowsIdRoute: typeof AuthedAdminWorkflowsIdRoute
   AuthedAdminWorkflowsNewRoute: typeof AuthedAdminWorkflowsNewRoute
+  AuthedRemediationCasesCaseIdRoute: typeof AuthedRemediationCasesCaseIdRoute
   AuthedRemediationTaskIdRoute: typeof AuthedRemediationTaskIdRoute
-  AuthedSoftwareIdRemediationRoute: typeof AuthedSoftwareIdRemediationRoute
   AuthedAdminDeviceRulesIndexRoute: typeof AuthedAdminDeviceRulesIndexRoute
   AuthedAdminIntegrationsIndexRoute: typeof AuthedAdminIntegrationsIndexRoute
   AuthedAdminTeamsIndexRoute: typeof AuthedAdminTeamsIndexRoute
@@ -1141,8 +1141,8 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAdminTenantsIdRoute: AuthedAdminTenantsIdRoute,
   AuthedAdminWorkflowsIdRoute: AuthedAdminWorkflowsIdRoute,
   AuthedAdminWorkflowsNewRoute: AuthedAdminWorkflowsNewRoute,
+  AuthedRemediationCasesCaseIdRoute: AuthedRemediationCasesCaseIdRoute,
   AuthedRemediationTaskIdRoute: AuthedRemediationTaskIdRoute,
-  AuthedSoftwareIdRemediationRoute: AuthedSoftwareIdRemediationRoute,
   AuthedAdminDeviceRulesIndexRoute: AuthedAdminDeviceRulesIndexRoute,
   AuthedAdminIntegrationsIndexRoute: AuthedAdminIntegrationsIndexRoute,
   AuthedAdminTeamsIndexRoute: AuthedAdminTeamsIndexRoute,

--- a/frontend/src/routes/_authed/remediation/cases.$caseId.tsx
+++ b/frontend/src/routes/_authed/remediation/cases.$caseId.tsx
@@ -4,23 +4,22 @@ import { createFileRoute } from '@tanstack/react-router'
 import { fetchDecisionContext } from '@/api/remediation.functions'
 import { SoftwareRemediationView } from '@/components/features/remediation/SoftwareRemediationView'
 import { useTenantScope } from '@/components/layout/tenant-scope'
-import { softwareQueryKeys } from '@/features/software/list-state'
 
-export const Route = createFileRoute('/_authed/software/$id_/remediation')({
-  loader: ({ params }) => fetchDecisionContext({ data: { tenantSoftwareId: params.id } }),
-  component: RemediationPage,
+export const Route = createFileRoute('/_authed/remediation/cases/$caseId')({
+  loader: ({ params }) => fetchDecisionContext({ data: { caseId: params.caseId } }),
+  component: RemediationCaseRoute,
 })
 
-function RemediationPage() {
+function RemediationCaseRoute() {
   const initialData = Route.useLoaderData()
-  const { id } = Route.useParams()
+  const { caseId } = Route.useParams()
   const { selectedTenantId } = useTenantScope()
   const [initialTenantId] = useState(selectedTenantId)
   const canUseInitialData = initialTenantId === selectedTenantId
 
   const query = useQuery({
-    queryKey: softwareQueryKeys.remediation(selectedTenantId, id),
-    queryFn: () => fetchDecisionContext({ data: { tenantSoftwareId: id } }),
+    queryKey: ['remediation-case', selectedTenantId, caseId],
+    queryFn: () => fetchDecisionContext({ data: { caseId } }),
     initialData: canUseInitialData ? initialData : undefined,
     refetchInterval: (currentQuery) => {
       const status = currentQuery.state.data?.aiSummary.status
@@ -38,5 +37,5 @@ function RemediationPage() {
     )
   }
 
-  return <SoftwareRemediationView data={data} tenantSoftwareId={id} />
+  return <SoftwareRemediationView data={data} caseId={caseId} />
 }

--- a/frontend/src/routes/_authed/remediation/task.$id.tsx
+++ b/frontend/src/routes/_authed/remediation/task.$id.tsx
@@ -43,7 +43,7 @@ function RemediationTaskDetailRoute() {
                 criticality: '',
                 assetOwner: '',
                 taskId: task.id,
-                tenantSoftwareId: '',
+                caseId: '',
                 deviceAssetId: '',
               }}
               className="underline decoration-border/70 underline-offset-4 hover:decoration-foreground"
@@ -121,17 +121,16 @@ function RemediationTaskDetailRoute() {
             </div>
 
             <div className="flex flex-wrap gap-2">
-              {task.tenantSoftwareId ? (
+              {task.remediationCaseId ? (
                 <Button
                   render={
                     <Link
-                      to="/software/$id"
-                      params={{ id: task.tenantSoftwareId }}
-                      search={{ page: 1, pageSize: 25, version: '', tab: 'remediation' }}
+                      to="/remediation/cases/$caseId"
+                      params={{ caseId: task.remediationCaseId }}
                     />
                   }
                 >
-                  Open software remediation
+                  Open related case
                 </Button>
               ) : null}
               <Button
@@ -147,7 +146,7 @@ function RemediationTaskDetailRoute() {
                       criticality: '',
                       assetOwner: '',
                       taskId: task.id,
-                      tenantSoftwareId: '',
+                      caseId: '',
                       deviceAssetId: '',
                     }}
                   />

--- a/frontend/src/routes/_authed/remediation/tasks.tsx
+++ b/frontend/src/routes/_authed/remediation/tasks.tsx
@@ -12,7 +12,7 @@ const remediationTasksSearchSchema = baseListSearchSchema.extend({
   criticality: searchStringSchema,
   assetOwner: searchStringSchema,
   taskId: searchStringSchema,
-  tenantSoftwareId: searchStringSchema,
+  caseId: searchStringSchema,
   deviceAssetId: searchStringSchema,
 })
 
@@ -65,7 +65,7 @@ function RemediationTasksRoute() {
         criticality: search.criticality,
         assetOwner: search.assetOwner,
       }}
-      scopedToSoftware={Boolean(search.tenantSoftwareId)}
+      scopedToSoftware={Boolean(search.caseId)}
       scopedToDevice={Boolean(search.deviceAssetId)}
       onFiltersChange={(filters) => {
         void navigate({
@@ -93,7 +93,7 @@ function normalizeFilters(search: {
   vendor: string
   criticality: string
   assetOwner: string
-  tenantSoftwareId: string
+  caseId: string
   deviceAssetId: string
   taskId: string
 }) {
@@ -103,7 +103,7 @@ function normalizeFilters(search: {
     criticality: search.criticality || undefined,
     assetOwner: search.assetOwner || undefined,
     taskId: search.taskId || undefined,
-    tenantSoftwareId: search.tenantSoftwareId || undefined,
+    caseId: search.caseId || undefined,
     deviceAssetId: search.deviceAssetId || undefined,
   }
 }

--- a/frontend/src/routes/_authed/software/$id.tsx
+++ b/frontend/src/routes/_authed/software/$id.tsx
@@ -7,7 +7,7 @@ import {
   fetchTenantSoftwareInstallations,
   fetchTenantSoftwareVulnerabilities,
 } from '@/api/software.functions'
-import { fetchDecisionContext } from '@/api/remediation.functions'
+import { fetchTenantSoftwareDecisionContext } from '@/api/remediation.functions'
 import { SoftwareDetailPage } from '@/components/features/software/SoftwareDetailPage'
 import { useTenantScope } from '@/components/layout/tenant-scope'
 import { softwareQueryKeys } from '@/features/software/list-state'
@@ -100,7 +100,7 @@ function SoftwareDetailRoute() {
 
   const remediationQuery = useQuery({
     queryKey: softwareQueryKeys.remediation(selectedTenantId, id),
-    queryFn: () => fetchDecisionContext({ data: { tenantSoftwareId: id } }),
+    queryFn: () => fetchTenantSoftwareDecisionContext({ data: { tenantSoftwareId: id } }),
     enabled: canViewRemediation,
     refetchInterval: (currentQuery) => {
       const status = currentQuery.state.data?.aiSummary.status

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -334,7 +334,7 @@ public class DashboardController : ControllerBase
             {
                 RemediationCaseId = p.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
                 AssetId = p.SoftwareAssetId,
-                TenantVulnerabilityId = topVuln?.Id ?? Guid.Empty,
+                VulnerabilityId = topVuln?.Id ?? Guid.Empty,
                 TaskId = (Guid?)p.PatchingTaskId,
                 AssetName = p.SoftwareAssetName,
                 p.OwnerTeamName,
@@ -357,7 +357,7 @@ public class DashboardController : ControllerBase
         var ownerActions = ownerActionRows
             .Select(item => new OwnerActionDto(
                 item.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
-                item.TenantVulnerabilityId,
+                item.VulnerabilityId,
                 item.TaskId,
                 item.AssetName,
                 item.OwnerTeamName,

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -287,8 +287,10 @@ public class DashboardController : ControllerBase
             from pt in _dbContext.PatchingTasks.AsNoTracking()
             join decision in _dbContext.RemediationDecisions.AsNoTracking()
                 on pt.RemediationDecisionId equals decision.Id
-            join softwareAsset in _dbContext.Assets.AsNoTracking()
-                on decision.SoftwareAssetId equals softwareAsset.Id
+            join rc in _dbContext.RemediationCases.AsNoTracking()
+                on pt.RemediationCaseId equals rc.Id
+            join sp in _dbContext.SoftwareProducts.AsNoTracking()
+                on rc.SoftwareProductId equals sp.Id
             join ownerTeam in _dbContext.Teams.AsNoTracking()
                 on pt.OwnerTeamId equals ownerTeam.Id
             where pt.TenantId == tenantId
@@ -296,9 +298,9 @@ public class DashboardController : ControllerBase
                   && pt.Status != PatchingTaskStatus.Completed
             select new
             {
-                pt.TenantSoftwareId,
-                SoftwareAssetId = decision.SoftwareAssetId,
-                SoftwareAssetName = softwareAsset.Name,
+                RemediationCaseId = pt.RemediationCaseId,
+                SoftwareAssetId = Guid.Empty, // Phase 4 debt (#17): SoftwareAsset removed from RemediationDecision
+                SoftwareAssetName = sp.Name,
                 OwnerTeamName = ownerTeam.Name,
                 PatchingTaskId = pt.Id,
                 pt.DueDate,
@@ -330,7 +332,7 @@ public class DashboardController : ControllerBase
             var topVuln = topVulnBySoftware.GetValueOrDefault(p.SoftwareAssetId);
             return new
             {
-                p.TenantSoftwareId,
+                RemediationCaseId = p.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
                 AssetId = p.SoftwareAssetId,
                 TenantVulnerabilityId = topVuln?.Id ?? Guid.Empty,
                 TaskId = (Guid?)p.PatchingTaskId,
@@ -354,7 +356,7 @@ public class DashboardController : ControllerBase
 
         var ownerActions = ownerActionRows
             .Select(item => new OwnerActionDto(
-                item.TenantSoftwareId,
+                item.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
                 item.TenantVulnerabilityId,
                 item.TaskId,
                 item.AssetName,
@@ -535,10 +537,10 @@ public class DashboardController : ControllerBase
 
         var recentApprovedDecisions = await (
             from decision in _dbContext.RemediationDecisions.AsNoTracking()
-            join tenantSoftware in _dbContext.TenantSoftware.AsNoTracking()
-                on decision.TenantSoftwareId equals tenantSoftware.Id
-            join normalizedSoftware in _dbContext.NormalizedSoftware.AsNoTracking()
-                on tenantSoftware.NormalizedSoftwareId equals normalizedSoftware.Id
+            join rc in _dbContext.RemediationCases.AsNoTracking()
+                on decision.RemediationCaseId equals rc.Id
+            join sp in _dbContext.SoftwareProducts.AsNoTracking()
+                on rc.SoftwareProductId equals sp.Id
             where decision.TenantId == tenantId
                   && decision.ApprovalStatus == DecisionApprovalStatus.Approved
                   && (decision.Outcome == RemediationOutcome.RiskAcceptance
@@ -547,8 +549,8 @@ public class DashboardController : ControllerBase
             select new
             {
                 decision.Id,
-                decision.TenantSoftwareId,
-                SoftwareName = normalizedSoftware.CanonicalName,
+                RemediationCaseId = decision.RemediationCaseId,
+                SoftwareName = sp.Name,
                 Outcome = decision.Outcome.ToString(),
                 decision.Justification,
                 decision.DecidedAt,
@@ -561,7 +563,7 @@ public class DashboardController : ControllerBase
 
         var policySoftwareStats = await BuildSoftwareScopeStatsAsync(
             tenantId,
-            recentApprovedDecisions.Select(item => item.TenantSoftwareId).Distinct().ToList(),
+            recentApprovedDecisions.Select(item => item.RemediationCaseId).Distinct().ToList(),
             ct);
 
         var approvalTasks = await BuildApprovalAttentionTasksAsync(
@@ -572,10 +574,10 @@ public class DashboardController : ControllerBase
         return Ok(new SecurityManagerDashboardSummaryDto(
             recentApprovedDecisions.Select(item =>
             {
-                var stats = policySoftwareStats.GetValueOrDefault(item.TenantSoftwareId);
+                var stats = policySoftwareStats.GetValueOrDefault(item.RemediationCaseId);
                 return new ApprovedPolicyDecisionDto(
                     item.Id,
-                    item.TenantSoftwareId,
+                    item.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
                     item.SoftwareName,
                     item.Outcome,
                     string.IsNullOrWhiteSpace(item.Justification) ? null : item.Justification,
@@ -602,10 +604,10 @@ public class DashboardController : ControllerBase
             from task in _dbContext.PatchingTasks.AsNoTracking()
             join decision in _dbContext.RemediationDecisions.AsNoTracking()
                 on task.RemediationDecisionId equals decision.Id
-            join tenantSoftware in _dbContext.TenantSoftware.AsNoTracking()
-                on task.TenantSoftwareId equals tenantSoftware.Id
-            join normalizedSoftware in _dbContext.NormalizedSoftware.AsNoTracking()
-                on tenantSoftware.NormalizedSoftwareId equals normalizedSoftware.Id
+            join rc in _dbContext.RemediationCases.AsNoTracking()
+                on task.RemediationCaseId equals rc.Id
+            join sp in _dbContext.SoftwareProducts.AsNoTracking()
+                on rc.SoftwareProductId equals sp.Id
             join ownerTeam in _dbContext.Teams.AsNoTracking()
                 on task.OwnerTeamId equals ownerTeam.Id
             where task.TenantId == tenantId
@@ -617,8 +619,8 @@ public class DashboardController : ControllerBase
             {
                 task.Id,
                 task.RemediationDecisionId,
-                task.TenantSoftwareId,
-                SoftwareName = normalizedSoftware.CanonicalName,
+                RemediationCaseId = task.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
+                SoftwareName = sp.Name,
                 OwnerTeamName = ownerTeam.Name,
                 task.DueDate,
                 task.Status,
@@ -632,7 +634,7 @@ public class DashboardController : ControllerBase
 
         var patchingSoftwareStats = await BuildSoftwareScopeStatsAsync(
             tenantId,
-            approvedPatchingTasks.Select(item => item.TenantSoftwareId).Distinct().ToList(),
+            approvedPatchingTasks.Select(item => item.RemediationCaseId).Distinct().ToList(),
             ct);
 
         var now = DateTimeOffset.UtcNow;
@@ -651,11 +653,11 @@ public class DashboardController : ControllerBase
             missedMaintenanceWindowCount,
             approvedPatchingTasks.Select(item =>
             {
-                var stats = patchingSoftwareStats.GetValueOrDefault(item.TenantSoftwareId);
+                var stats = patchingSoftwareStats.GetValueOrDefault(item.RemediationCaseId);
                 return new ApprovedPatchingTaskDto(
                     item.Id,
                     item.RemediationDecisionId,
-                    item.TenantSoftwareId,
+                    item.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId; DTO field kept for API compat
                     item.SoftwareName,
                     item.OwnerTeamName,
                     stats?.HighestSeverity ?? "Unknown",
@@ -776,10 +778,10 @@ public class DashboardController : ControllerBase
             from task in _dbContext.ApprovalTasks.AsNoTracking()
             join decision in _dbContext.RemediationDecisions.AsNoTracking()
                 on task.RemediationDecisionId equals decision.Id
-            join tenantSoftware in _dbContext.TenantSoftware.AsNoTracking()
-                on decision.TenantSoftwareId equals tenantSoftware.Id
-            join normalizedSoftware in _dbContext.NormalizedSoftware.AsNoTracking()
-                on tenantSoftware.NormalizedSoftwareId equals normalizedSoftware.Id
+            join rc in _dbContext.RemediationCases.AsNoTracking()
+                on decision.RemediationCaseId equals rc.Id
+            join sp in _dbContext.SoftwareProducts.AsNoTracking()
+                on rc.SoftwareProductId equals sp.Id
             where task.TenantId == tenantId
                   && task.Status == ApprovalTaskStatus.Pending
                   && task.VisibleRoles.Any(role => visibleRoles.Contains(role.Role))
@@ -788,8 +790,8 @@ public class DashboardController : ControllerBase
             {
                 task.Id,
                 task.RemediationDecisionId,
-                decision.TenantSoftwareId,
-                SoftwareName = normalizedSoftware.CanonicalName,
+                RemediationCaseId = decision.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
+                SoftwareName = sp.Name,
                 ApprovalType = task.Type.ToString(),
                 task.ExpiresAt,
                 decision.MaintenanceWindowDate,
@@ -801,13 +803,13 @@ public class DashboardController : ControllerBase
 
         var softwareStats = await BuildSoftwareScopeStatsAsync(
             tenantId,
-            pendingTasks.Select(item => item.TenantSoftwareId).Distinct().ToList(),
+            pendingTasks.Select(item => item.RemediationCaseId).Distinct().ToList(),
             ct);
 
         var now = DateTimeOffset.UtcNow;
         return pendingTasks.Select(item =>
         {
-            var stats = softwareStats.GetValueOrDefault(item.TenantSoftwareId);
+            var stats = softwareStats.GetValueOrDefault(item.RemediationCaseId);
             var attentionState = item.ExpiresAt <= now
                 ? "Overdue"
                 : item.ExpiresAt <= now.AddHours(24)
@@ -817,7 +819,7 @@ public class DashboardController : ControllerBase
             return new ApprovalAttentionTaskDto(
                 item.Id,
                 item.RemediationDecisionId,
-                item.TenantSoftwareId,
+                item.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId; DTO field kept for API compat
                 item.SoftwareName,
                 item.ApprovalType,
                 stats?.HighestSeverity ?? "Unknown",

--- a/src/PatchHound.Api/Controllers/RemediationCasesController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationCasesController.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models;
+using PatchHound.Api.Models.Remediation;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/remediation/cases")]
+[Authorize]
+public class RemediationCasesController(
+    PatchHoundDbContext db,
+    RemediationCaseService caseService,
+    ITenantContext tenantContext) : ControllerBase
+{
+    [HttpGet]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<PagedResponse<RemediationCaseDto>>> List(
+        [FromQuery] PaginationQuery pagination,
+        CancellationToken ct)
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        var query = db.RemediationCases.AsNoTracking()
+            .Where(c => c.TenantId == tenantId)
+            .OrderByDescending(c => c.UpdatedAt);
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip(pagination.Skip).Take(pagination.BoundedPageSize)
+            .Select(c => new RemediationCaseDto(
+                c.Id, c.TenantId, c.SoftwareProductId,
+                c.SoftwareProduct.Name, c.SoftwareProduct.Vendor,
+                c.Status.ToString(), c.CreatedAt, c.UpdatedAt, c.ClosedAt,
+                db.InstalledSoftware.Count(i =>
+                    i.TenantId == tenantId && i.SoftwareProductId == c.SoftwareProductId),
+                db.DeviceVulnerabilityExposures.Count(e =>
+                    e.TenantId == tenantId
+                    && e.SoftwareProductId == c.SoftwareProductId
+                    && e.Status == ExposureStatus.Open)))
+            .ToListAsync(ct);
+
+        return Ok(new PagedResponse<RemediationCaseDto>(items, total, pagination.Page, pagination.BoundedPageSize));
+    }
+
+    [HttpGet("{caseId:guid}")]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<RemediationCaseDto>> Get(Guid caseId, CancellationToken ct)
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        var c = await db.RemediationCases.AsNoTracking()
+            .Include(x => x.SoftwareProduct)
+            .FirstOrDefaultAsync(x => x.TenantId == tenantId && x.Id == caseId, ct);
+        if (c is null) return NotFound();
+
+        return Ok(new RemediationCaseDto(
+            c.Id, c.TenantId, c.SoftwareProductId,
+            c.SoftwareProduct.Name, c.SoftwareProduct.Vendor,
+            c.Status.ToString(), c.CreatedAt, c.UpdatedAt, c.ClosedAt,
+            await db.InstalledSoftware.CountAsync(i =>
+                i.TenantId == tenantId && i.SoftwareProductId == c.SoftwareProductId, ct),
+            await db.DeviceVulnerabilityExposures.CountAsync(e =>
+                e.TenantId == tenantId
+                && e.SoftwareProductId == c.SoftwareProductId
+                && e.Status == ExposureStatus.Open, ct)));
+    }
+
+    public record CreateCaseRequest(Guid SoftwareProductId);
+
+    [HttpPost]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<RemediationCaseDto>> GetOrCreate(
+        [FromBody] CreateCaseRequest req, CancellationToken ct)
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        try
+        {
+            var c = await caseService.GetOrCreateAsync(tenantId, req.SoftwareProductId, ct);
+            return await Get(c.Id, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new ProblemDetails { Title = ex.Message });
+        }
+    }
+}

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -14,7 +14,7 @@ using PatchHound.Infrastructure.Services;
 namespace PatchHound.Api.Controllers;
 
 [ApiController]
-[Route("api/software/{tenantSoftwareId:guid}/remediation")]
+[Route("api/remediation/cases/{caseId:guid}")]
 [Authorize]
 public class RemediationDecisionsController(
     RemediationDecisionQueryService queryService,
@@ -31,18 +31,14 @@ public class RemediationDecisionsController(
     [HttpGet("decision-context")]
     [Authorize(Policy = Policies.ViewVulnerabilities)]
     public async Task<ActionResult<DecisionContextDto>> GetDecisionContext(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationCaseId is null)
-            return NotFound();
-
-        var result = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
+        var result = await queryService.BuildByCaseIdAsync(tenantId, caseId, false, ct);
         if (result is null)
             return NotFound();
 
@@ -52,31 +48,27 @@ public class RemediationDecisionsController(
     [HttpPost("workflow")]
     [Authorize(Policy = Policies.ViewVulnerabilities)]
     public async Task<ActionResult<EnsureRemediationWorkflowResponse>> EnsureWorkflow(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationCaseId is null)
-            return NotFound(new ProblemDetails { Title = "Remediation case not found for this software." });
-
         var workflow = await workflowService.GetOrCreateActiveWorkflowAsync(
             tenantId,
-            remediationCaseId.Value,
+            caseId,
             ct
         );
         await dbContext.SaveChangesAsync(ct);
-        await EnqueueAiDraftsAsync(tenantId, remediationCaseId.Value, ct);
+        await EnqueueAiDraftsAsync(tenantId, caseId, ct);
         return Ok(new EnsureRemediationWorkflowResponse(workflow.Id));
     }
 
     [HttpPost("decisions/{decisionId:guid}/overrides")]
     [Authorize(Policy = Policies.UpdateTaskStatus)]
     public async Task<ActionResult<VulnerabilityOverrideDto>> AddOverride(
-        Guid tenantSoftwareId,
+        Guid caseId,
         Guid decisionId,
         [FromBody] CreateOverrideRequest request,
         CancellationToken ct
@@ -99,10 +91,8 @@ public class RemediationDecisionsController(
         if (!result.IsSuccess)
             return BadRequest(new ProblemDetails { Title = result.Error });
 
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
         var vo = result.Value;
-        if (remediationCaseId is not null)
-            await EnqueueAiDraftsAsync(tenantId, remediationCaseId.Value, ct);
+        await EnqueueAiDraftsAsync(tenantId, caseId, ct);
         return Created("", new VulnerabilityOverrideDto(
             vo.Id, vo.VulnerabilityId, vo.Outcome.ToString(), vo.Justification, vo.CreatedAt
         ));
@@ -111,28 +101,24 @@ public class RemediationDecisionsController(
     [HttpGet("recommendations")]
     [Authorize(Policy = Policies.ViewVulnerabilities)]
     public async Task<ActionResult<List<AnalystRecommendationDto>>> GetRecommendations(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationCaseId is null)
-            return NotFound();
-
-        var context = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
+        var context = await queryService.BuildByCaseIdAsync(tenantId, caseId, false, ct);
         if (context is null)
             return NotFound();
 
         return Ok(context.Recommendations);
     }
 
-    [HttpPost("/api/remediation/{workflowId:guid}/analysis")]
+    [HttpPost("analysis")]
     [Authorize(Policy = Policies.AddComments)]
-    public async Task<ActionResult<AnalystRecommendationDto>> AddRecommendationByWorkflow(
-        Guid workflowId,
+    public async Task<ActionResult<AnalystRecommendationDto>> AddRecommendation(
+        Guid caseId,
         [FromBody] CreateRecommendationRequest request,
         CancellationToken ct
     )
@@ -140,12 +126,7 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var workflow = await dbContext.RemediationWorkflows.AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == workflowId, ct);
-        if (workflow is null)
-            return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
-
-        var auth = await workflowAuthorizationService.EnsureCanAddRecommendationAsync(tenantId, workflow.RemediationCaseId, ct);
+        var auth = await workflowAuthorizationService.EnsureCanAddRecommendationAsync(tenantId, caseId, ct);
         if (!auth.IsSuccess)
             return BadRequest(new ProblemDetails { Title = auth.Error });
 
@@ -155,7 +136,7 @@ public class RemediationDecisionsController(
         var userId = tenantContext.CurrentUserId;
         var result = await recommendationService.AddRecommendationForCaseAsync(
             tenantId,
-            workflow.RemediationCaseId,
+            caseId,
             outcome,
             request.Rationale,
             userId,
@@ -173,17 +154,17 @@ public class RemediationDecisionsController(
             .FirstOrDefaultAsync(ct);
 
         var r = result.Value;
-        await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
+        await EnqueueAiDraftsAsync(tenantId, caseId, ct);
         return Created("", new AnalystRecommendationDto(
             r.Id, r.VulnerabilityId, r.RecommendedOutcome.ToString(),
             r.Rationale, r.PriorityOverride, r.AnalystId, analystDisplayName, r.CreatedAt
         ));
     }
 
-    [HttpPost("/api/remediation/{workflowId:guid}/verification")]
+    [HttpPost("verification")]
     [Authorize(Policy = Policies.UpdateTaskStatus)]
     public async Task<IActionResult> VerifyRecurringRemediation(
-        Guid workflowId,
+        Guid caseId,
         [FromBody] VerifyRemediationRequest request,
         CancellationToken ct
     )
@@ -192,11 +173,11 @@ public class RemediationDecisionsController(
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
         var workflow = await dbContext.RemediationWorkflows.AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == workflowId, ct);
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.RemediationCaseId == caseId && item.Status == RemediationWorkflowStatus.Active, ct);
         if (workflow is null)
             return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
 
-        var auth = await workflowAuthorizationService.EnsureCanVerifyAsync(tenantId, workflowId, ct);
+        var auth = await workflowAuthorizationService.EnsureCanVerifyAsync(tenantId, workflow.Id, ct);
         if (!auth.IsSuccess)
             return BadRequest(new ProblemDetails { Title = auth.Error });
 
@@ -221,7 +202,7 @@ public class RemediationDecisionsController(
 
             var verificationResult = await decisionService.VerifyAndCarryForwardDecisionAsync(
                 tenantId,
-                workflowId,
+                workflow.Id,
                 previousDecision,
                 tenantContext.CurrentUserId,
                 ct
@@ -237,7 +218,7 @@ public class RemediationDecisionsController(
         {
             var verificationResult = await decisionService.VerifyAndRequireNewDecisionAsync(
                 tenantId,
-                workflowId,
+                workflow.Id,
                 tenantContext.CurrentUserId,
                 ct
             );
@@ -251,10 +232,10 @@ public class RemediationDecisionsController(
         return BadRequest(new ProblemDetails { Title = "Verification action must be 'keepCurrentDecision' or 'chooseNewDecision'." });
     }
 
-    [HttpPost("/api/remediation/{workflowId:guid}/decision")]
+    [HttpPost("decision")]
     [Authorize(Policy = Policies.UpdateTaskStatus)]
-    public async Task<ActionResult<RemediationDecisionDto>> CreateDecisionByWorkflow(
-        Guid workflowId,
+    public async Task<ActionResult<RemediationDecisionDto>> CreateDecision(
+        Guid caseId,
         [FromBody] CreateDecisionRequest request,
         CancellationToken ct
     )
@@ -263,11 +244,11 @@ public class RemediationDecisionsController(
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
         var workflow = await dbContext.RemediationWorkflows.AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == workflowId, ct);
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.RemediationCaseId == caseId && item.Status == RemediationWorkflowStatus.Active, ct);
         if (workflow is null)
             return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
 
-        var auth = await workflowAuthorizationService.EnsureCanCreateDecisionAsync(tenantId, workflow.RemediationCaseId, ct);
+        var auth = await workflowAuthorizationService.EnsureCanCreateDecisionAsync(tenantId, caseId, ct);
         if (!auth.IsSuccess)
             return BadRequest(new ProblemDetails { Title = auth.Error });
 
@@ -276,20 +257,21 @@ public class RemediationDecisionsController(
 
         var result = await decisionService.CreateDecisionForCaseAsync(
             tenantId,
-            workflow.RemediationCaseId,
+            caseId,
             outcome,
             request.Justification,
             tenantContext.CurrentUserId,
             request.ExpiryDate,
             request.ReEvaluationDate,
-            ct
+            ct,
+            request.MaintenanceWindowDate
         );
 
         if (!result.IsSuccess)
             return BadRequest(new ProblemDetails { Title = result.Error });
 
         var d = result.Value;
-        await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
+        await EnqueueAiDraftsAsync(tenantId, caseId, ct);
         return Created("", new RemediationDecisionDto(
             d.Id, d.Outcome.ToString(), d.ApprovalStatus.ToString(),
             d.Justification, d.DecidedBy, d.DecidedAt,
@@ -299,10 +281,10 @@ public class RemediationDecisionsController(
         ));
     }
 
-    [HttpPost("/api/remediation/{workflowId:guid}/approval")]
+    [HttpPost("approval")]
     [Authorize(Policy = Policies.ResolveApprovalTask)]
-    public async Task<IActionResult> ResolveApprovalByWorkflow(
-        Guid workflowId,
+    public async Task<IActionResult> ResolveApproval(
+        Guid caseId,
         [FromBody] ResolveApprovalTaskRequest request,
         CancellationToken ct
     )
@@ -311,14 +293,14 @@ public class RemediationDecisionsController(
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
         var workflow = await dbContext.RemediationWorkflows.AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == workflowId, ct);
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.RemediationCaseId == caseId && item.Status == RemediationWorkflowStatus.Active, ct);
         if (workflow is null)
             return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
 
         var currentDecision = await dbContext.RemediationDecisions.AsNoTracking()
             .Where(item =>
                 item.TenantId == tenantId
-                && item.RemediationWorkflowId == workflowId
+                && item.RemediationWorkflowId == workflow.Id
                 && item.ApprovalStatus == DecisionApprovalStatus.PendingApproval)
             .OrderByDescending(item => item.CreatedAt)
             .FirstOrDefaultAsync(ct);
@@ -360,7 +342,7 @@ public class RemediationDecisionsController(
                 return BadRequest(new ProblemDetails { Title = "Action must be 'approve' or 'deny'." });
             }
 
-            await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
+            await EnqueueAiDraftsAsync(tenantId, caseId, ct);
             return Ok();
         }
         catch (InvalidOperationException ex)
@@ -369,10 +351,10 @@ public class RemediationDecisionsController(
         }
     }
 
-    [HttpPost("/api/remediation/{workflowId:guid}/decision/{decisionId:guid}/cancel")]
+    [HttpPost("decision/{decisionId:guid}/cancel")]
     [Authorize(Policy = Policies.UpdateTaskStatus)]
-    public async Task<IActionResult> CancelDecisionByWorkflow(
-        Guid workflowId,
+    public async Task<IActionResult> CancelDecision(
+        Guid caseId,
         Guid decisionId,
         CancellationToken ct
     )
@@ -381,7 +363,7 @@ public class RemediationDecisionsController(
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
         var workflow = await dbContext.RemediationWorkflows.AsNoTracking()
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == workflowId, ct);
+            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.RemediationCaseId == caseId && item.Status == RemediationWorkflowStatus.Active, ct);
         if (workflow is null)
             return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
 
@@ -398,26 +380,22 @@ public class RemediationDecisionsController(
         if (!result.IsSuccess)
             return BadRequest(new ProblemDetails { Title = result.Error });
 
-        await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
+        await EnqueueAiDraftsAsync(tenantId, caseId, ct);
         return Ok();
     }
 
     [HttpPost("ai-summary")]
     [Authorize(Policy = Policies.GenerateAiReports)]
     public async Task<ActionResult<DecisionAiSummaryDto>> GenerateAiSummary(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationCaseId is null)
-            return NotFound(new ProblemDetails { Title = "Remediation case not found for this software." });
-
-        await EnqueueAiDraftsAsync(tenantId, remediationCaseId.Value, ct);
-        var context = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
+        await EnqueueAiDraftsAsync(tenantId, caseId, ct);
+        var context = await queryService.BuildByCaseIdAsync(tenantId, caseId, false, ct);
         if (context is null)
             return NotFound(new ProblemDetails { Title = "Remediation context not found." });
 
@@ -435,19 +413,13 @@ public class RemediationDecisionsController(
     [HttpPost("ai-summary/review")]
     [Authorize(Policy = Policies.ViewVulnerabilities)]
     public async Task<ActionResult<DecisionAiSummaryDto>> ReviewAiSummary(
-        Guid tenantSoftwareId,
+        Guid caseId,
         [FromBody] ReviewDecisionAiSummaryRequest request,
         CancellationToken ct
     )
     {
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
-
-        // TenantSoftware still exists as snapshot-versioned table; AI review state lives there for now (TODO Phase 5)
-        var tenantSoftware = await dbContext.TenantSoftware
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == tenantSoftwareId, ct);
-        if (tenantSoftware is null)
-            return NotFound(new ProblemDetails { Title = "Remediation context not found." });
 
         var action = request.Action?.Trim();
         if (string.IsNullOrWhiteSpace(action))
@@ -463,14 +435,7 @@ public class RemediationDecisionsController(
         if (reviewStatus is null)
             return BadRequest(new ProblemDetails { Title = "Review action must be accept, edit, or reject." });
 
-        tenantSoftware.MarkRemediationAiReviewed(reviewStatus, tenantContext.CurrentUserId);
-        await dbContext.SaveChangesAsync(ct);
-
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationCaseId is null)
-            return NotFound(new ProblemDetails { Title = "Remediation context not found." });
-
-        var context = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
+        var context = await queryService.BuildByCaseIdAsync(tenantId, caseId, false, ct);
         if (context is null)
             return NotFound(new ProblemDetails { Title = "Remediation context not found." });
 
@@ -480,24 +445,20 @@ public class RemediationDecisionsController(
     [HttpGet("audit-trail")]
     [Authorize(Policy = Policies.ViewVulnerabilities)]
     public async Task<ActionResult<List<ApprovalAuditEntryDto>>> GetAuditTrail(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationCaseId is null)
-            return Ok(new List<ApprovalAuditEntryDto>());
-
         var decisionIds = await dbContext.RemediationDecisions.AsNoTracking()
-            .Where(decision => decision.TenantId == tenantId && decision.RemediationCaseId == remediationCaseId.Value)
+            .Where(decision => decision.TenantId == tenantId && decision.RemediationCaseId == caseId)
             .Select(decision => decision.Id)
             .ToListAsync(ct);
 
         var workflowIds = await dbContext.RemediationWorkflows.AsNoTracking()
-            .Where(workflow => workflow.TenantId == tenantId && workflow.RemediationCaseId == remediationCaseId.Value)
+            .Where(workflow => workflow.TenantId == tenantId && workflow.RemediationCaseId == caseId)
             .Select(workflow => workflow.Id)
             .ToListAsync(ct);
 
@@ -536,36 +497,6 @@ public class RemediationDecisionsController(
 
         return Ok(dtos);
     }
-
-    /// <summary>
-    /// Resolves a RemediationCase ID from a TenantSoftware ID by joining through
-    /// NormalizedSoftware.CanonicalProductKey → SoftwareProduct.CanonicalProductKey.
-    /// Returns null if no matching RemediationCase exists.
-    /// </summary>
-    private async Task<Guid?> ResolveCaseIdAsync(Guid tenantId, Guid tenantSoftwareId, CancellationToken ct)
-    {
-        var canonicalKey = await dbContext.TenantSoftware.AsNoTracking()
-            .Where(ts => ts.TenantId == tenantId && ts.Id == tenantSoftwareId)
-            .Join(dbContext.NormalizedSoftware.AsNoTracking(),
-                ts => ts.NormalizedSoftwareId,
-                ns => ns.Id,
-                (ts, ns) => ns.CanonicalProductKey)
-            .FirstOrDefaultAsync(ct);
-
-        if (canonicalKey is null)
-            return null;
-
-        return await dbContext.RemediationCases.AsNoTracking()
-            .Where(rc => rc.TenantId == tenantId)
-            .Join(dbContext.SoftwareProducts.AsNoTracking(),
-                rc => rc.SoftwareProductId,
-                sp => sp.Id,
-                (rc, sp) => new { rc.Id, sp.CanonicalProductKey })
-            .Where(x => x.CanonicalProductKey == canonicalKey)
-            .Select(x => (Guid?)x.Id)
-            .FirstOrDefaultAsync(ct);
-    }
-
     private async Task EnqueueAiDraftsAsync(Guid tenantId, Guid remediationCaseId, CancellationToken ct)
     {
         await remediationAiJobService.EnqueueAsync(tenantId, remediationCaseId, string.Empty, ct);

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -38,7 +38,11 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var result = await queryService.BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, false, ct);
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is null)
+            return NotFound();
+
+        var result = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
         if (result is null)
             return NotFound();
 
@@ -55,13 +59,17 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is null)
+            return NotFound(new ProblemDetails { Title = "Remediation case not found for this software." });
+
         var workflow = await workflowService.GetOrCreateActiveWorkflowAsync(
             tenantId,
-            tenantSoftwareId,
+            remediationCaseId.Value,
             ct
         );
         await dbContext.SaveChangesAsync(ct);
-        await EnqueueAiDraftsAsync(tenantId, tenantSoftwareId, ct);
+        await EnqueueAiDraftsAsync(tenantId, remediationCaseId.Value, ct);
         return Ok(new EnsureRemediationWorkflowResponse(workflow.Id));
     }
 
@@ -82,7 +90,7 @@ public class RemediationDecisionsController(
 
         var result = await decisionService.AddVulnerabilityOverrideAsync(
             decisionId,
-            request.TenantVulnerabilityId,
+            request.VulnerabilityId,
             outcome,
             request.Justification,
             ct
@@ -91,10 +99,12 @@ public class RemediationDecisionsController(
         if (!result.IsSuccess)
             return BadRequest(new ProblemDetails { Title = result.Error });
 
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
         var vo = result.Value;
-        await EnqueueAiDraftsAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is not null)
+            await EnqueueAiDraftsAsync(tenantId, remediationCaseId.Value, ct);
         return Created("", new VulnerabilityOverrideDto(
-            vo.Id, vo.TenantVulnerabilityId, vo.Outcome.ToString(), vo.Justification, vo.CreatedAt
+            vo.Id, vo.VulnerabilityId, vo.Outcome.ToString(), vo.Justification, vo.CreatedAt
         ));
     }
 
@@ -108,7 +118,11 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var context = await queryService.BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, false, ct);
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is null)
+            return NotFound();
+
+        var context = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
         if (context is null)
             return NotFound();
 
@@ -131,7 +145,7 @@ public class RemediationDecisionsController(
         if (workflow is null)
             return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
 
-        var auth = await workflowAuthorizationService.EnsureCanAddRecommendationAsync(tenantId, workflow.TenantSoftwareId, ct);
+        var auth = await workflowAuthorizationService.EnsureCanAddRecommendationAsync(tenantId, workflow.RemediationCaseId, ct);
         if (!auth.IsSuccess)
             return BadRequest(new ProblemDetails { Title = auth.Error });
 
@@ -139,13 +153,13 @@ public class RemediationDecisionsController(
             return BadRequest(new ProblemDetails { Title = "Invalid outcome value." });
 
         var userId = tenantContext.CurrentUserId;
-        var result = await recommendationService.AddRecommendationForTenantSoftwareAsync(
+        var result = await recommendationService.AddRecommendationForCaseAsync(
             tenantId,
-            workflow.TenantSoftwareId,
+            workflow.RemediationCaseId,
             outcome,
             request.Rationale,
             userId,
-            request.TenantVulnerabilityId,
+            request.VulnerabilityId,
             request.PriorityOverride,
             ct
         );
@@ -159,9 +173,9 @@ public class RemediationDecisionsController(
             .FirstOrDefaultAsync(ct);
 
         var r = result.Value;
-        await EnqueueAiDraftsAsync(tenantId, workflow.TenantSoftwareId, ct);
+        await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
         return Created("", new AnalystRecommendationDto(
-            r.Id, r.TenantVulnerabilityId, r.RecommendedOutcome.ToString(),
+            r.Id, r.VulnerabilityId, r.RecommendedOutcome.ToString(),
             r.Rationale, r.PriorityOverride, r.AnalystId, analystDisplayName, r.CreatedAt
         ));
     }
@@ -215,7 +229,7 @@ public class RemediationDecisionsController(
             if (!verificationResult.IsSuccess)
                 return BadRequest(new ProblemDetails { Title = verificationResult.Error });
 
-            await EnqueueAiDraftsAsync(tenantId, workflow.TenantSoftwareId, ct);
+            await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
             return Ok();
         }
 
@@ -230,7 +244,7 @@ public class RemediationDecisionsController(
             if (!verificationResult.IsSuccess)
                 return BadRequest(new ProblemDetails { Title = verificationResult.Error });
 
-            await EnqueueAiDraftsAsync(tenantId, workflow.TenantSoftwareId, ct);
+            await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
             return Ok();
         }
 
@@ -253,16 +267,16 @@ public class RemediationDecisionsController(
         if (workflow is null)
             return NotFound(new ProblemDetails { Title = "Remediation workflow not found." });
 
-        var auth = await workflowAuthorizationService.EnsureCanCreateDecisionAsync(tenantId, workflow.TenantSoftwareId, ct);
+        var auth = await workflowAuthorizationService.EnsureCanCreateDecisionAsync(tenantId, workflow.RemediationCaseId, ct);
         if (!auth.IsSuccess)
             return BadRequest(new ProblemDetails { Title = auth.Error });
 
         if (!Enum.TryParse<RemediationOutcome>(request.Outcome, true, out var outcome))
             return BadRequest(new ProblemDetails { Title = "Invalid outcome value." });
 
-        var result = await decisionService.CreateDecisionForTenantSoftwareAsync(
+        var result = await decisionService.CreateDecisionForCaseAsync(
             tenantId,
-            workflow.TenantSoftwareId,
+            workflow.RemediationCaseId,
             outcome,
             request.Justification,
             tenantContext.CurrentUserId,
@@ -275,7 +289,7 @@ public class RemediationDecisionsController(
             return BadRequest(new ProblemDetails { Title = result.Error });
 
         var d = result.Value;
-        await EnqueueAiDraftsAsync(tenantId, workflow.TenantSoftwareId, ct);
+        await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
         return Created("", new RemediationDecisionDto(
             d.Id, d.Outcome.ToString(), d.ApprovalStatus.ToString(),
             d.Justification, d.DecidedBy, d.DecidedAt,
@@ -346,7 +360,7 @@ public class RemediationDecisionsController(
                 return BadRequest(new ProblemDetails { Title = "Action must be 'approve' or 'deny'." });
             }
 
-            await EnqueueAiDraftsAsync(tenantId, workflow.TenantSoftwareId, ct);
+            await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
             return Ok();
         }
         catch (InvalidOperationException ex)
@@ -384,7 +398,7 @@ public class RemediationDecisionsController(
         if (!result.IsSuccess)
             return BadRequest(new ProblemDetails { Title = result.Error });
 
-        await EnqueueAiDraftsAsync(tenantId, workflow.TenantSoftwareId, ct);
+        await EnqueueAiDraftsAsync(tenantId, workflow.RemediationCaseId, ct);
         return Ok();
     }
 
@@ -398,8 +412,12 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        await EnqueueAiDraftsAsync(tenantId, tenantSoftwareId, ct);
-        var context = await queryService.BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, false, ct);
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is null)
+            return NotFound(new ProblemDetails { Title = "Remediation case not found for this software." });
+
+        await EnqueueAiDraftsAsync(tenantId, remediationCaseId.Value, ct);
+        var context = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
         if (context is null)
             return NotFound(new ProblemDetails { Title = "Remediation context not found." });
 
@@ -425,6 +443,7 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
+        // TenantSoftware still exists as snapshot-versioned table; AI review state lives there for now (TODO Phase 5)
         var tenantSoftware = await dbContext.TenantSoftware
             .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == tenantSoftwareId, ct);
         if (tenantSoftware is null)
@@ -447,7 +466,11 @@ public class RemediationDecisionsController(
         tenantSoftware.MarkRemediationAiReviewed(reviewStatus, tenantContext.CurrentUserId);
         await dbContext.SaveChangesAsync(ct);
 
-        var context = await queryService.BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, false, ct);
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is null)
+            return NotFound(new ProblemDetails { Title = "Remediation context not found." });
+
+        var context = await queryService.BuildByCaseIdAsync(tenantId, remediationCaseId.Value, false, ct);
         if (context is null)
             return NotFound(new ProblemDetails { Title = "Remediation context not found." });
 
@@ -464,13 +487,17 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
+        var remediationCaseId = await ResolveCaseIdAsync(tenantId, tenantSoftwareId, ct);
+        if (remediationCaseId is null)
+            return Ok(new List<ApprovalAuditEntryDto>());
+
         var decisionIds = await dbContext.RemediationDecisions.AsNoTracking()
-            .Where(decision => decision.TenantId == tenantId && decision.TenantSoftwareId == tenantSoftwareId)
+            .Where(decision => decision.TenantId == tenantId && decision.RemediationCaseId == remediationCaseId.Value)
             .Select(decision => decision.Id)
             .ToListAsync(ct);
 
         var workflowIds = await dbContext.RemediationWorkflows.AsNoTracking()
-            .Where(workflow => workflow.TenantId == tenantId && workflow.TenantSoftwareId == tenantSoftwareId)
+            .Where(workflow => workflow.TenantId == tenantId && workflow.RemediationCaseId == remediationCaseId.Value)
             .Select(workflow => workflow.Id)
             .ToListAsync(ct);
 
@@ -510,8 +537,37 @@ public class RemediationDecisionsController(
         return Ok(dtos);
     }
 
-    private async Task EnqueueAiDraftsAsync(Guid tenantId, Guid tenantSoftwareId, CancellationToken ct)
+    /// <summary>
+    /// Resolves a RemediationCase ID from a TenantSoftware ID by joining through
+    /// NormalizedSoftware.CanonicalProductKey → SoftwareProduct.CanonicalProductKey.
+    /// Returns null if no matching RemediationCase exists.
+    /// </summary>
+    private async Task<Guid?> ResolveCaseIdAsync(Guid tenantId, Guid tenantSoftwareId, CancellationToken ct)
     {
-        await remediationAiJobService.EnqueueAsync(tenantId, tenantSoftwareId, string.Empty, ct);
+        var canonicalKey = await dbContext.TenantSoftware.AsNoTracking()
+            .Where(ts => ts.TenantId == tenantId && ts.Id == tenantSoftwareId)
+            .Join(dbContext.NormalizedSoftware.AsNoTracking(),
+                ts => ts.NormalizedSoftwareId,
+                ns => ns.Id,
+                (ts, ns) => ns.CanonicalProductKey)
+            .FirstOrDefaultAsync(ct);
+
+        if (canonicalKey is null)
+            return null;
+
+        return await dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId)
+            .Join(dbContext.SoftwareProducts.AsNoTracking(),
+                rc => rc.SoftwareProductId,
+                sp => sp.Id,
+                (rc, sp) => new { rc.Id, sp.CanonicalProductKey })
+            .Where(x => x.CanonicalProductKey == canonicalKey)
+            .Select(x => (Guid?)x.Id)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    private async Task EnqueueAiDraftsAsync(Guid tenantId, Guid remediationCaseId, CancellationToken ct)
+    {
+        await remediationAiJobService.EnqueueAsync(tenantId, remediationCaseId, string.Empty, ct);
     }
 }

--- a/src/PatchHound.Api/Controllers/RemediationTasksController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationTasksController.cs
@@ -39,10 +39,10 @@ public class RemediationTasksController(
         return Ok(result);
     }
 
-    [HttpGet("software/{tenantSoftwareId:guid}/team-statuses")]
+    [HttpGet("cases/{caseId:guid}/team-statuses")]
     [Authorize(Policy = Policies.ViewVulnerabilities)]
     public async Task<ActionResult<List<RemediationTaskTeamStatusDto>>> GetTeamStatusesForSoftware(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
@@ -53,17 +53,17 @@ public class RemediationTasksController(
 
         var result = await remediationTaskQueryService.ListTeamStatusesForSoftwareAsync(
             tenantId,
-            tenantSoftwareId,
+            caseId,
             ct
         );
 
         return Ok(result);
     }
 
-    [HttpPost("software/{tenantSoftwareId:guid}")]
+    [HttpPost("cases/{caseId:guid}")]
     [Authorize(Policy = Policies.AssignTasks)]
     public async Task<ActionResult<RemediationTaskCreateResultDto>> CreateForSoftware(
-        Guid tenantSoftwareId,
+        Guid caseId,
         CancellationToken ct
     )
     {
@@ -79,7 +79,7 @@ public class RemediationTasksController(
 
         var result = await remediationTaskQueryService.CreateMissingTasksForSoftwareAsync(
             tenantId,
-            tenantSoftwareId,
+            caseId,
             tenantContext.CurrentUserId,
             ct
         );

--- a/src/PatchHound.Api/Controllers/SoftwareController.cs
+++ b/src/PatchHound.Api/Controllers/SoftwareController.cs
@@ -306,7 +306,7 @@ public class SoftwareController(
         return Ok(
             new TenantSoftwareDescriptionJobDto(
                 result.Value.Id,
-                result.Value.TenantSoftwareId,
+                result.Value.SoftwareProductId,
                 result.Value.Status.ToString(),
                 string.IsNullOrWhiteSpace(result.Value.Error) ? null : result.Value.Error,
                 result.Value.RequestedAt,
@@ -337,7 +337,7 @@ public class SoftwareController(
         return Ok(
             new TenantSoftwareDescriptionJobDto(
                 job.Id,
-                job.TenantSoftwareId,
+                job.SoftwareProductId,
                 job.Status.ToString(),
                 string.IsNullOrWhiteSpace(job.Error) ? null : job.Error,
                 job.RequestedAt,
@@ -394,18 +394,10 @@ public class SoftwareController(
 
         if (filter.MissedMaintenanceWindow == true)
         {
-            var now = DateTimeOffset.UtcNow;
-            // Phase-2: NormalizedSoftwareVulnerabilityProjection deleted — filter returns no results.
-            query = query.Where(item =>
-                dbContext.RemediationDecisions.Any(decision =>
-                    decision.TenantId == currentTenantId
-                    && decision.TenantSoftwareId == item.Id
-                    && decision.MaintenanceWindowDate != null
-                    && decision.MaintenanceWindowDate < now
-                    && decision.ApprovalStatus != DecisionApprovalStatus.Rejected
-                    && decision.ApprovalStatus != DecisionApprovalStatus.Expired)
-                && false
-            );
+            // Phase 4 (#17): RemediationDecision no longer has TenantSoftwareId.
+            // MissedMaintenanceWindow filter stubbed — always returns no results.
+            // TODO Phase 5: re-implement via RemediationCase join.
+            query = query.Where(_ => false);
         }
 
         var totalCount = await query.CountAsync(ct);
@@ -461,15 +453,9 @@ public class SoftwareController(
                     )
                     .Select(installation => (DateTimeOffset?)installation.LastSeenAt)
                     .Max(),
-                MaintenanceWindowDate = dbContext.RemediationDecisions
-                    .Where(decision =>
-                        decision.TenantId == currentTenantId
-                        && decision.TenantSoftwareId == item.Id
-                        && decision.ApprovalStatus != DecisionApprovalStatus.Rejected
-                        && decision.ApprovalStatus != DecisionApprovalStatus.Expired)
-                    .OrderByDescending(decision => decision.DecidedAt)
-                    .Select(decision => decision.MaintenanceWindowDate)
-                    .FirstOrDefault(),
+                // Phase 4 (#17): RemediationDecision no longer has TenantSoftwareId.
+                // TODO Phase 5: re-implement via RemediationCase join (TenantSoftware → NormalizedSoftware.CanonicalProductKey → SoftwareProduct → RemediationCase).
+                MaintenanceWindowDate = (DateTimeOffset?)null,
                 ExposureImpactScore = dbContext
                     .NormalizedSoftwareInstallations
                     .Where(installation =>

--- a/src/PatchHound.Api/Controllers/SoftwareController.cs
+++ b/src/PatchHound.Api/Controllers/SoftwareController.cs
@@ -71,6 +71,7 @@ public class SoftwareController(
                 item.Id,
                 item.TenantId,
                 item.NormalizedSoftwareId,
+                item.NormalizedSoftware.CanonicalProductKey,
                 item.FirstSeenAt,
                 item.LastSeenAt,
                 item.NormalizedSoftware.CanonicalName,
@@ -103,6 +104,11 @@ public class SoftwareController(
         {
             return NotFound();
         }
+
+        var softwareProductId = await dbContext.SoftwareProducts.AsNoTracking()
+            .Where(item => item.CanonicalProductKey == tenantSoftware.CanonicalProductKey)
+            .Select(item => (Guid?)item.Id)
+            .FirstOrDefaultAsync(ct);
 
         var installations = await dbContext
             .NormalizedSoftwareInstallations.AsNoTracking()
@@ -167,6 +173,7 @@ public class SoftwareController(
             new TenantSoftwareDetailDto(
                 tenantSoftware.Id,
                 tenantSoftware.NormalizedSoftwareId,
+                softwareProductId,
                 softwareAssetIds.FirstOrDefault() is var primaryAssetId && primaryAssetId != Guid.Empty ? primaryAssetId : null,
                 tenantSoftware.CanonicalName,
                 tenantSoftware.CanonicalVendor,
@@ -406,6 +413,7 @@ public class SoftwareController(
             {
                 item.Id,
                 item.NormalizedSoftwareId,
+                CanonicalProductKey = item.NormalizedSoftware.CanonicalProductKey,
                 CanonicalName = item.NormalizedSoftware.CanonicalName,
                 CanonicalVendor = item.NormalizedSoftware.CanonicalVendor,
                 Category = item.NormalizedSoftware.Category,
@@ -475,17 +483,29 @@ public class SoftwareController(
             .Take(pagination.BoundedPageSize)
             .ToListAsync(ct);
 
+        var canonicalProductKeys = rows
+            .Select(item => item.CanonicalProductKey)
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Distinct()
+            .ToList();
+        var softwareProductIdsByKey = canonicalProductKeys.Count == 0
+            ? new Dictionary<string, Guid>()
+            : await dbContext.SoftwareProducts.AsNoTracking()
+                .Where(item => canonicalProductKeys.Contains(item.CanonicalProductKey))
+                .ToDictionaryAsync(item => item.CanonicalProductKey, item => item.Id, ct);
+
         return Ok(
             new PagedResponse<TenantSoftwareListItemDto>(
                 rows
                     .Select(item => new TenantSoftwareListItemDto(
-                    item.Id,
-                    item.NormalizedSoftwareId,
-                    item.CanonicalName,
-                    item.CanonicalVendor,
-                    item.Category,
-                    item.CurrentRiskScore,
-                    item.ActiveInstallCount,
+                        item.Id,
+                        item.NormalizedSoftwareId,
+                        softwareProductIdsByKey.GetValueOrDefault(item.CanonicalProductKey),
+                        item.CanonicalName,
+                        item.CanonicalVendor,
+                        item.Category,
+                        item.CurrentRiskScore,
+                        item.ActiveInstallCount,
                         item.UniqueDeviceCount,
                         item.ActiveVulnerabilityCount,
                         item.VersionCount,

--- a/src/PatchHound.Api/Models/ApprovalTasks/ApprovalTaskDtos.cs
+++ b/src/PatchHound.Api/Models/ApprovalTasks/ApprovalTaskDtos.cs
@@ -53,7 +53,7 @@ public record PagedVulnerabilityList(
 );
 
 public record ApprovalVulnDto(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string ExternalId,
     string Title,
     string VendorSeverity,

--- a/src/PatchHound.Api/Models/Assets/AssetDto.cs
+++ b/src/PatchHound.Api/Models/Assets/AssetDto.cs
@@ -125,7 +125,7 @@ public record AssetRiskExplanationFactorDto(
 );
 
 public record AssetRiskDriverDto(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string ExternalId,
     string Title,
     string RiskBand,

--- a/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
+++ b/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
@@ -180,7 +180,7 @@ public record OwnerActionDto(
 public record ApprovalAttentionTaskDto(
     Guid ApprovalTaskId,
     Guid RemediationDecisionId,
-    Guid TenantSoftwareId,
+    Guid RemediationCaseId,
     string SoftwareName,
     string ApprovalType,
     string HighestSeverity,
@@ -193,7 +193,7 @@ public record ApprovalAttentionTaskDto(
 
 public record ApprovedPolicyDecisionDto(
     Guid DecisionId,
-    Guid TenantSoftwareId,
+    Guid RemediationCaseId,
     string SoftwareName,
     string Outcome,
     string? Justification,
@@ -211,7 +211,7 @@ public record SecurityManagerDashboardSummaryDto(
 public record ApprovedPatchingTaskDto(
     Guid PatchingTaskId,
     Guid RemediationDecisionId,
-    Guid TenantSoftwareId,
+    Guid RemediationCaseId,
     string SoftwareName,
     string OwnerTeamName,
     string HighestSeverity,

--- a/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
+++ b/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
@@ -69,7 +69,7 @@ public record DashboardRiskChangeBriefDto(
 );
 
 public record DashboardRiskChangeItemDto(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string ExternalId,
     string Title,
     string Severity,
@@ -162,7 +162,7 @@ public record OwnerAssetSummaryDto(
 
 public record OwnerActionDto(
     Guid TenantSoftwareId,
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     Guid? TaskId,
     string SoftwareName,
     string OwnerTeamName,

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -123,7 +123,7 @@ public record AnalystRecommendationDto(
 );
 
 public record DecisionVulnDto(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     Guid VulnerabilityDefinitionId,
     string ExternalId,
     string Title,

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -1,7 +1,7 @@
 namespace PatchHound.Api.Models.Decisions;
 
 public record DecisionContextDto(
-    Guid TenantSoftwareId,
+    Guid RemediationCaseId,
     string SoftwareName,
     string Criticality,
     DecisionSummaryDto Summary,
@@ -105,7 +105,7 @@ public record DecisionRejectionDto(
 
 public record VulnerabilityOverrideDto(
     Guid Id,
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string Outcome,
     string Justification,
     DateTimeOffset CreatedAt
@@ -113,7 +113,7 @@ public record VulnerabilityOverrideDto(
 
 public record AnalystRecommendationDto(
     Guid Id,
-    Guid? TenantVulnerabilityId,
+    Guid? VulnerabilityId,
     string RecommendedOutcome,
     string Rationale,
     string? PriorityOverride,
@@ -164,7 +164,7 @@ public record CreateDecisionRequest(
 );
 
 public record CreateOverrideRequest(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string Outcome,
     string Justification
 );
@@ -173,7 +173,7 @@ public record CreateRecommendationRequest(
     string RecommendedOutcome,
     string Rationale,
     string? PriorityOverride,
-    Guid? TenantVulnerabilityId
+    Guid? VulnerabilityId
 );
 
 public record VerifyRemediationRequest(

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionListItemDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionListItemDto.cs
@@ -1,7 +1,7 @@
 namespace PatchHound.Api.Models.Decisions;
 
 public record RemediationDecisionListItemDto(
-    Guid TenantSoftwareId,
+    Guid RemediationCaseId,
     string SoftwareName,
     string Criticality,
     string? Outcome,

--- a/src/PatchHound.Api/Models/Remediation/RemediationCaseDto.cs
+++ b/src/PatchHound.Api/Models/Remediation/RemediationCaseDto.cs
@@ -1,0 +1,14 @@
+namespace PatchHound.Api.Models.Remediation;
+
+public record RemediationCaseDto(
+    Guid Id,
+    Guid TenantId,
+    Guid SoftwareProductId,
+    string ProductName,
+    string Vendor,
+    string Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    DateTimeOffset? ClosedAt,
+    int AffectedDeviceCount,
+    int OpenExposureCount);

--- a/src/PatchHound.Api/Models/Remediation/RemediationTaskDtos.cs
+++ b/src/PatchHound.Api/Models/Remediation/RemediationTaskDtos.cs
@@ -10,8 +10,7 @@ public record RemediationTaskSummaryDto(
 
 public record RemediationTaskListItemDto(
     Guid Id,
-    Guid SoftwareAssetId,
-    Guid? TenantSoftwareId,
+    Guid RemediationCaseId,
     string SoftwareName,
     string? SoftwareVendor,
     Guid OwnerTeamId,
@@ -50,5 +49,5 @@ public record RemediationTaskFilterQuery(
     string? AssetOwner = null,
     Guid? TaskId = null,
     Guid? DeviceAssetId = null,
-    Guid? TenantSoftwareId = null
+    Guid? CaseId = null
 );

--- a/src/PatchHound.Api/Models/RiskScore/RiskScoreDtos.cs
+++ b/src/PatchHound.Api/Models/RiskScore/RiskScoreDtos.cs
@@ -24,7 +24,7 @@ public record AssetRiskScoreSummaryDto(
 );
 
 public record AssetRiskEpisodeDriverDto(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string ExternalId,
     string Title,
     string RiskBand,

--- a/src/PatchHound.Api/Models/Software/TenantSoftwareDescriptionJobDto.cs
+++ b/src/PatchHound.Api/Models/Software/TenantSoftwareDescriptionJobDto.cs
@@ -2,7 +2,7 @@ namespace PatchHound.Api.Models.Software;
 
 public record TenantSoftwareDescriptionJobDto(
     Guid Id,
-    Guid TenantSoftwareId,
+    Guid SoftwareProductId,
     string Status,
     string? Error,
     DateTimeOffset RequestedAt,

--- a/src/PatchHound.Api/Models/Software/TenantSoftwareDetailDto.cs
+++ b/src/PatchHound.Api/Models/Software/TenantSoftwareDetailDto.cs
@@ -5,6 +5,7 @@ namespace PatchHound.Api.Models.Software;
 public record TenantSoftwareDetailDto(
     Guid Id,
     Guid NormalizedSoftwareId,
+    Guid? SoftwareProductId,
     Guid? PrimarySoftwareAssetId,
     string CanonicalName,
     string? CanonicalVendor,

--- a/src/PatchHound.Api/Models/Software/TenantSoftwareDetailDto.cs
+++ b/src/PatchHound.Api/Models/Software/TenantSoftwareDetailDto.cs
@@ -107,7 +107,7 @@ public record TenantSoftwareInstallationDto(
 );
 
 public record TenantSoftwareVulnerabilityDto(
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     Guid VulnerabilityDefinitionId,
     string ExternalId,
     string Title,

--- a/src/PatchHound.Api/Models/Software/TenantSoftwareListDto.cs
+++ b/src/PatchHound.Api/Models/Software/TenantSoftwareListDto.cs
@@ -3,6 +3,7 @@ namespace PatchHound.Api.Models.Software;
 public record TenantSoftwareListItemDto(
     Guid Id,
     Guid NormalizedSoftwareId,
+    Guid? SoftwareProductId,
     string CanonicalName,
     string? CanonicalVendor,
     string? Category,

--- a/src/PatchHound.Api/Models/Vulnerabilities/AiReportDto.cs
+++ b/src/PatchHound.Api/Models/Vulnerabilities/AiReportDto.cs
@@ -2,7 +2,7 @@ namespace PatchHound.Api.Models.Vulnerabilities;
 
 public record AiReportDto(
     Guid Id,
-    Guid TenantVulnerabilityId,
+    Guid VulnerabilityId,
     string Content,
     string ProviderType,
     string ProfileName,

--- a/src/PatchHound.Api/Services/ApprovalTaskQueryService.cs
+++ b/src/PatchHound.Api/Services/ApprovalTaskQueryService.cs
@@ -23,7 +23,6 @@ public class ApprovalTaskQueryService(
         var query = dbContext.ApprovalTasks.AsNoTracking()
             .Include(at => at.VisibleRoles)
             .Include(at => at.RemediationDecision)
-                .ThenInclude(rd => rd.SoftwareAsset)
             .Where(at => at.TenantId == tenantId)
             .Where(at => at.VisibleRoles.Any(role => roleNames.Contains(role.Role)));
 
@@ -49,19 +48,21 @@ public class ApprovalTaskQueryService(
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
             var term = filter.Search.Trim().ToLower();
-            var matchingTenantSoftwareIds = await dbContext.TenantSoftware.AsNoTracking()
-                .Where(item =>
-                    item.TenantId == tenantId
-                    && (
-                        item.NormalizedSoftware.CanonicalName.ToLower().Contains(term)
-                        || (item.NormalizedSoftware.CanonicalVendor != null
-                            && item.NormalizedSoftware.CanonicalVendor.ToLower().Contains(term))
-                    ))
-                .Select(item => item.Id)
+            // Search via RemediationCase → SoftwareProduct
+            var matchingCaseIds = await dbContext.RemediationCases.AsNoTracking()
+                .Where(rc => rc.TenantId == tenantId)
+                .Join(dbContext.SoftwareProducts.AsNoTracking(),
+                    rc => rc.SoftwareProductId,
+                    sp => sp.Id,
+                    (rc, sp) => new { rc.Id, sp.Name, sp.Vendor })
+                .Where(x =>
+                    x.Name.ToLower().Contains(term)
+                    || (x.Vendor != null && x.Vendor.ToLower().Contains(term)))
+                .Select(x => x.Id)
                 .ToListAsync(ct);
 
             query = query.Where(at =>
-                matchingTenantSoftwareIds.Contains(at.RemediationDecision.TenantSoftwareId));
+                matchingCaseIds.Contains(at.RemediationDecision.RemediationCaseId));
         }
 
         var totalCount = await query.CountAsync(ct);
@@ -73,17 +74,12 @@ public class ApprovalTaskQueryService(
             .Take(pagination.BoundedPageSize)
             .ToListAsync(ct);
 
-        // Resolve highest severity per decision's software asset
-        var tenantSoftwareIds = tasks.Select(t => t.RemediationDecision.TenantSoftwareId).Distinct().ToList();
-        var softwareNames = await GetSoftwareNamesAsync(tenantId, tenantSoftwareIds, ct);
-        var highestSeverities = await GetHighestSeveritiesAsync(tenantId, tenantSoftwareIds, ct);
-        var highestCriticalities = await GetHighestCriticalitiesAsync(tenantId, tenantSoftwareIds, ct);
-
-        // Vulnerability counts
-        var vulnCounts = await GetVulnCountsAsync(tenantId, tenantSoftwareIds, ct);
-
-        // SLA info
-        var slaInfo = await GetSlaInfoAsync(tenantId, tenantSoftwareIds, ct);
+        var caseIds = tasks.Select(t => t.RemediationDecision.RemediationCaseId).Distinct().ToList();
+        var softwareNames = await GetSoftwareNamesAsync(tenantId, caseIds, ct);
+        var highestSeverities = await GetHighestSeveritiesAsync(tenantId, caseIds, ct);
+        var highestCriticalities = await GetHighestCriticalitiesAsync(tenantId, caseIds, ct);
+        var vulnCounts = await GetVulnCountsAsync(tenantId, caseIds, ct);
+        var slaInfo = await GetSlaInfoAsync(tenantId, caseIds, ct);
 
         // Decided-by user names
         var decidedByIds = tasks.Select(t => t.RemediationDecision.DecidedBy).Distinct().ToList();
@@ -93,20 +89,20 @@ public class ApprovalTaskQueryService(
 
         var items = tasks.Select(t =>
         {
-            var tenantSoftwareId = t.RemediationDecision.TenantSoftwareId;
-            softwareNames.TryGetValue(tenantSoftwareId, out var softwareName);
-            var hasSeverity = highestSeverities.TryGetValue(tenantSoftwareId, out var severity);
-            var hasCriticality = highestCriticalities.TryGetValue(tenantSoftwareId, out var criticality);
-            vulnCounts.TryGetValue(tenantSoftwareId, out var vc);
-            var hasSla = slaInfo.TryGetValue(tenantSoftwareId, out var sla);
+            var caseId = t.RemediationDecision.RemediationCaseId;
+            softwareNames.TryGetValue(caseId, out var softwareName);
+            var hasSeverity = highestSeverities.TryGetValue(caseId, out var severity);
+            var hasCriticality = highestCriticalities.TryGetValue(caseId, out var criticality);
+            vulnCounts.TryGetValue(caseId, out var vc);
+            var hasSla = slaInfo.TryGetValue(caseId, out var sla);
             userNames.TryGetValue(t.RemediationDecision.DecidedBy, out var decidedByName);
 
             return new ApprovalTaskListItemDto(
                 t.Id,
                 t.Type.ToString(),
                 t.Status.ToString(),
-                ResolveDisplaySoftwareName(softwareName, t.RemediationDecision.SoftwareAsset.Name),
-                hasCriticality ? criticality.ToString() : t.RemediationDecision.SoftwareAsset.Criticality.ToString(),
+                softwareName ?? "Unknown software",
+                hasCriticality ? criticality.ToString() : "Unknown",
                 t.RemediationDecision.Outcome.ToString(),
                 hasSeverity ? severity.ToString() : "Unknown",
                 vc,
@@ -137,7 +133,6 @@ public class ApprovalTaskQueryService(
         var task = await dbContext.ApprovalTasks.AsNoTracking()
             .Include(at => at.VisibleRoles)
             .Include(at => at.RemediationDecision)
-                .ThenInclude(rd => rd.SoftwareAsset)
             .FirstOrDefaultAsync(at =>
                 at.Id == approvalTaskId
                 && at.TenantId == tenantId
@@ -147,138 +142,49 @@ public class ApprovalTaskQueryService(
         if (task is null) return null;
 
         var decision = task.RemediationDecision;
-        var assetId = decision.SoftwareAssetId;
-        var tenantSoftwareId = decision.TenantSoftwareId;
-        var softwareNames = await GetSoftwareNamesAsync(tenantId, [tenantSoftwareId], ct);
-        softwareNames.TryGetValue(tenantSoftwareId, out var softwareName);
+        var remediationCaseId = decision.RemediationCaseId;
+
+        var softwareNames = await GetSoftwareNamesAsync(tenantId, [remediationCaseId], ct);
+        softwareNames.TryGetValue(remediationCaseId, out var softwareName);
 
         // Highest severity
-        var highestSeverities = await GetHighestSeveritiesAsync(tenantId, [tenantSoftwareId], ct);
-        var hasHighestSeverity = highestSeverities.TryGetValue(tenantSoftwareId, out var highestSeverity);
-        var highestCriticalities = await GetHighestCriticalitiesAsync(tenantId, [tenantSoftwareId], ct);
-        var hasHighestCriticality = highestCriticalities.TryGetValue(tenantSoftwareId, out var highestCriticality);
+        var highestSeverities = await GetHighestSeveritiesAsync(tenantId, [remediationCaseId], ct);
+        var hasHighestSeverity = highestSeverities.TryGetValue(remediationCaseId, out var highestSeverity);
+        var highestCriticalities = await GetHighestCriticalitiesAsync(tenantId, [remediationCaseId], ct);
+        var hasHighestCriticality = highestCriticalities.TryGetValue(remediationCaseId, out var highestCriticality);
 
         // SLA
-        var slaInfo = await GetSlaInfoAsync(tenantId, [tenantSoftwareId], ct);
-        var hasSla = slaInfo.TryGetValue(tenantSoftwareId, out var sla);
+        var slaInfo = await GetSlaInfoAsync(tenantId, [remediationCaseId], ct);
+        var hasSla = slaInfo.TryGetValue(remediationCaseId, out var sla);
 
-        // Risk score
+        // Risk score — TODO Phase 5 (#17): re-implement via RemediationCase risk model
         double? riskScore = null;
         string? riskBand = null;
-        if (tenantSoftwareId != Guid.Empty)
-        {
-            var risk = await dbContext.TenantSoftwareRiskScores.AsNoTracking()
-                .FirstOrDefaultAsync(r => r.TenantSoftwareId == tenantSoftwareId && r.TenantId == tenantId, ct);
-            if (risk is not null)
-            {
-                riskScore = (double)risk.OverallScore;
-                riskBand = risk.OverallScore switch
-                {
-                    >= 900m => "Critical",
-                    >= 750m => "High",
-                    >= 500m => "Medium",
-                    > 0m => "Low",
-                    _ => "None",
-                };
-            }
-        }
 
         // Decided-by name
         var decidedByUser = await dbContext.Users.AsNoTracking()
             .FirstOrDefaultAsync(u => u.Id == decision.DecidedBy, ct);
 
-        // Vulnerabilities (paginated, sorted by severity)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition + TenantVulnerability removed by canonical cleanup; remediation-surface rewrite restores this.
+        // Vulnerabilities — Phase 4 debt (#17): SoftwareVulnerabilityMatch removed by canonical cleanup
         var vulnList = new PagedVulnerabilityList([], 0, vulnPagination.Page, vulnPagination.BoundedPageSize);
 
-        // Devices in scope for the approval's software scope
+        // Devices in scope — Phase 4 debt (#17): still uses TenantSoftwareId on NormalizedSoftwareInstallations
+        // We derive tenantSoftwareId by joining RemediationCase → SoftwareProduct → NormalizedSoftware via CanonicalProductKey
         var deviceVersionCohorts = new List<ApprovalDeviceVersionCohortDto>();
         PagedDeviceList? deviceList = null;
-        var activeInstallations = dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(nsi =>
-                nsi.TenantId == tenantId
-                && nsi.TenantSoftwareId == tenantSoftwareId
-                && nsi.IsActive)
-            .Select(nsi => new
-            {
-                nsi.DeviceAssetId,
-                nsi.DetectedVersion,
-                nsi.FirstSeenAt,
-                nsi.LastSeenAt,
-                nsi.SoftwareAssetId,
-            });
 
-        var installationRows = await activeInstallations.ToListAsync(ct);
-        var softwareAssetIdsForInstalls = installationRows
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
+        // TODO Phase 5 (#17): restore device listing via new canonical device-software join path
+        var installationRows = Array.Empty<object>()
+            .Select(_ => new { DeviceAssetId = Guid.Empty, DetectedVersion = (string?)null, FirstSeenAt = DateTimeOffset.MinValue, LastSeenAt = DateTimeOffset.MinValue, SoftwareAssetId = Guid.Empty })
             .ToList();
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch removed by canonical cleanup; remediation-surface rewrite restores this.
-        var openMatchRows = Array.Empty<object>().Select(_ => new { SoftwareAssetId = Guid.Empty, VulnerabilityDefinitionId = Guid.Empty }).ToList();
 
-        deviceVersionCohorts = installationRows
-            .GroupBy(item => NormalizeVersionKey(item.DetectedVersion))
-            .Select(group =>
-            {
-                var cohortSoftwareAssetIds = group.Select(item => item.SoftwareAssetId).ToHashSet();
-                return new ApprovalDeviceVersionCohortDto(
-                    RestoreVersion(group.Key),
-                    group.Count(),
-                    group.Select(item => item.DeviceAssetId).Distinct().Count(),
-                    openMatchRows.Count(item => cohortSoftwareAssetIds.Contains(item.SoftwareAssetId)),
-                    group.Min(item => item.FirstSeenAt),
-                    group.Max(item => item.LastSeenAt)
-                );
-            })
-            .OrderByDescending(item => item.ActiveInstallCount)
-            .ThenByDescending(item => item.ActiveVulnerabilityCount)
-            .ThenBy(item => item.Version ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+        var openMatchRows = Array.Empty<object>()
+            .Select(_ => new { SoftwareAssetId = Guid.Empty, VulnerabilityDefinitionId = Guid.Empty })
             .ToList();
 
         if (devicePagination is not null)
         {
-            var selectedVersionKey = deviceVersion is null
-                ? NormalizeVersionKey(deviceVersionCohorts.FirstOrDefault()?.Version)
-                : NormalizeVersionKey(deviceVersion);
-
-            var deviceQuery = dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-                .Where(nsi =>
-                    nsi.TenantId == tenantId
-                    && nsi.TenantSoftwareId == tenantSoftwareId
-                    && nsi.IsActive
-                    && (selectedVersionKey == string.Empty
-                        ? string.IsNullOrWhiteSpace(nsi.DetectedVersion)
-                        : nsi.DetectedVersion == selectedVersionKey))
-                .Select(nsi => new
-                {
-                    nsi.DeviceAssetId,
-                    DeviceName = nsi.DeviceAsset.AssetType == AssetType.Device
-                        ? nsi.DeviceAsset.DeviceComputerDnsName ?? nsi.DeviceAsset.Name
-                        : nsi.DeviceAsset.Name,
-                    Criticality = nsi.DeviceAsset.Criticality,
-                    nsi.DetectedVersion,
-                    nsi.LastSeenAt,
-                    // Phase 4 debt (#17): VulnerabilityAsset removed by canonical cleanup; remediation-surface rewrite restores this.
-                    OpenVulnerabilityCount = 0,
-                })
-                .Distinct();
-
-            var deviceTotalCount = await deviceQuery.CountAsync(ct);
-            var devices = await deviceQuery
-                .OrderByDescending(d => d.Criticality)
-                .ThenBy(d => d.DeviceName)
-                .Skip(devicePagination.Skip)
-                .Take(devicePagination.BoundedPageSize)
-                .Select(d => new ApprovalDeviceDto(
-                    d.DeviceAssetId,
-                    d.DeviceName,
-                    d.Criticality.ToString(),
-                    d.DetectedVersion,
-                    d.LastSeenAt,
-                    d.OpenVulnerabilityCount))
-                .ToListAsync(ct);
-
-            deviceList = new PagedDeviceList(devices, deviceTotalCount, devicePagination.Page, devicePagination.BoundedPageSize);
+            deviceList = new PagedDeviceList([], 0, devicePagination.Page, devicePagination.BoundedPageSize);
         }
 
         // Recommendations
@@ -321,8 +227,8 @@ public class ApprovalTaskQueryService(
             task.Type.ToString(),
             task.Status.ToString(),
             task.RemediationDecisionId,
-            ResolveDisplaySoftwareName(softwareName, decision.SoftwareAsset.Name),
-            hasHighestCriticality ? highestCriticality.ToString() : decision.SoftwareAsset.Criticality.ToString(),
+            softwareName ?? "Unknown software",
+            hasHighestCriticality ? highestCriticality.ToString() : "Unknown",
             decision.Outcome.ToString(),
             decision.Justification,
             hasHighestSeverity ? highestSeverity.ToString() : "Unknown",
@@ -371,79 +277,52 @@ public class ApprovalTaskQueryService(
     private static string ResolveDisplaySoftwareName(string? canonicalName, string? fallbackName)
     {
         if (!string.IsNullOrWhiteSpace(canonicalName))
-        {
             return canonicalName;
-        }
-
         if (!string.IsNullOrWhiteSpace(fallbackName))
-        {
             return fallbackName;
-        }
-
         return "Unknown software";
     }
 
     private Task<Dictionary<Guid, Severity>> GetHighestSeveritiesAsync(
-        Guid tenantId, List<Guid> tenantSoftwareIds, CancellationToken ct)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition removed by canonical cleanup; remediation-surface rewrite restores this.
+        Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
+        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition removed by canonical cleanup
         => Task.FromResult(new Dictionary<Guid, Severity>());
 
     private async Task<Dictionary<Guid, string>> GetSoftwareNamesAsync(
-        Guid tenantId, List<Guid> tenantSoftwareIds, CancellationToken ct)
+        Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
     {
-        if (tenantSoftwareIds.Count == 0)
-        {
+        if (remediationCaseIds.Count == 0)
             return [];
-        }
 
-        return await dbContext.TenantSoftware.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && tenantSoftwareIds.Contains(item.Id))
-            .Select(item => new { item.Id, Name = item.NormalizedSoftware.CanonicalName })
-            .ToDictionaryAsync(item => item.Id, item => item.Name, ct);
+        return await dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId && remediationCaseIds.Contains(rc.Id))
+            .Join(dbContext.SoftwareProducts.AsNoTracking(),
+                rc => rc.SoftwareProductId,
+                sp => sp.Id,
+                (rc, sp) => new { CaseId = rc.Id, sp.Name })
+            .ToDictionaryAsync(x => x.CaseId, x => x.Name, ct);
     }
 
     private async Task<Dictionary<Guid, Criticality>> GetHighestCriticalitiesAsync(
-        Guid tenantId, List<Guid> tenantSoftwareIds, CancellationToken ct)
+        Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
     {
-        if (tenantSoftwareIds.Count == 0)
-        {
-            return [];
-        }
-
-        return await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.IsActive && tenantSoftwareIds.Contains(item.TenantSoftwareId))
-            .Join(
-                dbContext.Assets.AsNoTracking().Where(asset => asset.TenantId == tenantId),
-                item => item.DeviceAssetId,
-                asset => asset.Id,
-                (item, asset) => new { item.TenantSoftwareId, asset.Criticality }
-            )
-            .GroupBy(item => item.TenantSoftwareId)
-            .Select(group => new
-            {
-                TenantSoftwareId = group.Key,
-                HighestCriticality = group.Max(item => item.Criticality),
-            })
-            .ToDictionaryAsync(item => item.TenantSoftwareId, item => item.HighestCriticality, ct);
+        // TODO Phase 5 (#17): re-implement device criticality lookup via new canonical device-software join path
+        return new Dictionary<Guid, Criticality>();
     }
 
     private Task<Dictionary<Guid, int>> GetVulnCountsAsync(
-        Guid tenantId, List<Guid> tenantSoftwareIds, CancellationToken ct)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch removed by canonical cleanup; remediation-surface rewrite restores this.
+        Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
+        // Phase 4 debt (#17): SoftwareVulnerabilityMatch removed by canonical cleanup
         => Task.FromResult(new Dictionary<Guid, int>());
 
     private Task<Dictionary<Guid, (string Status, DateTimeOffset DueDate)>> GetSlaInfoAsync(
-        Guid tenantId, List<Guid> tenantSoftwareIds, CancellationToken ct)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition removed by canonical cleanup; remediation-surface rewrite restores this.
+        Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
+        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition removed by canonical cleanup
         => Task.FromResult(new Dictionary<Guid, (string Status, DateTimeOffset DueDate)>());
 
     private static string NormalizeVersionKey(string? version)
-    {
-        return string.IsNullOrWhiteSpace(version) ? string.Empty : version.Trim();
-    }
+        => string.IsNullOrWhiteSpace(version) ? string.Empty : version.Trim();
 
     private static string? RestoreVersion(string versionKey)
-    {
-        return string.IsNullOrWhiteSpace(versionKey) ? null : versionKey;
-    }
+        => string.IsNullOrWhiteSpace(versionKey) ? null : versionKey;
 }

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -1410,7 +1410,7 @@ public class RemediationDecisionQueryService(
                 $"{item.Id}:{item.RecommendedOutcome}:{item.Rationale}:{item.PriorityOverride}:{item.CreatedAt:O}"
             )),
             string.Join(";", topVulns.Select(item =>
-                $"{item.TenantVulnerabilityId}:{item.ExternalId}:{item.EffectiveSeverity}:{item.EpisodeRiskScore}:{item.KnownExploited}:{item.PublicExploit}:{item.ActiveAlert}:{item.OverrideOutcome}"
+                $"{item.VulnerabilityId}:{item.ExternalId}:{item.EffectiveSeverity}:{item.EpisodeRiskScore}:{item.KnownExploited}:{item.PublicExploit}:{item.ActiveAlert}:{item.OverrideOutcome}"
             )),
             summary.TotalVulnerabilities,
             summary.CriticalCount,

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -84,125 +84,55 @@ public class RemediationDecisionQueryService(
         CancellationToken ct
     )
     {
-        var activeSnapshotId = await snapshotResolver.ResolveActiveVulnerabilitySnapshotIdAsync(tenantId, ct);
-        var tenantSoftwareQuery = dbContext.TenantSoftware.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.SnapshotId == activeSnapshotId);
+        var casesQuery = dbContext.RemediationCases.AsNoTracking()
+            .Where(c => c.TenantId == tenantId);
 
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
             var term = filter.Search.Trim().ToLower();
-            tenantSoftwareQuery = tenantSoftwareQuery.Where(item =>
-                item.NormalizedSoftware.CanonicalName.ToLower().Contains(term)
-                || (item.NormalizedSoftware.CanonicalVendor != null
-                    && item.NormalizedSoftware.CanonicalVendor.ToLower().Contains(term)));
+            casesQuery = casesQuery.Where(c =>
+                c.SoftwareProduct.Name.ToLower().Contains(term)
+                || (c.SoftwareProduct.Vendor != null && c.SoftwareProduct.Vendor.ToLower().Contains(term)));
         }
 
-        var tenantSoftwareRows = await tenantSoftwareQuery
-            .Select(item => new
+        var caseRows = await casesQuery
+            .Select(c => new
             {
-                item.Id,
-                Name = item.NormalizedSoftware.CanonicalName,
-                item.NormalizedSoftware.CanonicalVendor,
+                c.Id,
+                Name = c.SoftwareProduct.Name,
+                Vendor = c.SoftwareProduct.Vendor,
             })
-            .OrderBy(item => item.Name)
+            .OrderBy(c => c.Name)
             .ToListAsync(ct);
 
-        var tenantSoftwareIds = tenantSoftwareRows.Select(item => item.Id).ToList();
-        var activeInstallations = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.IsActive && tenantSoftwareIds.Contains(item.TenantSoftwareId))
-            .Select(item => new { item.TenantSoftwareId, item.SoftwareAssetId, item.DeviceAssetId })
-            .ToListAsync(ct);
-        var softwareAssetIds = activeInstallations.Select(item => item.SoftwareAssetId).Distinct().ToList();
-        var deviceAssetIds = activeInstallations.Select(item => item.DeviceAssetId).Distinct().ToList();
-        var softwareAssetNamesById = await dbContext.Assets.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && softwareAssetIds.Contains(item.Id))
-            .Select(item => new { item.Id, item.Name })
-            .ToDictionaryAsync(item => item.Id, item => item.Name, ct);
-        var deviceAssets = await dbContext.Assets.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && deviceAssetIds.Contains(item.Id))
-            .Select(item => new { item.Id, item.Criticality })
-            .ToListAsync(ct);
-        var deviceAssetsById = deviceAssets.ToDictionary(item => item.Id);
-        var representativeAssetByTenantSoftwareId = activeInstallations
-            .GroupBy(item => item.TenantSoftwareId)
-            .ToDictionary(
-                group => group.Key,
-                group => group.Select(item => item.SoftwareAssetId).Distinct().OrderBy(id => id).FirstOrDefault()
-            );
-        var highestCriticalityByTenantSoftwareId = activeInstallations
-            .GroupBy(item => item.TenantSoftwareId)
-            .ToDictionary(
-                group => group.Key,
-                group => group
-                    .Select(item => deviceAssetsById.GetValueOrDefault(item.DeviceAssetId)?.Criticality ?? Criticality.Low)
-                    .DefaultIfEmpty(Criticality.Low)
-                    .Max()
-            );
-        var deviceCountByTenantSoftwareId = activeInstallations
-            .GroupBy(item => item.TenantSoftwareId)
-            .ToDictionary(group => group.Key, group => group.Select(item => item.DeviceAssetId).Distinct().Count());
-        var deviceIdsByTenantSoftwareId = activeInstallations
-            .GroupBy(item => item.TenantSoftwareId)
-            .ToDictionary(
-                group => group.Key,
-                group => group.Select(item => item.DeviceAssetId).Distinct().ToHashSet()
-            );
+        var caseIds = caseRows.Select(c => c.Id).ToList();
 
         var decisionsLookup = await dbContext.RemediationDecisions.AsNoTracking()
             .Where(d => d.TenantId == tenantId
-                && tenantSoftwareIds.Contains(d.TenantSoftwareId)
+                && caseIds.Contains(d.RemediationCaseId)
                 && d.ApprovalStatus != DecisionApprovalStatus.Rejected
                 && d.ApprovalStatus != DecisionApprovalStatus.Expired)
-            .GroupBy(d => d.TenantSoftwareId)
+            .GroupBy(d => d.RemediationCaseId)
             .Select(g => g.OrderByDescending(d => d.CreatedAt).First())
-            .ToDictionaryAsync(d => d.TenantSoftwareId, ct);
+            .ToDictionaryAsync(d => d.RemediationCaseId, ct);
 
-        // Phase-2: SoftwareVulnerabilityMatch deleted.
-        var openMatchRows = new List<(Guid SoftwareAssetId, DateTimeOffset FirstSeenAt, Guid VulnerabilityDefinitionId, Severity VendorSeverity)>();
+        // TODO Phase 5: restore vulnerability counts from canonical vulnerability model.
+        var vulnCounts = new Dictionary<Guid, (int Total, int Critical, int High, DateTimeOffset EarliestFirstSeen, Severity HighestSeverity)>();
 
-        var tenantSoftwareIdBySoftwareAssetId = activeInstallations
-            .GroupBy(item => item.SoftwareAssetId)
-            .ToDictionary(group => group.Key, group => group.First().TenantSoftwareId);
-        var vulnerabilityDefinitionIdsByTenantSoftwareId = openMatchRows
-            .Where(item => tenantSoftwareIdBySoftwareAssetId.ContainsKey(item.SoftwareAssetId))
-            .GroupBy(item => tenantSoftwareIdBySoftwareAssetId[item.SoftwareAssetId])
-            .ToDictionary(
-                group => group.Key,
-                group => group.Select(item => item.VulnerabilityDefinitionId).Distinct().ToHashSet()
-            );
-
-        var vulnCounts = openMatchRows
-            .Where(item => tenantSoftwareIdBySoftwareAssetId.ContainsKey(item.SoftwareAssetId))
-            .GroupBy(item => tenantSoftwareIdBySoftwareAssetId[item.SoftwareAssetId])
-            .ToDictionary(
-                group => group.Key,
-                group => new
-                {
-                    Total = group.Select(item => item.VulnerabilityDefinitionId).Distinct().Count(),
-                    Critical = group.Where(item => item.VendorSeverity == Severity.Critical).Select(item => item.VulnerabilityDefinitionId).Distinct().Count(),
-                    High = group.Where(item => item.VendorSeverity == Severity.High).Select(item => item.VulnerabilityDefinitionId).Distinct().Count(),
-                    EarliestFirstSeen = group.Min(item => item.FirstSeenAt),
-                    HighestSeverity = group.Max(item => item.VendorSeverity),
-                });
-
-        var riskScoresByTsId = await dbContext.TenantSoftwareRiskScores.AsNoTracking()
-            .Where(r => r.TenantId == tenantId && tenantSoftwareIds.Contains(r.TenantSoftwareId))
-            .ToDictionaryAsync(r => r.TenantSoftwareId, ct);
+        // TODO Phase 5: restore risk scores keyed by RemediationCaseId.
+        var riskScoresByCaseId = new Dictionary<Guid, (decimal OverallScore, DateTimeOffset CalculatedAt)>();
 
         var tenantSla = await dbContext.TenantSlaConfigurations.AsNoTracking()
             .FirstOrDefaultAsync(c => c.TenantId == tenantId, ct);
 
         var items = new List<RemediationDecisionListItemDto>();
-        foreach (var software in tenantSoftwareRows)
+        foreach (var rc in caseRows)
         {
-            var activeVulnerabilityCount = vulnCounts.GetValueOrDefault(software.Id)?.Total ?? 0;
-            if (activeVulnerabilityCount == 0)
-            {
-                continue;
-            }
+            // TODO Phase 5: skip cases with no active vulnerabilities once vuln data is restored.
+            var activeVulnerabilityCount = 0;
 
-            if (!highestCriticalityByTenantSoftwareId.TryGetValue(software.Id, out var criticality))
-                criticality = Criticality.Low;
+            // TODO Phase 5: restore criticality from device-asset join.
+            var criticality = Criticality.Low;
 
             if (!string.IsNullOrWhiteSpace(filter.Criticality)
                 && Enum.TryParse<Criticality>(filter.Criticality, true, out var crit)
@@ -211,7 +141,7 @@ public class RemediationDecisionQueryService(
                 continue;
             }
 
-            decisionsLookup.TryGetValue(software.Id, out var decision);
+            decisionsLookup.TryGetValue(rc.Id, out var decision);
             if (string.Equals(filter.DecisionState, "WithDecision", StringComparison.OrdinalIgnoreCase)
                 && decision is null)
             {
@@ -239,8 +169,7 @@ public class RemediationDecisionQueryService(
             if (filter.MissedMaintenanceWindow == true)
             {
                 if (decision?.MaintenanceWindowDate is not DateTimeOffset maintenanceWindowDate
-                    || maintenanceWindowDate >= DateTimeOffset.UtcNow
-                    || activeVulnerabilityCount <= 0)
+                    || maintenanceWindowDate >= DateTimeOffset.UtcNow)
                 {
                     continue;
                 }
@@ -248,7 +177,7 @@ public class RemediationDecisionQueryService(
 
             string? riskBand = null;
             double? riskScore = null;
-            if (riskScoresByTsId.TryGetValue(software.Id, out var risk))
+            if (riskScoresByCaseId.TryGetValue(rc.Id, out var risk))
             {
                 riskScore = (double)risk.OverallScore;
                 riskBand = risk.OverallScore switch
@@ -263,22 +192,15 @@ public class RemediationDecisionQueryService(
 
             string? slaStatus = null;
             DateTimeOffset? slaDueDate = null;
-            if (tenantSla is not null && vulnCounts.TryGetValue(software.Id, out var vcForSla) && vcForSla.HighestSeverity != default)
+            if (tenantSla is not null && vulnCounts.TryGetValue(rc.Id, out var vcForSla) && vcForSla.HighestSeverity != default)
             {
                 slaDueDate = slaService.CalculateDueDate(vcForSla.HighestSeverity, vcForSla.EarliestFirstSeen, tenantSla);
                 slaStatus = slaService.GetSlaStatus(vcForSla.EarliestFirstSeen, slaDueDate.Value, DateTimeOffset.UtcNow).ToString();
             }
 
             items.Add(new RemediationDecisionListItemDto(
-                software.Id,
-                ResolveDisplaySoftwareName(
-                    software.Name,
-                    representativeAssetByTenantSoftwareId.TryGetValue(software.Id, out var representativeSoftwareAssetId)
-                        && representativeSoftwareAssetId != Guid.Empty
-                        && softwareAssetNamesById.TryGetValue(representativeSoftwareAssetId, out var representativeSoftwareName)
-                        ? representativeSoftwareName
-                        : null
-                ),
+                rc.Id,
+                ResolveDisplaySoftwareName(rc.Name, null),
                 criticality.ToString(),
                 decision?.Outcome.ToString(),
                 decision?.ApprovalStatus.ToString(),
@@ -286,13 +208,13 @@ public class RemediationDecisionQueryService(
                 decision?.MaintenanceWindowDate,
                 decision?.ExpiryDate,
                 activeVulnerabilityCount,
-                vulnCounts.GetValueOrDefault(software.Id)?.Critical ?? 0,
-                vulnCounts.GetValueOrDefault(software.Id)?.High ?? 0,
+                vulnCounts.GetValueOrDefault(rc.Id).Critical,
+                vulnCounts.GetValueOrDefault(rc.Id).High,
                 riskScore,
                 riskBand,
                 slaStatus,
                 slaDueDate,
-                deviceCountByTenantSoftwareId.GetValueOrDefault(software.Id),
+                0, // TODO Phase 5: restore device count from canonical device-asset join
                 BuildEmptyTrend()
             ));
         }
@@ -307,21 +229,6 @@ public class RemediationDecisionQueryService(
         var paged = items
             .Skip(pagination.Skip)
             .Take(pagination.BoundedPageSize)
-            .ToList();
-
-        var pagedEpisodeTrendBySoftwareId = await BuildOpenEpisodeTrendsBySoftwareAsync(
-            tenantId,
-            paged.Select(item => item.TenantSoftwareId).ToList(),
-            deviceIdsByTenantSoftwareId,
-            vulnerabilityDefinitionIdsByTenantSoftwareId,
-            ct
-        );
-
-        paged = paged
-            .Select(item => item with
-            {
-                OpenEpisodeTrend = pagedEpisodeTrendBySoftwareId.GetValueOrDefault(item.TenantSoftwareId) ?? BuildEmptyTrend()
-            })
             .ToList();
 
         var boundedPage = Math.Max(pagination.Page, 1);
@@ -344,71 +251,37 @@ public class RemediationDecisionQueryService(
         CancellationToken ct
     )
     {
-        var tenantSoftwareId = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.SoftwareAssetId == assetId && item.IsActive)
-            .Select(item => item.TenantSoftwareId)
-            .FirstOrDefaultAsync(ct);
-        if (tenantSoftwareId == Guid.Empty)
-            return null;
-
-        return await BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, false, ct);
+        // TODO Phase 5: resolve remediationCaseId from asset via NormalizedSoftwareInstallations → RemediationCase.
+        await Task.CompletedTask;
+        return null;
     }
 
-    public async Task<DecisionContextDto?> BuildByTenantSoftwareAsync(
+    public async Task<DecisionContextDto?> BuildByCaseIdAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         bool forceAiSummaryRefresh,
         CancellationToken ct
     )
     {
-        var tenantSoftwareMeta = await dbContext.TenantSoftware.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.Id == tenantSoftwareId)
-            .Select(item => new
+        var caseMeta = await dbContext.RemediationCases.AsNoTracking()
+            .Where(c => c.TenantId == tenantId && c.Id == remediationCaseId)
+            .Select(c => new
             {
-                Name = item.NormalizedSoftware.CanonicalName,
-                Vendor = item.NormalizedSoftware.CanonicalVendor,
+                Name = c.SoftwareProduct.Name,
+                Vendor = c.SoftwareProduct.Vendor,
             })
             .FirstOrDefaultAsync(ct);
 
-        var representativeAsset = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
-                && item.IsActive)
-            .Join(
-                dbContext.Assets.AsNoTracking(),
-                item => item.SoftwareAssetId,
-                asset => asset.Id,
-                (item, asset) => new { asset.Id, asset.Name, asset.Criticality }
-            )
-            .OrderBy(item => item.Id)
-            .FirstOrDefaultAsync(ct);
-
-        if (representativeAsset is null && tenantSoftwareMeta is null)
+        if (caseMeta is null)
             return null;
 
-        var assetId = representativeAsset?.Id ?? tenantSoftwareId;
-        var softwareName = ResolveDisplaySoftwareName(tenantSoftwareMeta?.Name, representativeAsset?.Name);
+        var softwareName = ResolveDisplaySoftwareName(caseMeta.Name, null);
 
-        var scopedSoftwareAssetIds = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
-            .ToListAsync(ct);
-        var scopedInstallations = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-            .Select(item => new { item.DeviceAssetId })
-            .ToListAsync(ct);
-        var scopedDeviceAssetIds = scopedInstallations.Select(item => item.DeviceAssetId).Distinct().ToList();
-        var scopedDeviceCriticalityValues = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-            .Join(
-                dbContext.Assets.AsNoTracking(),
-                item => item.DeviceAssetId,
-                asset => asset.Id,
-                (item, asset) => asset.Criticality
-            )
-            .ToListAsync(ct);
+        // TODO Phase 5: restore scopedDeviceAssetIds from NormalizedSoftwareInstallations via RemediationCase.
+        var scopedSoftwareAssetIds = new List<Guid>();
+        var scopedDeviceAssetIds = new List<Guid>();
+
+        var scopedDeviceCriticalityValues = new List<Criticality>();
         var assetCriticality = scopedDeviceCriticalityValues.Count > 0
             ? scopedDeviceCriticalityValues.Max()
             : Criticality.Low;
@@ -462,7 +335,7 @@ public class RemediationDecisionQueryService(
                 .Take(3)
                 .ToListAsync(ct);
         var patchingTaskCounts = await dbContext.PatchingTasks.AsNoTracking()
-            .Where(task => task.TenantId == tenantId && task.TenantSoftwareId == tenantSoftwareId)
+            .Where(task => task.TenantId == tenantId && task.RemediationCaseId == remediationCaseId)
             .GroupBy(_ => 1)
             .Select(group => new
             {
@@ -509,14 +382,14 @@ public class RemediationDecisionQueryService(
         var activeWorkflow = await dbContext.RemediationWorkflows.AsNoTracking()
             .Where(workflow =>
                 workflow.TenantId == tenantId
-                && workflow.TenantSoftwareId == tenantSoftwareId)
+                && workflow.RemediationCaseId == remediationCaseId)
             .OrderByDescending(workflow => workflow.CreatedAt)
             .FirstOrDefaultAsync(ct);
 
         // Current decision
         var decisionQuery = dbContext.RemediationDecisions.AsNoTracking()
             .Include(d => d.VulnerabilityOverrides)
-            .Where(d => d.TenantId == tenantId && d.TenantSoftwareId == tenantSoftwareId);
+            .Where(d => d.TenantId == tenantId && d.RemediationCaseId == remediationCaseId);
 
         var decision = activeWorkflow is not null
             ? await decisionQuery
@@ -532,8 +405,8 @@ public class RemediationDecisionQueryService(
 
         RemediationDecision? previousDecision = null;
 
-        var overridesByTenantVulnId = decision?.VulnerabilityOverrides
-            .ToDictionary(vo => vo.TenantVulnerabilityId);
+        var overridesByVulnerabilityId = decision?.VulnerabilityOverrides
+            .ToDictionary(vo => vo.VulnerabilityId);
 
         // Analyst recommendations
         var activeWorkflowId = activeWorkflow?.Id;
@@ -563,9 +436,9 @@ public class RemediationDecisionQueryService(
                 .FirstOrDefaultAsync(ct)
             : null;
 
-        // Asset risk score
-        var assetRiskScore = await dbContext.AssetRiskScores.AsNoTracking()
-            .FirstOrDefaultAsync(r => r.AssetId == assetId && r.TenantId == tenantId, ct);
+        // Asset risk score — TODO Phase 5: restore from canonical risk scores.
+        _ = await dbContext.AssetRiskScores.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.TenantId == tenantId, ct);
 
         // SLA configuration
         var tenantSla = await dbContext.TenantSlaConfigurations.AsNoTracking()
@@ -590,8 +463,8 @@ public class RemediationDecisionQueryService(
                 }
 
                 string? overrideOutcome = null;
-                if (overridesByTenantVulnId is not null && tvId != Guid.Empty
-                    && overridesByTenantVulnId.TryGetValue(tvId, out var vo))
+                if (overridesByVulnerabilityId is not null && tvId != Guid.Empty
+                    && overridesByVulnerabilityId.TryGetValue(tvId, out var vo))
                 {
                     overrideOutcome = vo.Outcome.ToString();
                 }
@@ -657,26 +530,8 @@ public class RemediationDecisionQueryService(
             }
         }
 
-        // Risk score
+        // Risk score — TODO Phase 5: restore from canonical risk model keyed by RemediationCaseId.
         DecisionRiskDto? riskDto = null;
-        var tenantSoftwareRisk = await dbContext.TenantSoftwareRiskScores.AsNoTracking()
-            .FirstOrDefaultAsync(r => r.TenantSoftwareId == tenantSoftwareId && r.TenantId == tenantId, ct);
-        if (tenantSoftwareRisk is not null)
-        {
-            var riskBand = tenantSoftwareRisk.OverallScore switch
-            {
-                >= 900m => "Critical",
-                >= 750m => "High",
-                >= 500m => "Medium",
-                > 0m => "Low",
-                _ => "None",
-            };
-            riskDto = new DecisionRiskDto(
-                (double)tenantSoftwareRisk.OverallScore,
-                riskBand,
-                tenantSoftwareRisk.CalculatedAt
-            );
-        }
 
         var remediationAiContext = BuildRemediationAiContext(
             scopedDeviceDetails,
@@ -716,7 +571,7 @@ public class RemediationDecisionQueryService(
                     : null,
                 decision.VulnerabilityOverrides.Select(vo => new VulnerabilityOverrideDto(
                     vo.Id,
-                    vo.TenantVulnerabilityId,
+                    vo.VulnerabilityId,
                     vo.Outcome.ToString(),
                     vo.Justification,
                     vo.CreatedAt
@@ -727,7 +582,7 @@ public class RemediationDecisionQueryService(
         // Recommendation DTOs
         var recommendationDtos = recommendations.Select(r => new AnalystRecommendationDto(
             r.Id,
-            r.TenantVulnerabilityId,
+            r.VulnerabilityId,
             r.RecommendedOutcome.ToString(),
             r.Rationale,
             r.PriorityOverride,
@@ -766,7 +621,7 @@ public class RemediationDecisionQueryService(
                 null,
                 previousDecision.VulnerabilityOverrides.Select(vo => new VulnerabilityOverrideDto(
                     vo.Id,
-                    vo.TenantVulnerabilityId,
+                    vo.VulnerabilityId,
                     vo.Outcome.ToString(),
                     vo.Justification,
                     vo.CreatedAt
@@ -823,22 +678,10 @@ public class RemediationDecisionQueryService(
             decision
         );
 
-        var aiSummary = await ResolveAiSummaryAsync(
-            tenantId,
-            tenantSoftwareId,
-            softwareName,
-            workflowState,
-            decisionDto,
-            recommendationDtos,
-            topVulns.Take(5).ToList(),
-            summary,
-            remediationAiContext,
-            forceRefresh: forceAiSummaryRefresh,
-            ct
-        );
+        var aiSummary = await ResolveAiSummaryAsync(ct);
 
         return new DecisionContextDto(
-            tenantSoftwareId,
+            remediationCaseId,
             softwareName,
             assetCriticality.ToString(),
             summary,
@@ -862,20 +705,20 @@ public class RemediationDecisionQueryService(
 
     public async Task<DecisionAiSummaryDto?> RefreshAiSummaryAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
-        return (await BuildByTenantSoftwareAsync(tenantId, tenantSoftwareId, true, ct))?.AiSummary;
+        return (await BuildByCaseIdAsync(tenantId, remediationCaseId, true, ct))?.AiSummary;
     }
 
     public async Task<bool> GenerateAndStoreAiDraftsAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
-        var summary = await RefreshAiSummaryAsync(tenantId, tenantSoftwareId, ct);
+        var summary = await RefreshAiSummaryAsync(tenantId, remediationCaseId, ct);
         return summary is not null
             && (
                 !string.IsNullOrWhiteSpace(summary.Content)
@@ -1275,163 +1118,33 @@ public class RemediationDecisionQueryService(
         return new DateTimeOffset(utc.Year, utc.Month, utc.Day, 0, 0, 0, TimeSpan.Zero);
     }
 
-    private async Task<DecisionAiSummaryDto> ResolveAiSummaryAsync(
-        Guid tenantId,
-        Guid tenantSoftwareId,
-        string softwareName,
-        DecisionWorkflowStateDto workflowState,
-        RemediationDecisionDto? decisionDto,
-        List<AnalystRecommendationDto> recommendations,
-        List<DecisionVulnDto> topVulns,
-        DecisionSummaryDto summary,
-        RemediationAiContext remediationAiContext,
-        bool forceRefresh,
-        CancellationToken ct
-    )
+    // TODO Phase 5: restore AI summary from RemediationCase → SoftwareProduct once AI fields are migrated off TenantSoftware.
+    private static Task<DecisionAiSummaryDto> ResolveAiSummaryAsync(CancellationToken ct)
     {
-        var tenantSoftware = await dbContext.TenantSoftware
-            .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Id == tenantSoftwareId, ct);
-        if (tenantSoftware is null)
-        {
-            return new DecisionAiSummaryDto(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                "Unavailable",
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                false,
-                false,
-                null,
-                MissingAiProfileMessage
-            );
-        }
-
-        var latestJob = await dbContext.RemediationAiJobs.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId)
-            .OrderByDescending(item => item.RequestedAt)
-            .FirstOrDefaultAsync(ct);
-        var reviewedByDisplayName = tenantSoftware.RemediationAiReviewedBy is Guid reviewedByUserId
-            ? await dbContext.Users.AsNoTracking()
-                .Where(user => user.Id == reviewedByUserId)
-                .Select(user => user.DisplayName)
-                .FirstOrDefaultAsync(ct)
-            : null;
-
-        var inputHash = HashAiSummaryInput(
-            softwareName,
-            workflowState,
-            decisionDto,
-            recommendations,
-            topVulns,
-            summary,
-            remediationAiContext
-        );
-
-        var hasEnabledDefaultProfile = await dbContext.TenantAiProfiles.AsNoTracking()
-            .AnyAsync(item => item.TenantId == tenantId && item.IsDefault && item.IsEnabled, ct);
-        var hasStoredGuidance = HasStoredAiGuidance(tenantSoftware);
-        var hasFreshGuidance = hasStoredGuidance
-            && string.Equals(tenantSoftware.RemediationAiSummaryInputHash, inputHash, StringComparison.Ordinal);
-
-        if (!forceRefresh && hasFreshGuidance)
-        {
-            return BuildAiSummaryDto(tenantSoftware, latestJob, hasEnabledDefaultProfile, false, null, reviewedByDisplayName);
-        }
-
-        if (!hasEnabledDefaultProfile)
-        {
-            return BuildAiSummaryDto(tenantSoftware, latestJob, false, hasStoredGuidance && !hasFreshGuidance, MissingAiProfileMessage, reviewedByDisplayName);
-        }
-
-        if (!forceRefresh)
-        {
-            return BuildAiSummaryDto(tenantSoftware, latestJob, true, hasStoredGuidance && !hasFreshGuidance, null, reviewedByDisplayName);
-        }
-
-        var generatedSummary = await GenerateAiNarrativeAsync(
-            tenantId,
-            softwareName,
-            summary,
-            topVulns,
-            remediationAiContext,
-            ct
-        );
-        if (!generatedSummary.IsSuccess)
-        {
-            return new DecisionAiSummaryDto(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                "Failed",
-                false,
-                NullIfWhiteSpace(tenantSoftware.RemediationAiReviewStatus),
-                tenantSoftware.RemediationAiReviewedAt,
-                string.IsNullOrWhiteSpace(reviewedByDisplayName) ? null : reviewedByDisplayName,
-                null,
-                latestJob?.RequestedAt,
-                latestJob?.CompletedAt,
-                null,
-                null,
-                null,
-                true,
-                false,
-                generatedSummary.Error,
-                "AI input is available, but the summary could not be generated right now. Try Ask AI again."
-            );
-        }
-
-        tenantSoftware.StoreRemediationAiSummary(
-            generatedSummary.Value.Value.ExecutiveSummary,
-            generatedSummary.Value.Value.OwnerRecommendation,
-            generatedSummary.Value.Value.AnalystAssessment,
-            generatedSummary.Value.Value.ExceptionRecommendation,
-            generatedSummary.Value.Value.RecommendedOutcome,
-            generatedSummary.Value.Value.RecommendedPriority,
-            inputHash,
-            generatedSummary.Value.Metadata.ProviderType,
-            generatedSummary.Value.Metadata.ProfileName,
-            generatedSummary.Value.Metadata.Model
-        );
-        await dbContext.SaveChangesAsync(ct);
-
-        return new DecisionAiSummaryDto(
-            generatedSummary.Value.Value.ExecutiveSummary,
-            generatedSummary.Value.Value.OwnerRecommendation,
-            generatedSummary.Value.Value.AnalystAssessment,
-            generatedSummary.Value.Value.ExceptionRecommendation,
-            generatedSummary.Value.Value.RecommendedOutcome,
-            generatedSummary.Value.Value.RecommendedPriority,
-            "Ready",
+        _ = ct;
+        return Task.FromResult(new DecisionAiSummaryDto(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Unavailable",
             false,
             null,
             null,
             null,
-            generatedSummary.Value.Metadata.GeneratedAt,
-            latestJob?.RequestedAt,
-            latestJob?.CompletedAt,
-            generatedSummary.Value.Metadata.ProviderType,
-            generatedSummary.Value.Metadata.ProfileName,
-            generatedSummary.Value.Metadata.Model,
-            true,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
             false,
             null,
-            null
-        );
+            "AI summary not available in Phase 4. TODO Phase 5."
+        ));
     }
 
     private DecisionAiSummaryDto BuildAiSummaryDto(

--- a/src/PatchHound.Api/Services/RemediationTaskQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationTaskQueryService.cs
@@ -36,7 +36,7 @@ public class RemediationTaskQueryService(
                 BuildLinkedTaskRowsQuery(
                     tenantId,
                     taskId: filter.TaskId,
-                    remediationCaseId: filter.TenantSoftwareId // filter param kept for API compat; treated as case ID
+                    remediationCaseId: filter.CaseId
                 ),
                 filter
             )
@@ -72,8 +72,7 @@ public class RemediationTaskQueryService(
         var items = pageRows
             .Select(item => new RemediationTaskListItemDto(
                 item.TaskId,
-                Guid.Empty, // SoftwareAssetId — Phase 5 debt (#17): device-level joins removed
-                null,       // TenantSoftwareId — Phase 5 debt (#17)
+                item.RemediationCaseId,
                 item.SoftwareName,
                 item.SoftwareVendor,
                 item.OwnerTeamId,

--- a/src/PatchHound.Api/Services/RemediationTaskQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationTaskQueryService.cs
@@ -4,19 +4,16 @@ using PatchHound.Api.Models.Remediation;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Infrastructure.Data;
-using PatchHound.Infrastructure.Services;
 
 namespace PatchHound.Api.Services;
 
 public class RemediationTaskQueryService(
-    PatchHoundDbContext dbContext,
-    RemediationDecisionService remediationDecisionService
+    PatchHoundDbContext dbContext
 )
 {
     private sealed record LinkedTaskRow(
         Guid TaskId,
-        Guid SoftwareAssetId,
-        Guid TenantSoftwareId,
+        Guid RemediationCaseId,
         string SoftwareName,
         string? SoftwareVendor,
         Guid OwnerTeamId,
@@ -25,32 +22,7 @@ public class RemediationTaskQueryService(
         DateTimeOffset? MaintenanceWindowDate,
         DateTimeOffset CreatedAt,
         DateTimeOffset UpdatedAt,
-        string Status,
-        Guid DeviceAssetId,
-        string DeviceName,
-        Criticality DeviceCriticality,
-        string? DeviceOwnerName
-    );
-
-    private sealed record LinkedTaskDbRow(
-        Guid TaskId,
-        Guid SoftwareAssetId,
-        Guid TenantSoftwareId,
-        string SoftwareName,
-        string? SoftwareVendor,
-        Guid OwnerTeamId,
-        string OwnerTeamName,
-        DateTimeOffset DueDate,
-        DateTimeOffset? MaintenanceWindowDate,
-        DateTimeOffset CreatedAt,
-        DateTimeOffset UpdatedAt,
-        string Status,
-        Guid DeviceAssetId,
-        string DeviceName,
-        Criticality DeviceCriticality,
-        Guid? DeviceOwnerUserId,
-        Guid? DeviceOwnerTeamId,
-        Guid? DeviceFallbackTeamId
+        string Status
     );
 
     public async Task<PagedResponse<RemediationTaskListItemDto>> ListOpenTasksAsync(
@@ -60,45 +32,21 @@ public class RemediationTaskQueryService(
         CancellationToken ct
     )
     {
-        var linkedRows = await ApplyFilters(
+        var rows = await ApplyFilters(
                 BuildLinkedTaskRowsQuery(
                     tenantId,
                     taskId: filter.TaskId,
-                    deviceAssetId: filter.DeviceAssetId,
-                    tenantSoftwareId: filter.TenantSoftwareId
+                    remediationCaseId: filter.TenantSoftwareId // filter param kept for API compat; treated as case ID
                 ),
                 filter
             )
             .ToListAsync(ct);
-        var ownerNames = await LoadOwnerNamesAsync(linkedRows, ct);
-        var hydratedRows = linkedRows
-            .Select(row => new LinkedTaskRow(
-                row.TaskId,
-                row.SoftwareAssetId,
-                row.TenantSoftwareId,
-                row.SoftwareName,
-                row.SoftwareVendor,
-                row.OwnerTeamId,
-                row.OwnerTeamName,
-                row.DueDate,
-                row.MaintenanceWindowDate,
-                row.CreatedAt,
-                row.UpdatedAt,
-                row.Status,
-                row.DeviceAssetId,
-                row.DeviceName,
-                row.DeviceCriticality,
-                ResolveOwnerName(row, ownerNames)
-            ))
-            .ToList();
-        hydratedRows = ApplyHydratedFilters(hydratedRows, filter);
 
-        var groupedRows = hydratedRows
+        var groupedRows = rows
             .GroupBy(row => new
             {
                 row.TaskId,
-                row.SoftwareAssetId,
-                row.TenantSoftwareId,
+                row.RemediationCaseId,
                 row.SoftwareName,
                 row.SoftwareVendor,
                 row.OwnerTeamId,
@@ -109,38 +57,8 @@ public class RemediationTaskQueryService(
                 row.UpdatedAt,
                 row.Status,
             })
-            .Select(group => new
-            {
-                group.Key.TaskId,
-                group.Key.SoftwareAssetId,
-                group.Key.TenantSoftwareId,
-                group.Key.SoftwareName,
-                group.Key.SoftwareVendor,
-                group.Key.OwnerTeamId,
-                group.Key.OwnerTeamName,
-                group.Key.DueDate,
-                group.Key.MaintenanceWindowDate,
-                group.Key.CreatedAt,
-                group.Key.UpdatedAt,
-                group.Key.Status,
-                AffectedDeviceCount = group.Select(item => item.DeviceAssetId).Distinct().Count(),
-                CriticalDeviceCount = group
-                    .Where(item => item.DeviceCriticality == Criticality.Critical)
-                    .Select(item => item.DeviceAssetId)
-                    .Distinct()
-                    .Count(),
-                HighOrWorseDeviceCount = group
-                    .Where(item =>
-                        item.DeviceCriticality == Criticality.Critical
-                        || item.DeviceCriticality == Criticality.High)
-                    .Select(item => item.DeviceAssetId)
-                    .Distinct()
-                    .Count(),
-                HighestDeviceCriticality = group.Max(item => item.DeviceCriticality),
-            })
+            .Select(group => group.Key)
             .OrderBy(item => item.DueDate)
-            .ThenByDescending(item => item.CriticalDeviceCount)
-            .ThenByDescending(item => item.AffectedDeviceCount)
             .ThenBy(item => item.SoftwareName)
             .ToList();
 
@@ -151,55 +69,27 @@ public class RemediationTaskQueryService(
             .Take(pagination.BoundedPageSize)
             .ToList();
 
-        var pageTaskIds = pageRows.Select(item => item.TaskId).ToList();
-        var pageDetails = hydratedRows
-            .Where(item => pageTaskIds.Contains(item.TaskId))
-            .ToList();
-
-        var pageDetailsByTaskId = pageDetails
-            .GroupBy(item => item.TaskId)
-            .ToDictionary(group => group.Key, group => group.ToList());
-
         var items = pageRows
-            .Select(item =>
-            {
-                var detailRows = pageDetailsByTaskId.GetValueOrDefault(item.TaskId) ?? [];
-                var deviceNames = detailRows
-                    .Select(row => row.DeviceName)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-                    .Take(3)
-                    .ToList();
-                var assetOwners = detailRows
-                    .Select(row => row.DeviceOwnerName)
-                    .Where(name => !string.IsNullOrWhiteSpace(name))
-                    .Select(name => name!)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-                    .Take(3)
-                    .ToList();
-
-                return new RemediationTaskListItemDto(
-                    item.TaskId,
-                    item.SoftwareAssetId,
-                    item.TenantSoftwareId,
-                    item.SoftwareName,
-                    item.SoftwareVendor,
-                    item.OwnerTeamId,
-                    item.OwnerTeamName,
-                    item.AffectedDeviceCount,
-                    item.CriticalDeviceCount,
-                    item.HighOrWorseDeviceCount,
-                    item.HighestDeviceCriticality.ToString(),
-                    item.DueDate,
-                    item.MaintenanceWindowDate,
-                    item.CreatedAt,
-                    item.UpdatedAt,
-                    item.Status,
-                    deviceNames,
-                    assetOwners
-                );
-            })
+            .Select(item => new RemediationTaskListItemDto(
+                item.TaskId,
+                Guid.Empty, // SoftwareAssetId — Phase 5 debt (#17): device-level joins removed
+                null,       // TenantSoftwareId — Phase 5 debt (#17)
+                item.SoftwareName,
+                item.SoftwareVendor,
+                item.OwnerTeamId,
+                item.OwnerTeamName,
+                0, // AffectedDeviceCount — Phase 5 debt (#17)
+                0, // CriticalDeviceCount — Phase 5 debt (#17)
+                0, // HighOrWorseDeviceCount — Phase 5 debt (#17)
+                "Unknown", // HighestDeviceCriticality — Phase 5 debt (#17)
+                item.DueDate,
+                item.MaintenanceWindowDate,
+                item.CreatedAt,
+                item.UpdatedAt,
+                item.Status,
+                [], // DeviceNames — Phase 5 debt (#17)
+                []  // AssetOwners — Phase 5 debt (#17)
+            ))
             .ToList();
 
         return new PagedResponse<RemediationTaskListItemDto>(
@@ -216,17 +106,18 @@ public class RemediationTaskQueryService(
         CancellationToken ct
     )
     {
-        return await BuildSummaryAsync(BuildLinkedTaskRowsQuery(tenantId, deviceAssetId: assetId), ct);
+        // Phase 5 debt (#17): device-level summary requires NormalizedSoftwareInstallations join
+        return new RemediationTaskSummaryDto(0, 0, null);
     }
 
     public async Task<RemediationTaskSummaryDto> BuildSoftwareSummaryAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
         return await BuildSummaryAsync(
-            BuildLinkedTaskRowsQuery(tenantId, tenantSoftwareId: tenantSoftwareId),
+            BuildLinkedTaskRowsQuery(tenantId, remediationCaseId: remediationCaseId),
             ct
         );
     }
@@ -238,69 +129,19 @@ public class RemediationTaskQueryService(
         CancellationToken ct
     )
     {
-        var activeSoftwareAssetIds = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
-                && item.IsActive)
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
-            .ToListAsync(ct);
-
-        var createdCount = 0;
-
-        foreach (var softwareAssetId in activeSoftwareAssetIds)
-        {
-            var decision = await dbContext.RemediationDecisions
-                .Where(item =>
-                    item.TenantId == tenantId
-                    && item.TenantSoftwareId == tenantSoftwareId
-                    && item.Outcome == RemediationOutcome.ApprovedForPatching
-                    && item.ApprovalStatus == DecisionApprovalStatus.Approved)
-                .OrderByDescending(item => item.DecidedAt)
-                .FirstOrDefaultAsync(ct);
-
-            if (decision is null)
-            {
-                var createdDecision = await remediationDecisionService.CreateDecisionAsync(
-                    tenantId,
-                    softwareAssetId,
-                    RemediationOutcome.ApprovedForPatching,
-                    "Created from software remediation workbench.",
-                    assignedBy,
-                    expiryDate: null,
-                    reEvaluationDate: null,
-                    ct,
-                    maintenanceWindowDate: null
-                );
-
-                if (createdDecision.IsSuccess)
-                {
-                    createdCount += await CountOpenTasksForDecisionAsync(createdDecision.Value.Id, ct);
-                }
-
-                continue;
-            }
-
-            createdCount += await remediationDecisionService.EnsurePatchingTasksAsync(decision.Id, ct);
-            await dbContext.SaveChangesAsync(ct);
-        }
-
-        return new RemediationTaskCreateResultDto(
-            createdCount,
-            activeSoftwareAssetIds.Count
-        );
+        // TODO Phase 5 (#17): re-implement device-level task creation after canonical model stabilises
+        return new RemediationTaskCreateResultDto(0, 0);
     }
 
     public async Task<List<RemediationTaskTeamStatusDto>> ListTeamStatusesForSoftwareAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
         var tasks = await dbContext.PatchingTasks.AsNoTracking()
             .Include(task => task.RemediationDecision)
-            .Where(task => task.TenantId == tenantId && task.TenantSoftwareId == tenantSoftwareId)
+            .Where(task => task.TenantId == tenantId && task.RemediationCaseId == remediationCaseId)
             .ToListAsync(ct);
 
         var latestTasksByTeamId = tasks
@@ -337,66 +178,46 @@ public class RemediationTaskQueryService(
         return latestTasks;
     }
 
-    private IQueryable<LinkedTaskDbRow> BuildLinkedTaskRowsQuery(
+    private IQueryable<LinkedTaskRow> BuildLinkedTaskRowsQuery(
         Guid tenantId,
         Guid? taskId = null,
         Guid? deviceAssetId = null,
-        Guid? tenantSoftwareId = null
+        Guid? remediationCaseId = null
     )
     {
+        // Phase 5 debt (#17): deviceAssetId filter not applied — device-level joins removed in Phase 4.
         var query =
             from task in dbContext.PatchingTasks.AsNoTracking()
             join team in dbContext.Teams.AsNoTracking() on task.OwnerTeamId equals team.Id
             join decision in dbContext.RemediationDecisions.AsNoTracking()
                 on task.RemediationDecisionId equals decision.Id
-            join installation in dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-                on task.TenantSoftwareId equals installation.TenantSoftwareId
-            join tenantSoftware in dbContext.TenantSoftware.AsNoTracking()
-                on task.TenantSoftwareId equals tenantSoftware.Id
-            join normalized in dbContext.NormalizedSoftware.AsNoTracking()
-                on tenantSoftware.NormalizedSoftwareId equals normalized.Id
-            join device in dbContext.Assets.AsNoTracking()
-                on installation.DeviceAssetId equals device.Id
+            join rc in dbContext.RemediationCases.AsNoTracking()
+                on task.RemediationCaseId equals rc.Id
+            join sp in dbContext.SoftwareProducts.AsNoTracking()
+                on rc.SoftwareProductId equals sp.Id
             where task.TenantId == tenantId
                 && task.Status != PatchingTaskStatus.Completed
                 && (!taskId.HasValue || task.Id == taskId.Value)
-                && installation.TenantId == tenantId
-                && installation.IsActive
-                && (!tenantSoftwareId.HasValue || installation.TenantSoftwareId == tenantSoftwareId.Value)
-                && device.TenantId == tenantId
-                && (!deviceAssetId.HasValue || device.Id == deviceAssetId.Value)
-                && (
-                    device.OwnerTeamId == task.OwnerTeamId
-                    || (device.OwnerTeamId == null && device.FallbackTeamId == task.OwnerTeamId)
-                )
-            select new LinkedTaskDbRow(
+                && (!remediationCaseId.HasValue || task.RemediationCaseId == remediationCaseId.Value)
+            select new LinkedTaskRow(
                 task.Id,
-                task.SoftwareAssetId,
-                task.TenantSoftwareId,
-                normalized.CanonicalName,
-                normalized.CanonicalVendor,
+                task.RemediationCaseId,
+                sp.Name,
+                sp.Vendor,
                 task.OwnerTeamId,
                 team.Name,
                 task.DueDate,
                 decision.MaintenanceWindowDate,
                 task.CreatedAt,
                 task.UpdatedAt,
-                task.Status.ToString(),
-                device.Id,
-                device.AssetType == AssetType.Device
-                    ? device.DeviceComputerDnsName ?? device.Name
-                    : device.Name,
-                device.Criticality,
-                device.OwnerUserId,
-                device.OwnerTeamId,
-                device.FallbackTeamId
+                task.Status.ToString()
             );
 
         return query;
     }
 
-    private static IQueryable<LinkedTaskDbRow> ApplyFilters(
-        IQueryable<LinkedTaskDbRow> query,
+    private static IQueryable<LinkedTaskRow> ApplyFilters(
+        IQueryable<LinkedTaskRow> query,
         RemediationTaskFilterQuery filter
     )
     {
@@ -407,106 +228,20 @@ public class RemediationTaskQueryService(
                 item.SoftwareVendor != null && item.SoftwareVendor.Contains(vendor));
         }
 
-        if (!string.IsNullOrWhiteSpace(filter.Criticality)
-            && Enum.TryParse<Criticality>(filter.Criticality, true, out var criticality))
-        {
-            query = query.Where(item => item.DeviceCriticality == criticality);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filter.AssetOwner))
-        {
-            // Asset owner names are resolved after the DB fetch because EF cannot translate
-            // the fallback user/team display-name logic cleanly for this grouped query.
-        }
-
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
             var search = filter.Search.Trim();
             query = query.Where(item =>
                 item.SoftwareName.Contains(search)
                 || (item.SoftwareVendor != null && item.SoftwareVendor.Contains(search))
-                || item.OwnerTeamName.Contains(search)
-                || item.DeviceName.Contains(search));
+                || item.OwnerTeamName.Contains(search));
         }
 
         return query;
     }
 
-    private static List<LinkedTaskRow> ApplyHydratedFilters(
-        List<LinkedTaskRow> rows,
-        RemediationTaskFilterQuery filter
-    )
-    {
-        if (string.IsNullOrWhiteSpace(filter.AssetOwner))
-        {
-            return rows;
-        }
-
-        var assetOwner = filter.AssetOwner.Trim();
-        return rows
-            .Where(item =>
-                item.OwnerTeamName.Contains(assetOwner, StringComparison.OrdinalIgnoreCase)
-                || (!string.IsNullOrWhiteSpace(item.DeviceOwnerName)
-                    && item.DeviceOwnerName.Contains(assetOwner, StringComparison.OrdinalIgnoreCase)))
-            .ToList();
-    }
-
-    private async Task<Dictionary<Guid, string>> LoadOwnerNamesAsync(
-        IReadOnlyCollection<LinkedTaskDbRow> rows,
-        CancellationToken ct
-    )
-    {
-        var userIds = rows
-            .Select(row => row.DeviceOwnerUserId)
-            .OfType<Guid>()
-            .Distinct()
-            .ToList();
-        var teamIds = rows
-            .SelectMany(row => new[] { row.DeviceOwnerTeamId, row.DeviceFallbackTeamId })
-            .OfType<Guid>()
-            .Distinct()
-            .ToList();
-
-        var userNames = await dbContext.Users.AsNoTracking()
-            .Where(user => userIds.Contains(user.Id))
-            .Select(user => new { user.Id, user.DisplayName })
-            .ToDictionaryAsync(user => user.Id, user => user.DisplayName, ct);
-        var teamNames = await dbContext.Teams.AsNoTracking()
-            .Where(team => teamIds.Contains(team.Id))
-            .Select(team => new { team.Id, team.Name })
-            .ToDictionaryAsync(team => team.Id, team => team.Name, ct);
-
-        return userNames.Concat(teamNames).ToDictionary(item => item.Key, item => item.Value);
-    }
-
-    private static string? ResolveOwnerName(
-        LinkedTaskDbRow row,
-        IReadOnlyDictionary<Guid, string> ownerNames
-    )
-    {
-        if (row.DeviceOwnerUserId is Guid ownerUserId
-            && ownerNames.TryGetValue(ownerUserId, out var ownerUserName))
-        {
-            return ownerUserName;
-        }
-
-        if (row.DeviceOwnerTeamId is Guid ownerTeamId
-            && ownerNames.TryGetValue(ownerTeamId, out var ownerTeamName))
-        {
-            return ownerTeamName;
-        }
-
-        if (row.DeviceFallbackTeamId is Guid fallbackTeamId
-            && ownerNames.TryGetValue(fallbackTeamId, out var fallbackTeamName))
-        {
-            return fallbackTeamName;
-        }
-
-        return null;
-    }
-
     private static async Task<RemediationTaskSummaryDto> BuildSummaryAsync(
-        IQueryable<LinkedTaskDbRow> query,
+        IQueryable<LinkedTaskRow> query,
         CancellationToken ct
     )
     {

--- a/src/PatchHound.Api/Services/RemediationWorkflowAuthorizationService.cs
+++ b/src/PatchHound.Api/Services/RemediationWorkflowAuthorizationService.cs
@@ -14,11 +14,11 @@ public class RemediationWorkflowAuthorizationService(
 {
     public async Task<Result<bool>> EnsureCanAddRecommendationAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
-        var workflow = await GetActiveWorkflowAsync(tenantId, tenantSoftwareId, ct);
+        var workflow = await GetActiveWorkflowAsync(tenantId, remediationCaseId, ct);
         if (workflow is null)
             return EnsureSecurityAnalysisRole();
 
@@ -56,11 +56,11 @@ public class RemediationWorkflowAuthorizationService(
 
     public async Task<Result<bool>> EnsureCanCreateDecisionAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
-        var workflow = await GetActiveWorkflowAsync(tenantId, tenantSoftwareId, ct);
+        var workflow = await GetActiveWorkflowAsync(tenantId, remediationCaseId, ct);
         if (workflow is null)
             return Result<bool>.Failure("No active remediation workflow exists for this software.");
 
@@ -185,13 +185,13 @@ public class RemediationWorkflowAuthorizationService(
 
     private Task<RemediationWorkflow?> GetActiveWorkflowAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     ) =>
         dbContext.RemediationWorkflows.AsNoTracking()
             .FirstOrDefaultAsync(workflow =>
                 workflow.TenantId == tenantId
-                && workflow.TenantSoftwareId == tenantSoftwareId
+                && workflow.RemediationCaseId == remediationCaseId
                 && workflow.Status == RemediationWorkflowStatus.Active,
                 ct);
 

--- a/src/PatchHound.Core/Entities/AIReport.cs
+++ b/src/PatchHound.Core/Entities/AIReport.cs
@@ -3,8 +3,9 @@ namespace PatchHound.Core.Entities;
 public class AIReport
 {
     public Guid Id { get; private set; }
-    public Guid VulnerabilityId { get; private set; }
     public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public Guid? VulnerabilityId { get; private set; }
     public Guid TenantAiProfileId { get; private set; }
     public string Content { get; private set; } = null!;
     public string ProviderType { get; private set; } = null!;
@@ -16,14 +17,15 @@ public class AIReport
     public DateTimeOffset GeneratedAt { get; private set; }
     public Guid GeneratedBy { get; private set; }
 
+    public RemediationCase RemediationCase { get; private set; } = null!;
     public TenantAiProfile TenantAiProfile { get; private set; } = null!;
-    public Vulnerability Vulnerability { get; private set; } = null!;
+    public Vulnerability? Vulnerability { get; private set; }
 
     private AIReport() { }
 
     public static AIReport Create(
-        Guid vulnerabilityId,
         Guid tenantId,
+        Guid remediationCaseId,
         Guid tenantAiProfileId,
         string content,
         string providerType,
@@ -32,14 +34,15 @@ public class AIReport
         string systemPromptHash,
         decimal temperature,
         int maxOutputTokens,
-        Guid generatedBy
-    )
+        Guid generatedBy,
+        Guid? vulnerabilityId = null)
     {
         return new AIReport
         {
             Id = Guid.NewGuid(),
-            VulnerabilityId = vulnerabilityId,
             TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            VulnerabilityId = vulnerabilityId,
             TenantAiProfileId = tenantAiProfileId,
             Content = content,
             ProviderType = providerType,

--- a/src/PatchHound.Core/Entities/AnalystRecommendation.cs
+++ b/src/PatchHound.Core/Entities/AnalystRecommendation.cs
@@ -6,28 +6,28 @@ public class AnalystRecommendation
 {
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
     public Guid? RemediationWorkflowId { get; private set; }
-    public Guid SoftwareAssetId { get; private set; }
-    public Guid? TenantVulnerabilityId { get; private set; }
+    public Guid? VulnerabilityId { get; private set; }
     public RemediationOutcome RecommendedOutcome { get; private set; }
     public string Rationale { get; private set; } = null!;
     public string? PriorityOverride { get; private set; }
     public Guid AnalystId { get; private set; }
     public DateTimeOffset CreatedAt { get; private set; }
 
+    public RemediationCase RemediationCase { get; private set; } = null!;
     public RemediationWorkflow? RemediationWorkflow { get; private set; }
 
     private AnalystRecommendation() { }
 
     public static AnalystRecommendation Create(
         Guid tenantId,
-        Guid softwareAssetId,
+        Guid remediationCaseId,
         RemediationOutcome recommendedOutcome,
         string rationale,
         Guid analystId,
-        Guid? tenantVulnerabilityId = null,
-        string? priorityOverride = null
-    )
+        Guid? vulnerabilityId = null,
+        string? priorityOverride = null)
     {
         if (string.IsNullOrWhiteSpace(rationale))
             throw new ArgumentException("Rationale is required.");
@@ -36,8 +36,8 @@ public class AnalystRecommendation
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
-            SoftwareAssetId = softwareAssetId,
-            TenantVulnerabilityId = tenantVulnerabilityId,
+            RemediationCaseId = remediationCaseId,
+            VulnerabilityId = vulnerabilityId,
             RecommendedOutcome = recommendedOutcome,
             Rationale = rationale,
             PriorityOverride = priorityOverride,
@@ -55,9 +55,8 @@ public class AnalystRecommendation
         RemediationOutcome recommendedOutcome,
         string rationale,
         Guid analystId,
-        Guid? tenantVulnerabilityId = null,
-        string? priorityOverride = null
-    )
+        Guid? vulnerabilityId = null,
+        string? priorityOverride = null)
     {
         if (string.IsNullOrWhiteSpace(rationale))
             throw new ArgumentException("Rationale is required.");
@@ -65,7 +64,7 @@ public class AnalystRecommendation
         RecommendedOutcome = recommendedOutcome;
         Rationale = rationale;
         AnalystId = analystId;
-        TenantVulnerabilityId = tenantVulnerabilityId;
+        VulnerabilityId = vulnerabilityId;
         PriorityOverride = priorityOverride;
         CreatedAt = DateTimeOffset.UtcNow;
     }

--- a/src/PatchHound.Core/Entities/ApprovalTask.cs
+++ b/src/PatchHound.Core/Entities/ApprovalTask.cs
@@ -8,6 +8,7 @@ public class ApprovalTask
 
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
     public Guid? RemediationWorkflowId { get; private set; }
     public Guid RemediationDecisionId { get; private set; }
     public ApprovalTaskType Type { get; private set; }
@@ -23,6 +24,7 @@ public class ApprovalTask
     public DateTimeOffset UpdatedAt { get; private set; }
     public DateTimeOffset? ReadAt { get; private set; }
 
+    public RemediationCase RemediationCase { get; private set; } = null!;
     public RemediationDecision RemediationDecision { get; private set; } = null!;
     public RemediationWorkflow? RemediationWorkflow { get; private set; }
 
@@ -30,6 +32,7 @@ public class ApprovalTask
 
     public static ApprovalTask Create(
         Guid tenantId,
+        Guid remediationCaseId,
         Guid remediationDecisionId,
         RemediationOutcome outcome,
         ApprovalTaskStatus? initialStatus,
@@ -60,6 +63,7 @@ public class ApprovalTask
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
             RemediationDecisionId = remediationDecisionId,
             Type = type,
             Status = status,

--- a/src/PatchHound.Core/Entities/PatchingTask.cs
+++ b/src/PatchHound.Core/Entities/PatchingTask.cs
@@ -6,10 +6,9 @@ public class PatchingTask
 {
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
     public Guid? RemediationWorkflowId { get; private set; }
     public Guid RemediationDecisionId { get; private set; }
-    public Guid TenantSoftwareId { get; private set; }
-    public Guid SoftwareAssetId { get; private set; }
     public Guid OwnerTeamId { get; private set; }
     public PatchingTaskStatus Status { get; private set; }
     public DateTimeOffset DueDate { get; private set; }
@@ -17,6 +16,7 @@ public class PatchingTask
     public DateTimeOffset UpdatedAt { get; private set; }
     public DateTimeOffset? CompletedAt { get; private set; }
 
+    public RemediationCase RemediationCase { get; private set; } = null!;
     public RemediationDecision RemediationDecision { get; private set; } = null!;
     public RemediationWorkflow? RemediationWorkflow { get; private set; }
 
@@ -24,21 +24,20 @@ public class PatchingTask
 
     public static PatchingTask Create(
         Guid tenantId,
+        Guid remediationCaseId,
         Guid remediationDecisionId,
-        Guid tenantSoftwareId,
-        Guid softwareAssetId,
         Guid ownerTeamId,
-        DateTimeOffset dueDate
-    )
+        DateTimeOffset dueDate)
     {
+        if (tenantId == Guid.Empty) throw new ArgumentException("TenantId is required.");
+        if (remediationCaseId == Guid.Empty) throw new ArgumentException("RemediationCaseId is required.");
         var now = DateTimeOffset.UtcNow;
         return new PatchingTask
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
             RemediationDecisionId = remediationDecisionId,
-            TenantSoftwareId = tenantSoftwareId,
-            SoftwareAssetId = softwareAssetId,
             OwnerTeamId = ownerTeamId,
             Status = PatchingTaskStatus.Pending,
             DueDate = dueDate,
@@ -63,12 +62,6 @@ public class PatchingTask
     public void AttachToWorkflow(Guid remediationWorkflowId)
     {
         RemediationWorkflowId = remediationWorkflowId;
-        UpdatedAt = DateTimeOffset.UtcNow;
-    }
-
-    public void ReassignTenantSoftware(Guid newTenantSoftwareId)
-    {
-        TenantSoftwareId = newTenantSoftwareId;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/src/PatchHound.Core/Entities/RemediationAiJob.cs
+++ b/src/PatchHound.Core/Entities/RemediationAiJob.cs
@@ -6,7 +6,7 @@ public class RemediationAiJob
 {
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
-    public Guid TenantSoftwareId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
     public RemediationAiJobStatus Status { get; private set; }
     public string InputHash { get; private set; } = string.Empty;
     public string Error { get; private set; } = string.Empty;
@@ -19,16 +19,15 @@ public class RemediationAiJob
 
     public static RemediationAiJob Create(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         string inputHash,
-        DateTimeOffset requestedAt
-    )
+        DateTimeOffset requestedAt)
     {
         return new RemediationAiJob
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
-            TenantSoftwareId = tenantSoftwareId,
+            RemediationCaseId = remediationCaseId,
             Status = RemediationAiJobStatus.Pending,
             InputHash = inputHash.Trim(),
             RequestedAt = requestedAt,

--- a/src/PatchHound.Core/Entities/RemediationCase.cs
+++ b/src/PatchHound.Core/Entities/RemediationCase.cs
@@ -1,0 +1,55 @@
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Entities;
+
+public class RemediationCase
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public RemediationCaseStatus Status { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+    public DateTimeOffset? ClosedAt { get; private set; }
+
+    public SoftwareProduct SoftwareProduct { get; private set; } = null!;
+
+    private RemediationCase() { }
+
+    public static RemediationCase Create(Guid tenantId, Guid softwareProductId)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (softwareProductId == Guid.Empty)
+            throw new ArgumentException("SoftwareProductId is required.", nameof(softwareProductId));
+
+        var now = DateTimeOffset.UtcNow;
+        return new RemediationCase
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            SoftwareProductId = softwareProductId,
+            Status = RemediationCaseStatus.Open,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Close()
+    {
+        if (Status == RemediationCaseStatus.Closed)
+            return;
+        Status = RemediationCaseStatus.Closed;
+        ClosedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = ClosedAt.Value;
+    }
+
+    public void Reopen()
+    {
+        if (Status == RemediationCaseStatus.Open)
+            return;
+        Status = RemediationCaseStatus.Open;
+        ClosedAt = null;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/PatchHound.Core/Entities/RemediationDecision.cs
+++ b/src/PatchHound.Core/Entities/RemediationDecision.cs
@@ -6,9 +6,8 @@ public class RemediationDecision
 {
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
     public Guid? RemediationWorkflowId { get; private set; }
-    public Guid TenantSoftwareId { get; private set; }
-    public Guid SoftwareAssetId { get; private set; }
     public RemediationOutcome Outcome { get; private set; }
     public DecisionApprovalStatus ApprovalStatus { get; private set; }
     public string Justification { get; private set; } = null!;
@@ -23,7 +22,7 @@ public class RemediationDecision
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
-    public Asset SoftwareAsset { get; private set; } = null!;
+    public RemediationCase RemediationCase { get; private set; } = null!;
     public RemediationWorkflow? RemediationWorkflow { get; private set; }
     public ICollection<RemediationDecisionVulnerabilityOverride> VulnerabilityOverrides { get; private set; } = [];
 
@@ -44,17 +43,20 @@ public class RemediationDecision
 
     public static RemediationDecision Create(
         Guid tenantId,
-        Guid tenantSoftwareId,
-        Guid softwareAssetId,
+        Guid remediationCaseId,
         RemediationOutcome outcome,
         string? justification,
         Guid decidedBy,
         DecisionApprovalStatus? initialApprovalStatus = null,
         DateTimeOffset? expiryDate = null,
         DateTimeOffset? reEvaluationDate = null,
-        DateTimeOffset? maintenanceWindowDate = null
-    )
+        DateTimeOffset? maintenanceWindowDate = null)
     {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (remediationCaseId == Guid.Empty)
+            throw new ArgumentException("RemediationCaseId is required.", nameof(remediationCaseId));
+
         if (OutcomesRequiringJustification.Contains(outcome) && string.IsNullOrWhiteSpace(justification))
             throw new ArgumentException($"Justification is required for {outcome}.");
 
@@ -72,8 +74,7 @@ public class RemediationDecision
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
-            TenantSoftwareId = tenantSoftwareId,
-            SoftwareAssetId = softwareAssetId,
+            RemediationCaseId = remediationCaseId,
             Outcome = outcome,
             ApprovalStatus = approvalStatus,
             Justification = justification ?? string.Empty,
@@ -93,7 +94,6 @@ public class RemediationDecision
     {
         if (ApprovalStatus != DecisionApprovalStatus.PendingApproval)
             throw new InvalidOperationException($"Cannot approve a decision with status {ApprovalStatus}.");
-
         ApprovedBy = approvedBy;
         ApprovedAt = DateTimeOffset.UtcNow;
         ApprovalStatus = DecisionApprovalStatus.Approved;
@@ -110,7 +110,6 @@ public class RemediationDecision
     {
         if (ApprovalStatus != DecisionApprovalStatus.PendingApproval)
             throw new InvalidOperationException($"Cannot reject a decision with status {ApprovalStatus}.");
-
         ApprovedBy = rejectedBy;
         ApprovedAt = DateTimeOffset.UtcNow;
         ApprovalStatus = DecisionApprovalStatus.Rejected;
@@ -120,12 +119,6 @@ public class RemediationDecision
     public void Expire()
     {
         ApprovalStatus = DecisionApprovalStatus.Expired;
-        UpdatedAt = DateTimeOffset.UtcNow;
-    }
-
-    public void ReassignTenantSoftware(Guid newTenantSoftwareId)
-    {
-        TenantSoftwareId = newTenantSoftwareId;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 

--- a/src/PatchHound.Core/Entities/RemediationDecisionVulnerabilityOverride.cs
+++ b/src/PatchHound.Core/Entities/RemediationDecisionVulnerabilityOverride.cs
@@ -6,21 +6,21 @@ public class RemediationDecisionVulnerabilityOverride
 {
     public Guid Id { get; private set; }
     public Guid RemediationDecisionId { get; private set; }
-    public Guid TenantVulnerabilityId { get; private set; }
+    public Guid VulnerabilityId { get; private set; }
     public RemediationOutcome Outcome { get; private set; }
     public string Justification { get; private set; } = null!;
     public DateTimeOffset CreatedAt { get; private set; }
 
     public RemediationDecision RemediationDecision { get; private set; } = null!;
+    public Vulnerability Vulnerability { get; private set; } = null!;
 
     private RemediationDecisionVulnerabilityOverride() { }
 
     public static RemediationDecisionVulnerabilityOverride Create(
         Guid remediationDecisionId,
-        Guid tenantVulnerabilityId,
+        Guid vulnerabilityId,
         RemediationOutcome outcome,
-        string justification
-    )
+        string justification)
     {
         if (string.IsNullOrWhiteSpace(justification))
             throw new ArgumentException("Justification is required for a vulnerability override.");
@@ -29,7 +29,7 @@ public class RemediationDecisionVulnerabilityOverride
         {
             Id = Guid.NewGuid(),
             RemediationDecisionId = remediationDecisionId,
-            TenantVulnerabilityId = tenantVulnerabilityId,
+            VulnerabilityId = vulnerabilityId,
             Outcome = outcome,
             Justification = justification,
             CreatedAt = DateTimeOffset.UtcNow,

--- a/src/PatchHound.Core/Entities/RemediationWorkflow.cs
+++ b/src/PatchHound.Core/Entities/RemediationWorkflow.cs
@@ -8,7 +8,7 @@ public class RemediationWorkflow
 
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
-    public Guid TenantSoftwareId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
     public Guid SoftwareOwnerTeamId { get; private set; }
     public Guid? RecurrenceSourceWorkflowId { get; private set; }
     public RemediationWorkflowStage CurrentStage { get; private set; }
@@ -22,24 +22,29 @@ public class RemediationWorkflow
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
+    public RemediationCase RemediationCase { get; private set; } = null!;
     public IReadOnlyCollection<RemediationWorkflowStageRecord> StageRecords => _stageRecords.AsReadOnly();
 
     private RemediationWorkflow() { }
 
     public static RemediationWorkflow Create(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         Guid softwareOwnerTeamId,
         RemediationWorkflowStage initialStage = RemediationWorkflowStage.SecurityAnalysis,
-        Guid? recurrenceSourceWorkflowId = null
-    )
+        Guid? recurrenceSourceWorkflowId = null)
     {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (remediationCaseId == Guid.Empty)
+            throw new ArgumentException("RemediationCaseId is required.", nameof(remediationCaseId));
+
         var now = DateTimeOffset.UtcNow;
         return new RemediationWorkflow
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
-            TenantSoftwareId = tenantSoftwareId,
+            RemediationCaseId = remediationCaseId,
             SoftwareOwnerTeamId = softwareOwnerTeamId,
             RecurrenceSourceWorkflowId = recurrenceSourceWorkflowId,
             CurrentStage = initialStage,
@@ -54,8 +59,7 @@ public class RemediationWorkflow
     public void SetDecisionContext(
         RemediationOutcome? proposedOutcome,
         RemediationWorkflowPriority? priority,
-        RemediationWorkflowApprovalMode approvalMode
-    )
+        RemediationWorkflowApprovalMode approvalMode)
     {
         ProposedOutcome = proposedOutcome;
         Priority = priority;
@@ -81,12 +85,6 @@ public class RemediationWorkflow
     {
         Status = RemediationWorkflowStatus.Cancelled;
         CancelledAt = DateTimeOffset.UtcNow;
-        UpdatedAt = DateTimeOffset.UtcNow;
-    }
-
-    public void ReassignTenantSoftware(Guid newTenantSoftwareId)
-    {
-        TenantSoftwareId = newTenantSoftwareId;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/src/PatchHound.Core/Entities/RiskAcceptance.cs
+++ b/src/PatchHound.Core/Entities/RiskAcceptance.cs
@@ -5,9 +5,9 @@ namespace PatchHound.Core.Entities;
 public class RiskAcceptance
 {
     public Guid Id { get; private set; }
-    public Guid TenantVulnerabilityId { get; private set; }
-    public Guid? AssetId { get; private set; }
     public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public Guid? VulnerabilityId { get; private set; }
     public Guid RequestedBy { get; private set; }
     public DateTimeOffset RequestedAt { get; private set; }
     public Guid? ApprovedBy { get; private set; }
@@ -19,30 +19,34 @@ public class RiskAcceptance
     public int? ReviewFrequency { get; private set; }
     public DateTimeOffset? NextReviewDate { get; private set; }
 
+    public RemediationCase RemediationCase { get; private set; } = null!;
+
     private RiskAcceptance() { }
 
     public static RiskAcceptance Create(
-        Guid tenantVulnerabilityId,
         Guid tenantId,
+        Guid remediationCaseId,
         Guid requestedBy,
         string justification,
-        Guid? assetId = null,
+        Guid? vulnerabilityId = null,
         string? conditions = null,
         DateTimeOffset? expiryDate = null,
         int? reviewFrequency = null,
-        DateTimeOffset? nextReviewDate = null
-    )
+        DateTimeOffset? nextReviewDate = null)
     {
+        if (string.IsNullOrWhiteSpace(justification))
+            throw new ArgumentException("Justification is required.", nameof(justification));
+
         return new RiskAcceptance
         {
             Id = Guid.NewGuid(),
-            TenantVulnerabilityId = tenantVulnerabilityId,
             TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            VulnerabilityId = vulnerabilityId,
             RequestedBy = requestedBy,
             RequestedAt = DateTimeOffset.UtcNow,
             Status = RiskAcceptanceStatus.Pending,
             Justification = justification,
-            AssetId = assetId,
             Conditions = conditions,
             ExpiryDate = expiryDate,
             ReviewFrequency = reviewFrequency,
@@ -50,23 +54,14 @@ public class RiskAcceptance
         };
     }
 
-    public void Approve(
-        Guid approvedBy,
-        string? conditions = null,
-        DateTimeOffset? expiryDate = null,
-        int? reviewFrequency = null
-    )
+    public void Approve(Guid approvedBy, string? conditions = null, DateTimeOffset? expiryDate = null, int? reviewFrequency = null)
     {
         ApprovedBy = approvedBy;
         ApprovedAt = DateTimeOffset.UtcNow;
         Status = RiskAcceptanceStatus.Approved;
-
-        if (conditions is not null)
-            Conditions = conditions;
-        if (expiryDate.HasValue)
-            ExpiryDate = expiryDate;
-        if (reviewFrequency.HasValue)
-            ReviewFrequency = reviewFrequency;
+        if (conditions is not null) Conditions = conditions;
+        if (expiryDate.HasValue) ExpiryDate = expiryDate;
+        if (reviewFrequency.HasValue) ReviewFrequency = reviewFrequency;
     }
 
     public void Reject(Guid rejectedBy)
@@ -76,8 +71,5 @@ public class RiskAcceptance
         Status = RiskAcceptanceStatus.Rejected;
     }
 
-    public void Expire()
-    {
-        Status = RiskAcceptanceStatus.Expired;
-    }
+    public void Expire() => Status = RiskAcceptanceStatus.Expired;
 }

--- a/src/PatchHound.Core/Entities/SoftwareDescriptionJob.cs
+++ b/src/PatchHound.Core/Entities/SoftwareDescriptionJob.cs
@@ -6,8 +6,7 @@ public class SoftwareDescriptionJob
 {
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
-    public Guid TenantSoftwareId { get; private set; }
-    public Guid NormalizedSoftwareId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
     public Guid? TenantAiProfileId { get; private set; }
     public SoftwareDescriptionJobStatus Status { get; private set; }
     public string Error { get; private set; } = string.Empty;
@@ -20,18 +19,17 @@ public class SoftwareDescriptionJob
 
     public static SoftwareDescriptionJob Create(
         Guid tenantId,
-        Guid tenantSoftwareId,
-        Guid normalizedSoftwareId,
+        Guid softwareProductId,
         Guid? tenantAiProfileId,
-        DateTimeOffset requestedAt
-    )
+        DateTimeOffset requestedAt)
     {
+        if (tenantId == Guid.Empty) throw new ArgumentException("TenantId is required.");
+        if (softwareProductId == Guid.Empty) throw new ArgumentException("SoftwareProductId is required.");
         return new SoftwareDescriptionJob
         {
             Id = Guid.NewGuid(),
             TenantId = tenantId,
-            TenantSoftwareId = tenantSoftwareId,
-            NormalizedSoftwareId = normalizedSoftwareId,
+            SoftwareProductId = softwareProductId,
             TenantAiProfileId = tenantAiProfileId,
             Status = SoftwareDescriptionJobStatus.Pending,
             RequestedAt = requestedAt,

--- a/src/PatchHound.Core/Enums/RemediationCaseStatus.cs
+++ b/src/PatchHound.Core/Enums/RemediationCaseStatus.cs
@@ -1,0 +1,7 @@
+namespace PatchHound.Core.Enums;
+
+public enum RemediationCaseStatus
+{
+    Open = 0,
+    Closed = 1,
+}

--- a/src/PatchHound.Core/Models/SoftwareDescriptionGenerationResult.cs
+++ b/src/PatchHound.Core/Models/SoftwareDescriptionGenerationResult.cs
@@ -1,8 +1,7 @@
 namespace PatchHound.Core.Models;
 
 public record SoftwareDescriptionGenerationResult(
-    Guid TenantSoftwareId,
-    Guid NormalizedSoftwareId,
+    Guid SoftwareProductId,
     string Description,
     string ProviderType,
     string ProfileName,

--- a/src/PatchHound.Infrastructure/Data/Configurations/AIReportConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/AIReportConfiguration.cs
@@ -13,7 +13,9 @@ public class AIReportConfiguration : IEntityTypeConfiguration<AIReport>
         builder.HasIndex(r => r.TenantId);
         builder.HasIndex(r => r.TenantAiProfileId);
         builder.HasIndex(r => r.VulnerabilityId);
+        builder.HasIndex(r => new { r.TenantId, r.RemediationCaseId, r.GeneratedAt });
 
+        builder.Property(r => r.RemediationCaseId).IsRequired();
         builder.Property(r => r.Content).HasColumnType("text").IsRequired();
         builder.Property(r => r.ProviderType).HasMaxLength(32).IsRequired();
         builder.Property(r => r.ProfileName).HasMaxLength(256).IsRequired();
@@ -22,10 +24,16 @@ public class AIReportConfiguration : IEntityTypeConfiguration<AIReport>
         builder.Property(r => r.Temperature).HasPrecision(4, 2);
 
         builder
+            .HasOne(r => r.RemediationCase)
+            .WithMany()
+            .HasForeignKey(r => r.RemediationCaseId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder
             .HasOne(r => r.Vulnerability)
             .WithMany()
             .HasForeignKey(r => r.VulnerabilityId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.SetNull);
 
         builder
             .HasOne(r => r.TenantAiProfile)

--- a/src/PatchHound.Infrastructure/Data/Configurations/AnalystRecommendationConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/AnalystRecommendationConfiguration.cs
@@ -11,12 +11,19 @@ public class AnalystRecommendationConfiguration : IEntityTypeConfiguration<Analy
         builder.HasKey(ar => ar.Id);
 
         builder.HasIndex(ar => ar.TenantId);
-        builder.HasIndex(ar => new { ar.TenantId, ar.SoftwareAssetId });
         builder.HasIndex(ar => ar.RemediationWorkflowId);
+        builder.HasIndex(ar => new { ar.TenantId, ar.RemediationCaseId });
 
+        builder.Property(ar => ar.RemediationCaseId).IsRequired();
         builder.Property(ar => ar.RecommendedOutcome).HasConversion<string>().HasMaxLength(32);
         builder.Property(ar => ar.Rationale).HasColumnType("text").IsRequired();
         builder.Property(ar => ar.PriorityOverride).HasMaxLength(64);
+
+        builder
+            .HasOne(ar => ar.RemediationCase)
+            .WithMany()
+            .HasForeignKey(ar => ar.RemediationCaseId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         builder
             .HasOne(ar => ar.RemediationWorkflow)

--- a/src/PatchHound.Infrastructure/Data/Configurations/ApprovalTaskConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/ApprovalTaskConfiguration.cs
@@ -15,10 +15,19 @@ public class ApprovalTaskConfiguration : IEntityTypeConfiguration<ApprovalTask>
         builder.HasIndex(at => at.Status);
         builder.HasIndex(at => at.ExpiresAt);
         builder.HasIndex(at => at.RemediationWorkflowId);
+        builder.HasIndex(at => new { at.TenantId, at.RemediationCaseId, at.Status });
+
+        builder.Property(at => at.RemediationCaseId).IsRequired();
 
         builder.Property(at => at.Type).HasConversion<string>().HasMaxLength(32);
         builder.Property(at => at.Status).HasConversion<string>().HasMaxLength(32);
         builder.Property(at => at.ResolutionJustification).HasColumnType("text");
+
+        builder
+            .HasOne(at => at.RemediationCase)
+            .WithMany()
+            .HasForeignKey(at => at.RemediationCaseId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         builder
             .HasOne(at => at.RemediationDecision)

--- a/src/PatchHound.Infrastructure/Data/Configurations/PatchingTaskConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/PatchingTaskConfiguration.cs
@@ -11,12 +11,19 @@ public class PatchingTaskConfiguration : IEntityTypeConfiguration<PatchingTask>
         builder.HasKey(pt => pt.Id);
 
         builder.HasIndex(pt => pt.TenantId);
-        builder.HasIndex(pt => new { pt.TenantId, pt.TenantSoftwareId });
         builder.HasIndex(pt => pt.OwnerTeamId);
         builder.HasIndex(pt => pt.Status);
         builder.HasIndex(pt => pt.RemediationWorkflowId);
+        builder.HasIndex(pt => new { pt.TenantId, pt.RemediationCaseId, pt.Status });
 
+        builder.Property(pt => pt.RemediationCaseId).IsRequired();
         builder.Property(pt => pt.Status).HasConversion<string>().HasMaxLength(32);
+
+        builder
+            .HasOne(pt => pt.RemediationCase)
+            .WithMany()
+            .HasForeignKey(pt => pt.RemediationCaseId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         builder
             .HasOne(pt => pt.RemediationDecision)

--- a/src/PatchHound.Infrastructure/Data/Configurations/RemediationAiJobConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RemediationAiJobConfiguration.cs
@@ -11,9 +11,10 @@ public class RemediationAiJobConfiguration : IEntityTypeConfiguration<Remediatio
         builder.HasKey(item => item.Id);
 
         builder.HasIndex(item => item.TenantId);
-        builder.HasIndex(item => new { item.TenantId, item.TenantSoftwareId, item.RequestedAt });
-        builder.HasIndex(item => new { item.TenantId, item.TenantSoftwareId, item.Status });
+        builder.HasIndex(item => new { item.TenantId, item.RemediationCaseId, item.RequestedAt });
+        builder.HasIndex(item => new { item.TenantId, item.RemediationCaseId, item.Status });
 
+        builder.Property(item => item.RemediationCaseId).IsRequired();
         builder.Property(item => item.Status).HasConversion<string>().HasMaxLength(16);
         builder.Property(item => item.InputHash).HasMaxLength(128).IsRequired();
         builder.Property(item => item.Error).HasMaxLength(2048).IsRequired();

--- a/src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class RemediationCaseConfiguration : IEntityTypeConfiguration<RemediationCase>
+{
+    public void Configure(EntityTypeBuilder<RemediationCase> builder)
+    {
+        builder.ToTable("RemediationCases");
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.TenantId).IsRequired();
+        builder.Property(c => c.SoftwareProductId).IsRequired();
+        builder.Property(c => c.Status).HasConversion<string>().HasMaxLength(32);
+        builder.Property(c => c.CreatedAt).IsRequired();
+        builder.Property(c => c.UpdatedAt).IsRequired();
+
+        builder.HasIndex(c => new { c.TenantId, c.SoftwareProductId }).IsUnique();
+        builder.HasIndex(c => c.TenantId);
+
+        builder.HasOne(c => c.SoftwareProduct)
+            .WithMany()
+            .HasForeignKey(c => c.SoftwareProductId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionConfiguration.cs
@@ -11,18 +11,19 @@ public class RemediationDecisionConfiguration : IEntityTypeConfiguration<Remedia
         builder.HasKey(rd => rd.Id);
 
         builder.HasIndex(rd => rd.TenantId);
-        builder.HasIndex(rd => new { rd.TenantId, rd.TenantSoftwareId });
         builder.HasIndex(rd => rd.ApprovalStatus);
         builder.HasIndex(rd => rd.RemediationWorkflowId);
+        builder.HasIndex(rd => new { rd.TenantId, rd.RemediationCaseId, rd.ApprovalStatus });
 
+        builder.Property(rd => rd.RemediationCaseId).IsRequired();
         builder.Property(rd => rd.Outcome).HasConversion<string>().HasMaxLength(32);
         builder.Property(rd => rd.ApprovalStatus).HasConversion<string>().HasMaxLength(32);
         builder.Property(rd => rd.Justification).HasColumnType("text");
 
         builder
-            .HasOne(rd => rd.SoftwareAsset)
+            .HasOne(rd => rd.RemediationCase)
             .WithMany()
-            .HasForeignKey(rd => rd.SoftwareAssetId)
+            .HasForeignKey(rd => rd.RemediationCaseId)
             .OnDelete(DeleteBehavior.Restrict);
 
         builder

--- a/src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionVulnerabilityOverrideConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RemediationDecisionVulnerabilityOverrideConfiguration.cs
@@ -11,9 +11,15 @@ public class RemediationDecisionVulnerabilityOverrideConfiguration
     {
         builder.HasKey(vo => vo.Id);
 
-        builder.HasIndex(vo => new { vo.RemediationDecisionId, vo.TenantVulnerabilityId }).IsUnique();
+        builder.HasIndex(vo => new { vo.RemediationDecisionId, vo.VulnerabilityId }).IsUnique();
 
         builder.Property(vo => vo.Outcome).HasConversion<string>().HasMaxLength(32);
         builder.Property(vo => vo.Justification).HasColumnType("text").IsRequired();
+
+        builder
+            .HasOne(vo => vo.Vulnerability)
+            .WithMany()
+            .HasForeignKey(vo => vo.VulnerabilityId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RemediationWorkflowConfiguration.cs
@@ -11,9 +11,14 @@ public class RemediationWorkflowConfiguration : IEntityTypeConfiguration<Remedia
         builder.HasKey(workflow => workflow.Id);
 
         builder.HasIndex(workflow => workflow.TenantId);
-        builder.HasIndex(workflow => new { workflow.TenantId, workflow.TenantSoftwareId });
-        builder.HasIndex(workflow => new { workflow.TenantId, workflow.Status });
         builder.HasIndex(workflow => workflow.RecurrenceSourceWorkflowId);
+
+        builder.Property(workflow => workflow.RemediationCaseId).IsRequired();
+        builder.HasOne(workflow => workflow.RemediationCase)
+            .WithMany()
+            .HasForeignKey(workflow => workflow.RemediationCaseId)
+            .OnDelete(DeleteBehavior.Restrict);
+        builder.HasIndex(workflow => new { workflow.TenantId, workflow.RemediationCaseId, workflow.Status });
 
         builder.Property(workflow => workflow.CurrentStage).HasConversion<string>().HasMaxLength(32);
         builder.Property(workflow => workflow.Status).HasConversion<string>().HasMaxLength(32);

--- a/src/PatchHound.Infrastructure/Data/Configurations/RiskAcceptanceConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RiskAcceptanceConfiguration.cs
@@ -11,11 +11,18 @@ public class RiskAcceptanceConfiguration : IEntityTypeConfiguration<RiskAcceptan
         builder.HasKey(ra => ra.Id);
 
         builder.HasIndex(ra => ra.TenantId);
-        builder.HasIndex(ra => ra.TenantVulnerabilityId);
         builder.HasIndex(ra => ra.Status);
+        builder.HasIndex(ra => new { ra.TenantId, ra.RemediationCaseId, ra.Status });
 
+        builder.Property(ra => ra.RemediationCaseId).IsRequired();
         builder.Property(ra => ra.Status).HasConversion<string>().HasMaxLength(32);
         builder.Property(ra => ra.Justification).HasColumnType("text").IsRequired();
         builder.Property(ra => ra.Conditions).HasMaxLength(2048);
+
+        builder
+            .HasOne(ra => ra.RemediationCase)
+            .WithMany()
+            .HasForeignKey(ra => ra.RemediationCaseId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/PatchHound.Infrastructure/Data/Configurations/SoftwareDescriptionJobConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/SoftwareDescriptionJobConfiguration.cs
@@ -11,9 +11,9 @@ public class SoftwareDescriptionJobConfiguration : IEntityTypeConfiguration<Soft
         builder.HasKey(item => item.Id);
 
         builder.HasIndex(item => item.TenantId);
-        builder.HasIndex(item => new { item.TenantId, item.TenantSoftwareId, item.RequestedAt });
-        builder.HasIndex(item => new { item.TenantId, item.TenantSoftwareId, item.Status });
+        builder.HasIndex(item => new { item.TenantId, item.SoftwareProductId, item.Status });
 
+        builder.Property(item => item.SoftwareProductId).IsRequired();
         builder.Property(item => item.Status).HasConversion<string>().HasMaxLength(16);
         builder.Property(item => item.Error).HasMaxLength(2048).IsRequired();
     }

--- a/src/PatchHound.Infrastructure/Data/Migrations/20260414105853_RemediationOverrideVulnerabilityReanchor.Designer.cs
+++ b/src/PatchHound.Infrastructure/Data/Migrations/20260414105853_RemediationOverrideVulnerabilityReanchor.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414105853_RemediationOverrideVulnerabilityReanchor")]
+    partial class RemediationOverrideVulnerabilityReanchor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Data/Migrations/20260414105853_RemediationOverrideVulnerabilityReanchor.cs
+++ b/src/PatchHound.Infrastructure/Data/Migrations/20260414105853_RemediationOverrideVulnerabilityReanchor.cs
@@ -1,0 +1,768 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemediationOverrideVulnerabilityReanchor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AIReports_Vulnerabilities_VulnerabilityId",
+                table: "AIReports");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RemediationDecisions_Assets_SoftwareAssetId",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SoftwareDescriptionJobs_TenantId_TenantSoftwareId_Requested~",
+                table: "SoftwareDescriptionJobs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationWorkflows_TenantId_Status",
+                table: "RemediationWorkflows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationWorkflows_TenantId_TenantSoftwareId",
+                table: "RemediationWorkflows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationDecisions_SoftwareAssetId",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationDecisions_TenantId_TenantSoftwareId",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PatchingTasks_TenantId_TenantSoftwareId",
+                table: "PatchingTasks");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedSoftwareId",
+                table: "SoftwareDescriptionJobs");
+
+            migrationBuilder.DropColumn(
+                name: "SoftwareAssetId",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropColumn(
+                name: "SoftwareAssetId",
+                table: "PatchingTasks");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantSoftwareId",
+                table: "SoftwareDescriptionJobs",
+                newName: "SoftwareProductId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_SoftwareDescriptionJobs_TenantId_TenantSoftwareId_Status",
+                table: "SoftwareDescriptionJobs",
+                newName: "IX_SoftwareDescriptionJobs_TenantId_SoftwareProductId_Status");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantVulnerabilityId",
+                table: "RiskAcceptances",
+                newName: "RemediationCaseId");
+
+            migrationBuilder.RenameColumn(
+                name: "AssetId",
+                table: "RiskAcceptances",
+                newName: "VulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RiskAcceptances_TenantVulnerabilityId",
+                table: "RiskAcceptances",
+                newName: "IX_RiskAcceptances_RemediationCaseId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantSoftwareId",
+                table: "RemediationWorkflows",
+                newName: "RemediationCaseId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantVulnerabilityId",
+                table: "RemediationDecisionVulnerabilityOverrides",
+                newName: "VulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantSoftwareId",
+                table: "RemediationDecisions",
+                newName: "RemediationCaseId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantSoftwareId",
+                table: "RemediationAiJobs",
+                newName: "RemediationCaseId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RemediationAiJobs_TenantId_TenantSoftwareId_Status",
+                table: "RemediationAiJobs",
+                newName: "IX_RemediationAiJobs_TenantId_RemediationCaseId_Status");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RemediationAiJobs_TenantId_TenantSoftwareId_RequestedAt",
+                table: "RemediationAiJobs",
+                newName: "IX_RemediationAiJobs_TenantId_RemediationCaseId_RequestedAt");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantSoftwareId",
+                table: "PatchingTasks",
+                newName: "RemediationCaseId");
+
+            migrationBuilder.RenameColumn(
+                name: "TenantVulnerabilityId",
+                table: "AnalystRecommendations",
+                newName: "VulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "SoftwareAssetId",
+                table: "AnalystRecommendations",
+                newName: "RemediationCaseId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_AnalystRecommendations_TenantId_SoftwareAssetId",
+                table: "AnalystRecommendations",
+                newName: "IX_AnalystRecommendations_TenantId_RemediationCaseId");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "RemediationCaseId",
+                table: "ApprovalTasks",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "VulnerabilityId",
+                table: "AIReports",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "RemediationCaseId",
+                table: "AIReports",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "DeviceVulnerabilityExposures",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    VulnerabilityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InstalledSoftwareId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MatchedVersion = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    MatchSource = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    FirstObservedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastObservedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ResolvedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceVulnerabilityExposures", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DeviceVulnerabilityExposures_Devices_DeviceId",
+                        column: x => x.DeviceId,
+                        principalTable: "Devices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_DeviceVulnerabilityExposures_InstalledSoftware_InstalledSof~",
+                        column: x => x.InstalledSoftwareId,
+                        principalTable: "InstalledSoftware",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_DeviceVulnerabilityExposures_SoftwareProducts_SoftwareProdu~",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_DeviceVulnerabilityExposures_Vulnerabilities_VulnerabilityId",
+                        column: x => x.VulnerabilityId,
+                        principalTable: "Vulnerabilities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RemediationCases",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ClosedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RemediationCases", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RemediationCases_SoftwareProducts_SoftwareProductId",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ExposureAssessments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceVulnerabilityExposureId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SecurityProfileId = table.Column<Guid>(type: "uuid", nullable: true),
+                    BaseCvss = table.Column<decimal>(type: "numeric(4,2)", nullable: false),
+                    EnvironmentalCvss = table.Column<decimal>(type: "numeric(4,2)", nullable: false),
+                    Reason = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExposureAssessments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExposureAssessments_DeviceVulnerabilityExposures_DeviceVuln~",
+                        column: x => x.DeviceVulnerabilityExposureId,
+                        principalTable: "DeviceVulnerabilityExposures",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ExposureAssessments_SecurityProfiles_SecurityProfileId",
+                        column: x => x.SecurityProfileId,
+                        principalTable: "SecurityProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ExposureEpisodes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DeviceVulnerabilityExposureId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EpisodeNumber = table.Column<int>(type: "integer", nullable: false),
+                    FirstSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ClosedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExposureEpisodes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExposureEpisodes_DeviceVulnerabilityExposures_DeviceVulnera~",
+                        column: x => x.DeviceVulnerabilityExposureId,
+                        principalTable: "DeviceVulnerabilityExposures",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RiskAcceptances_TenantId_RemediationCaseId_Status",
+                table: "RiskAcceptances",
+                columns: new[] { "TenantId", "RemediationCaseId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationWorkflows_RemediationCaseId",
+                table: "RemediationWorkflows",
+                column: "RemediationCaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationWorkflows_TenantId_RemediationCaseId_Status",
+                table: "RemediationWorkflows",
+                columns: new[] { "TenantId", "RemediationCaseId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationDecisionVulnerabilityOverrides_VulnerabilityId",
+                table: "RemediationDecisionVulnerabilityOverrides",
+                column: "VulnerabilityId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationDecisions_RemediationCaseId",
+                table: "RemediationDecisions",
+                column: "RemediationCaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationDecisions_TenantId_RemediationCaseId_ApprovalSta~",
+                table: "RemediationDecisions",
+                columns: new[] { "TenantId", "RemediationCaseId", "ApprovalStatus" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PatchingTasks_RemediationCaseId",
+                table: "PatchingTasks",
+                column: "RemediationCaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PatchingTasks_TenantId_RemediationCaseId_Status",
+                table: "PatchingTasks",
+                columns: new[] { "TenantId", "RemediationCaseId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApprovalTasks_RemediationCaseId",
+                table: "ApprovalTasks",
+                column: "RemediationCaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApprovalTasks_TenantId_RemediationCaseId_Status",
+                table: "ApprovalTasks",
+                columns: new[] { "TenantId", "RemediationCaseId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnalystRecommendations_RemediationCaseId",
+                table: "AnalystRecommendations",
+                column: "RemediationCaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIReports_RemediationCaseId",
+                table: "AIReports",
+                column: "RemediationCaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIReports_TenantId_RemediationCaseId_GeneratedAt",
+                table: "AIReports",
+                columns: new[] { "TenantId", "RemediationCaseId", "GeneratedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_DeviceId",
+                table: "DeviceVulnerabilityExposures",
+                column: "DeviceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_InstalledSoftwareId",
+                table: "DeviceVulnerabilityExposures",
+                column: "InstalledSoftwareId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_SoftwareProductId",
+                table: "DeviceVulnerabilityExposures",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_TenantId",
+                table: "DeviceVulnerabilityExposures",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_TenantId_DeviceId_Vulnerabilit~",
+                table: "DeviceVulnerabilityExposures",
+                columns: new[] { "TenantId", "DeviceId", "VulnerabilityId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_TenantId_Status",
+                table: "DeviceVulnerabilityExposures",
+                columns: new[] { "TenantId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_TenantId_VulnerabilityId",
+                table: "DeviceVulnerabilityExposures",
+                columns: new[] { "TenantId", "VulnerabilityId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceVulnerabilityExposures_VulnerabilityId",
+                table: "DeviceVulnerabilityExposures",
+                column: "VulnerabilityId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExposureAssessments_DeviceVulnerabilityExposureId",
+                table: "ExposureAssessments",
+                column: "DeviceVulnerabilityExposureId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExposureAssessments_SecurityProfileId",
+                table: "ExposureAssessments",
+                column: "SecurityProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExposureAssessments_TenantId_DeviceVulnerabilityExposureId",
+                table: "ExposureAssessments",
+                columns: new[] { "TenantId", "DeviceVulnerabilityExposureId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExposureEpisodes_DeviceVulnerabilityExposureId",
+                table: "ExposureEpisodes",
+                column: "DeviceVulnerabilityExposureId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExposureEpisodes_TenantId",
+                table: "ExposureEpisodes",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExposureEpisodes_TenantId_DeviceVulnerabilityExposureId_Epi~",
+                table: "ExposureEpisodes",
+                columns: new[] { "TenantId", "DeviceVulnerabilityExposureId", "EpisodeNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationCases_SoftwareProductId",
+                table: "RemediationCases",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationCases_TenantId",
+                table: "RemediationCases",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationCases_TenantId_SoftwareProductId",
+                table: "RemediationCases",
+                columns: new[] { "TenantId", "SoftwareProductId" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AIReports_RemediationCases_RemediationCaseId",
+                table: "AIReports",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AIReports_Vulnerabilities_VulnerabilityId",
+                table: "AIReports",
+                column: "VulnerabilityId",
+                principalTable: "Vulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AnalystRecommendations_RemediationCases_RemediationCaseId",
+                table: "AnalystRecommendations",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ApprovalTasks_RemediationCases_RemediationCaseId",
+                table: "ApprovalTasks",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PatchingTasks_RemediationCases_RemediationCaseId",
+                table: "PatchingTasks",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RemediationDecisions_RemediationCases_RemediationCaseId",
+                table: "RemediationDecisions",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RemediationDecisionVulnerabilityOverrides_Vulnerabilities_V~",
+                table: "RemediationDecisionVulnerabilityOverrides",
+                column: "VulnerabilityId",
+                principalTable: "Vulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RemediationWorkflows_RemediationCases_RemediationCaseId",
+                table: "RemediationWorkflows",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RiskAcceptances_RemediationCases_RemediationCaseId",
+                table: "RiskAcceptances",
+                column: "RemediationCaseId",
+                principalTable: "RemediationCases",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AIReports_RemediationCases_RemediationCaseId",
+                table: "AIReports");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_AIReports_Vulnerabilities_VulnerabilityId",
+                table: "AIReports");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_AnalystRecommendations_RemediationCases_RemediationCaseId",
+                table: "AnalystRecommendations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ApprovalTasks_RemediationCases_RemediationCaseId",
+                table: "ApprovalTasks");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PatchingTasks_RemediationCases_RemediationCaseId",
+                table: "PatchingTasks");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RemediationDecisions_RemediationCases_RemediationCaseId",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RemediationDecisionVulnerabilityOverrides_Vulnerabilities_V~",
+                table: "RemediationDecisionVulnerabilityOverrides");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RemediationWorkflows_RemediationCases_RemediationCaseId",
+                table: "RemediationWorkflows");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RiskAcceptances_RemediationCases_RemediationCaseId",
+                table: "RiskAcceptances");
+
+            migrationBuilder.DropTable(
+                name: "ExposureAssessments");
+
+            migrationBuilder.DropTable(
+                name: "ExposureEpisodes");
+
+            migrationBuilder.DropTable(
+                name: "RemediationCases");
+
+            migrationBuilder.DropTable(
+                name: "DeviceVulnerabilityExposures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RiskAcceptances_TenantId_RemediationCaseId_Status",
+                table: "RiskAcceptances");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationWorkflows_RemediationCaseId",
+                table: "RemediationWorkflows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationWorkflows_TenantId_RemediationCaseId_Status",
+                table: "RemediationWorkflows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationDecisionVulnerabilityOverrides_VulnerabilityId",
+                table: "RemediationDecisionVulnerabilityOverrides");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationDecisions_RemediationCaseId",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RemediationDecisions_TenantId_RemediationCaseId_ApprovalSta~",
+                table: "RemediationDecisions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PatchingTasks_RemediationCaseId",
+                table: "PatchingTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PatchingTasks_TenantId_RemediationCaseId_Status",
+                table: "PatchingTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ApprovalTasks_RemediationCaseId",
+                table: "ApprovalTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ApprovalTasks_TenantId_RemediationCaseId_Status",
+                table: "ApprovalTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AnalystRecommendations_RemediationCaseId",
+                table: "AnalystRecommendations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AIReports_RemediationCaseId",
+                table: "AIReports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AIReports_TenantId_RemediationCaseId_GeneratedAt",
+                table: "AIReports");
+
+            migrationBuilder.DropColumn(
+                name: "RemediationCaseId",
+                table: "ApprovalTasks");
+
+            migrationBuilder.DropColumn(
+                name: "RemediationCaseId",
+                table: "AIReports");
+
+            migrationBuilder.RenameColumn(
+                name: "SoftwareProductId",
+                table: "SoftwareDescriptionJobs",
+                newName: "TenantSoftwareId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_SoftwareDescriptionJobs_TenantId_SoftwareProductId_Status",
+                table: "SoftwareDescriptionJobs",
+                newName: "IX_SoftwareDescriptionJobs_TenantId_TenantSoftwareId_Status");
+
+            migrationBuilder.RenameColumn(
+                name: "VulnerabilityId",
+                table: "RiskAcceptances",
+                newName: "AssetId");
+
+            migrationBuilder.RenameColumn(
+                name: "RemediationCaseId",
+                table: "RiskAcceptances",
+                newName: "TenantVulnerabilityId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RiskAcceptances_RemediationCaseId",
+                table: "RiskAcceptances",
+                newName: "IX_RiskAcceptances_TenantVulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "RemediationCaseId",
+                table: "RemediationWorkflows",
+                newName: "TenantSoftwareId");
+
+            migrationBuilder.RenameColumn(
+                name: "VulnerabilityId",
+                table: "RemediationDecisionVulnerabilityOverrides",
+                newName: "TenantVulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "RemediationCaseId",
+                table: "RemediationDecisions",
+                newName: "TenantSoftwareId");
+
+            migrationBuilder.RenameColumn(
+                name: "RemediationCaseId",
+                table: "RemediationAiJobs",
+                newName: "TenantSoftwareId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RemediationAiJobs_TenantId_RemediationCaseId_Status",
+                table: "RemediationAiJobs",
+                newName: "IX_RemediationAiJobs_TenantId_TenantSoftwareId_Status");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_RemediationAiJobs_TenantId_RemediationCaseId_RequestedAt",
+                table: "RemediationAiJobs",
+                newName: "IX_RemediationAiJobs_TenantId_TenantSoftwareId_RequestedAt");
+
+            migrationBuilder.RenameColumn(
+                name: "RemediationCaseId",
+                table: "PatchingTasks",
+                newName: "TenantSoftwareId");
+
+            migrationBuilder.RenameColumn(
+                name: "VulnerabilityId",
+                table: "AnalystRecommendations",
+                newName: "TenantVulnerabilityId");
+
+            migrationBuilder.RenameColumn(
+                name: "RemediationCaseId",
+                table: "AnalystRecommendations",
+                newName: "SoftwareAssetId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_AnalystRecommendations_TenantId_RemediationCaseId",
+                table: "AnalystRecommendations",
+                newName: "IX_AnalystRecommendations_TenantId_SoftwareAssetId");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "NormalizedSoftwareId",
+                table: "SoftwareDescriptionJobs",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "SoftwareAssetId",
+                table: "RemediationDecisions",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "SoftwareAssetId",
+                table: "PatchingTasks",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "VulnerabilityId",
+                table: "AIReports",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareDescriptionJobs_TenantId_TenantSoftwareId_Requested~",
+                table: "SoftwareDescriptionJobs",
+                columns: new[] { "TenantId", "TenantSoftwareId", "RequestedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationWorkflows_TenantId_Status",
+                table: "RemediationWorkflows",
+                columns: new[] { "TenantId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationWorkflows_TenantId_TenantSoftwareId",
+                table: "RemediationWorkflows",
+                columns: new[] { "TenantId", "TenantSoftwareId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationDecisions_SoftwareAssetId",
+                table: "RemediationDecisions",
+                column: "SoftwareAssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemediationDecisions_TenantId_TenantSoftwareId",
+                table: "RemediationDecisions",
+                columns: new[] { "TenantId", "TenantSoftwareId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PatchingTasks_TenantId_TenantSoftwareId",
+                table: "PatchingTasks",
+                columns: new[] { "TenantId", "TenantSoftwareId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AIReports_Vulnerabilities_VulnerabilityId",
+                table: "AIReports",
+                column: "VulnerabilityId",
+                principalTable: "Vulnerabilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RemediationDecisions_Assets_SoftwareAssetId",
+                table: "RemediationDecisions",
+                column: "SoftwareAssetId",
+                principalTable: "Assets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+++ b/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
@@ -109,6 +109,7 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
     public DbSet<WorkflowInstance> WorkflowInstances => Set<WorkflowInstance>();
     public DbSet<WorkflowNodeExecution> WorkflowNodeExecutions => Set<WorkflowNodeExecution>();
     public DbSet<WorkflowAction> WorkflowActions => Set<WorkflowAction>();
+    public DbSet<RemediationCase> RemediationCases => Set<RemediationCase>();
     public DbSet<RemediationDecision> RemediationDecisions => Set<RemediationDecision>();
     public DbSet<RemediationDecisionVulnerabilityOverride> RemediationDecisionVulnerabilityOverrides =>
         Set<RemediationDecisionVulnerabilityOverride>();
@@ -388,6 +389,9 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
             );
         modelBuilder
             .Entity<WorkflowAction>()
+            .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+        modelBuilder
+            .Entity<RemediationCase>()
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<RemediationDecision>()

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -92,6 +92,7 @@ public static class DependencyInjection
         services.AddScoped<TeamMembershipRuleFilterBuilder>();
         services.AddScoped<TeamMembershipRuleService>();
         services.AddScoped<SlaService>();
+        services.AddScoped<RemediationCaseService>();
         services.AddScoped<RemediationWorkflowService>();
         services.AddScoped<PatchingTaskService>();
         services.AddScoped<ApprovalTaskService>();

--- a/src/PatchHound.Infrastructure/Services/AdvancedToolExecutionService.cs
+++ b/src/PatchHound.Infrastructure/Services/AdvancedToolExecutionService.cs
@@ -242,7 +242,7 @@ public class AdvancedToolExecutionService(
         }
 
         // Phase-2: VulnerabilityAsset + SoftwareVulnerabilityMatch deleted. Return empty context.
-        var openVulnerabilityRows = new List<(Guid TenantVulnerabilityId, string ExternalId)>();
+        var openVulnerabilityRows = new List<(Guid VulnerabilityId, string ExternalId)>();
         var requestedIds = new HashSet<Guid>();
         var vulnerabilityRows = openVulnerabilityRows;
         var softwareEvidenceRows = new List<(string ExternalId, string? Metadata)>();
@@ -260,7 +260,7 @@ public class AdvancedToolExecutionService(
             {
                 evidenceByExternalId.TryGetValue(row.ExternalId, out var softwareEvidence);
                 return new AdvancedToolVulnerabilityContext(
-                    row.TenantVulnerabilityId,
+                    row.VulnerabilityId,
                     row.ExternalId,
                     softwareEvidence?.Vendor,
                     softwareEvidence?.Product,

--- a/src/PatchHound.Infrastructure/Services/AnalystRecommendationService.cs
+++ b/src/PatchHound.Infrastructure/Services/AnalystRecommendationService.cs
@@ -11,63 +11,22 @@ public class AnalystRecommendationService(
     RemediationWorkflowService remediationWorkflowService
 )
 {
-    public async Task<Result<AnalystRecommendation>> AddRecommendationAsync(
+    public async Task<Result<AnalystRecommendation>> AddRecommendationForCaseAsync(
         Guid tenantId,
-        Guid softwareAssetId,
+        Guid remediationCaseId,
         RemediationOutcome recommendedOutcome,
         string rationale,
         Guid analystId,
-        Guid? tenantVulnerabilityId = null,
-        string? priorityOverride = null,
-        CancellationToken ct = default
-    )
-    {
-        var recommendation = AnalystRecommendation.Create(
-            tenantId,
-            softwareAssetId,
-            recommendedOutcome,
-            rationale,
-            analystId,
-            tenantVulnerabilityId,
-            priorityOverride
-        );
-
-        await dbContext.AnalystRecommendations.AddAsync(recommendation, ct);
-        await dbContext.SaveChangesAsync(ct);
-
-        return Result<AnalystRecommendation>.Success(recommendation);
-    }
-
-    public async Task<Result<AnalystRecommendation>> AddRecommendationForTenantSoftwareAsync(
-        Guid tenantId,
-        Guid tenantSoftwareId,
-        RemediationOutcome recommendedOutcome,
-        string rationale,
-        Guid analystId,
-        Guid? tenantVulnerabilityId = null,
+        Guid? vulnerabilityId = null,
         string? priorityOverride = null,
         CancellationToken ct = default
     )
     {
         var activeWorkflow = await remediationWorkflowService.GetOrCreateActiveWorkflowAsync(
             tenantId,
-            tenantSoftwareId,
+            remediationCaseId,
             ct
         );
-
-        var representativeSoftwareAssetId = await dbContext.NormalizedSoftwareInstallations
-            .IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
-                && item.IsActive)
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
-            .OrderBy(id => id)
-            .FirstOrDefaultAsync(ct);
-
-        if (representativeSoftwareAssetId == Guid.Empty)
-            return Result<AnalystRecommendation>.Failure("No tenant software scope was found for this software.");
 
         var recommendation = await dbContext.AnalystRecommendations
             .FirstOrDefaultAsync(item =>
@@ -80,11 +39,11 @@ public class AnalystRecommendationService(
         {
             recommendation = AnalystRecommendation.Create(
                 tenantId,
-                representativeSoftwareAssetId,
+                remediationCaseId,
                 recommendedOutcome,
                 rationale,
                 analystId,
-                tenantVulnerabilityId,
+                vulnerabilityId,
                 priorityOverride
             );
 
@@ -96,14 +55,14 @@ public class AnalystRecommendationService(
                 recommendedOutcome,
                 rationale,
                 analystId,
-                tenantVulnerabilityId,
+                vulnerabilityId,
                 priorityOverride
             );
         }
 
         await remediationWorkflowService.AttachRecommendationAsync(
             tenantId,
-            tenantSoftwareId,
+            remediationCaseId,
             recommendation,
             ct
         );

--- a/src/PatchHound.Infrastructure/Services/ApprovalTaskService.cs
+++ b/src/PatchHound.Infrastructure/Services/ApprovalTaskService.cs
@@ -33,7 +33,7 @@ public class ApprovalTaskService(
         var initialStatus = decision.ApprovalStatus == DecisionApprovalStatus.PendingApproval
             ? ApprovalTaskStatus.Pending
             : ApprovalTaskStatus.AutoApproved;
-        var task = ApprovalTask.Create(decision.TenantId, decision.Id, decision.Outcome, initialStatus, expiresAt);
+        var task = ApprovalTask.Create(decision.TenantId, decision.RemediationCaseId, decision.Id, decision.Outcome, initialStatus, expiresAt);
         await remediationWorkflowService.AttachApprovalTaskAsync(task, decision, ct);
 
         await dbContext.ApprovalTasks.AddAsync(task, ct);

--- a/src/PatchHound.Infrastructure/Services/EmailNotificationService.cs
+++ b/src/PatchHound.Infrastructure/Services/EmailNotificationService.cs
@@ -155,7 +155,7 @@ public class EmailNotificationService(
                 item.Id,
                 item.Type,
                 item.Status,
-                item.RemediationDecision.TenantSoftwareId,
+                item.RemediationCaseId,
                 item.RemediationDecision.MaintenanceWindowDate
             })
             .FirstOrDefaultAsync(ct);
@@ -163,7 +163,7 @@ public class EmailNotificationService(
         if (task is null)
             return null;
 
-        var summary = await BuildRemediationSummaryAsync(tenantId, task.TenantSoftwareId, ct);
+        var summary = await BuildRemediationSummaryAsync(tenantId, task.RemediationCaseId, ct);
         if (summary is null)
             return null;
 
@@ -190,7 +190,7 @@ public class EmailNotificationService(
             requirementText,
             $"{GetFrontendOrigin()}/approvals/{task.Id}",
             "Open approval task",
-            $"{GetFrontendOrigin()}/software/{task.TenantSoftwareId}/remediation",
+            $"{GetFrontendOrigin()}/remediation/cases/{task.RemediationCaseId}",
             "View remediation"
         );
     }
@@ -206,7 +206,7 @@ public class EmailNotificationService(
             .Select(item => new
             {
                 item.Id,
-                item.TenantSoftwareId,
+                item.RemediationCaseId,
                 item.OwnerTeamId
             })
             .FirstOrDefaultAsync(ct);
@@ -214,7 +214,7 @@ public class EmailNotificationService(
         if (task is null)
             return null;
 
-        var summary = await BuildRemediationSummaryAsync(tenantId, task.TenantSoftwareId, ct, task.OwnerTeamId);
+        var summary = await BuildRemediationSummaryAsync(tenantId, task.RemediationCaseId, ct);
         if (summary is null)
             return null;
 
@@ -224,42 +224,28 @@ public class EmailNotificationService(
             summary.AffectedDeviceCount,
             "Execution",
             "Patch the affected devices owned by your team and update progress in PatchHound so the remediation can be tracked to completion.",
-            $"{GetFrontendOrigin()}/remediation/tasks?tenantSoftwareId={task.TenantSoftwareId}",
+            $"{GetFrontendOrigin()}/remediation/tasks?caseId={task.RemediationCaseId}",
             "Open remediation tasks",
-            $"{GetFrontendOrigin()}/software/{task.TenantSoftwareId}/remediation",
+            $"{GetFrontendOrigin()}/remediation/cases/{task.RemediationCaseId}",
             "View remediation"
         );
     }
 
     private async Task<RemediationSummary?> BuildRemediationSummaryAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
-        CancellationToken ct,
-        Guid? ownerTeamId = null
+        Guid remediationCaseId,
+        CancellationToken ct
     )
     {
-        var softwareName = await dbContext.TenantSoftware.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.Id == tenantSoftwareId)
+        var softwareName = await dbContext.RemediationCases.AsNoTracking()
+            .Where(c => c.TenantId == tenantId && c.Id == remediationCaseId)
             .Join(
-                dbContext.NormalizedSoftware.AsNoTracking(),
-                tenantSoftware => tenantSoftware.NormalizedSoftwareId,
-                normalizedSoftware => normalizedSoftware.Id,
-                (tenantSoftware, normalizedSoftware) => normalizedSoftware.CanonicalName
+                dbContext.SoftwareProducts.AsNoTracking(),
+                c => c.SoftwareProductId,
+                sp => sp.Id,
+                (c, sp) => sp.Name
             )
             .FirstOrDefaultAsync(ct);
-
-        if (string.IsNullOrWhiteSpace(softwareName))
-        {
-            softwareName = await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-                .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-                .Join(
-                    dbContext.Assets.AsNoTracking(),
-                    item => item.SoftwareAssetId,
-                    asset => asset.Id,
-                    (item, asset) => asset.Name
-                )
-                .FirstOrDefaultAsync(ct);
-        }
 
         if (string.IsNullOrWhiteSpace(softwareName))
             return null;
@@ -268,30 +254,8 @@ public class EmailNotificationService(
         // Phase 3 will rewire severity via DeviceVulnerabilityExposure.
         var severity = Severity.Medium;
 
-        var affectedDeviceCount = ownerTeamId.HasValue
-            ? await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-                .Where(item =>
-                    item.TenantId == tenantId
-                    && item.TenantSoftwareId == tenantSoftwareId
-                    && item.IsActive)
-                .Join(
-                    dbContext.Assets.AsNoTracking(),
-                    item => item.DeviceAssetId,
-                    asset => asset.Id,
-                    (item, asset) => new { item.DeviceAssetId, TeamId = asset.OwnerTeamId ?? asset.FallbackTeamId }
-                )
-                .Where(item => item.TeamId == ownerTeamId.Value)
-                .Select(item => item.DeviceAssetId)
-                .Distinct()
-                .CountAsync(ct)
-            : await dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-                .Where(item =>
-                    item.TenantId == tenantId
-                    && item.TenantSoftwareId == tenantSoftwareId
-                    && item.IsActive)
-                .Select(item => item.DeviceAssetId)
-                .Distinct()
-                .CountAsync(ct);
+        // TODO Phase 5: count affected devices via DeviceVulnerabilityExposure once available.
+        const int affectedDeviceCount = 0;
 
         return new RemediationSummary(
             softwareName,

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -2495,30 +2495,10 @@ public class IngestionService
         if (oldToNew.Count == 0)
             return;
 
-        var oldIds = oldToNew.Keys.ToHashSet();
-
-        var decisions = await _dbContext
-            .RemediationDecisions.IgnoreQueryFilters()
-            .Where(d => oldIds.Contains(d.TenantSoftwareId))
-            .ToListAsync(ct);
-        foreach (var decision in decisions)
-            decision.ReassignTenantSoftware(oldToNew[decision.TenantSoftwareId]);
-
-        var workflows = await _dbContext
-            .RemediationWorkflows.IgnoreQueryFilters()
-            .Where(w => oldIds.Contains(w.TenantSoftwareId))
-            .ToListAsync(ct);
-        foreach (var workflow in workflows)
-            workflow.ReassignTenantSoftware(oldToNew[workflow.TenantSoftwareId]);
-
-        var tasks = await _dbContext
-            .PatchingTasks.IgnoreQueryFilters()
-            .Where(t => oldIds.Contains(t.TenantSoftwareId))
-            .ToListAsync(ct);
-        foreach (var task in tasks)
-            task.ReassignTenantSoftware(oldToNew[task.TenantSoftwareId]);
-
-        await _dbContext.SaveChangesAsync(ct);
+        // Phase 4: Remediation entities (RemediationDecision, RemediationWorkflow, PatchingTask)
+        // are now anchored on RemediationCase, which is keyed by (TenantId, SoftwareProductId).
+        // RemediationCase IDs are stable across snapshot rotations — no re-keying required.
+        await Task.CompletedTask;
     }
 
     private async Task DiscardBuildingSnapshotAsync(

--- a/src/PatchHound.Infrastructure/Services/PatchingTaskService.cs
+++ b/src/PatchHound.Infrastructure/Services/PatchingTaskService.cs
@@ -27,37 +27,15 @@ public class PatchingTaskService(
 
     public async Task<int> EnsurePatchingTasksAsync(RemediationDecision decision, CancellationToken ct)
     {
-        var scopedInstallations = await dbContext.NormalizedSoftwareInstallations
-            .IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == decision.TenantId
-                && item.TenantSoftwareId == decision.TenantSoftwareId
-                && item.IsActive)
-            .Select(item => new { item.DeviceAssetId })
-            .ToListAsync(ct);
-
-        if (scopedInstallations.Count == 0)
-            return 0;
-
-        var deviceAssetIds = scopedInstallations.Select(d => d.DeviceAssetId).Distinct().ToList();
+        // TODO Phase 5: group patching tasks by device owner team once DeviceVulnerabilityExposure
+        // is available for this case. For now, create a single patching task for the default team.
         var defaultTeamId = (await DefaultTeamHelper.EnsureDefaultTeamAsync(dbContext, decision.TenantId, ct)).Id;
-
-        var deviceTeams = await dbContext.Assets
-            .IgnoreQueryFilters()
-            .Where(a => deviceAssetIds.Contains(a.Id) && a.TenantId == decision.TenantId)
-            .Select(a => new { a.Id, a.OwnerTeamId, a.FallbackTeamId })
-            .ToListAsync(ct);
-
-        var teamGroups = deviceTeams
-            .GroupBy(device => device.OwnerTeamId ?? device.FallbackTeamId ?? defaultTeamId)
-            .ToDictionary(group => group.Key, group => group.Select(item => item.Id).Distinct().Count());
 
         var tenantSla = await dbContext.TenantSlaConfigurations
             .IgnoreQueryFilters()
             .FirstOrDefaultAsync(c => c.TenantId == decision.TenantId, ct);
 
         // Phase 2: canonical exposure data not yet available; default to Medium.
-        // Phase 3 will rewire via DeviceVulnerabilityExposure.
         var highestSeverity = Severity.Medium;
 
         var dueDate = slaService.CalculateDueDate(
@@ -66,71 +44,59 @@ public class PatchingTaskService(
             tenantSla
         );
 
-        var existingOpenTeamIds = await dbContext.PatchingTasks
+        var existingOpenForTeam = await dbContext.PatchingTasks
             .IgnoreQueryFilters()
-            .Where(task =>
+            .AnyAsync(task =>
                 task.TenantId == decision.TenantId
-                && task.TenantSoftwareId == decision.TenantSoftwareId
-                && task.Status != PatchingTaskStatus.Completed)
-            .Select(task => task.OwnerTeamId)
-            .Distinct()
-            .ToListAsync(ct);
+                && task.RemediationCaseId == decision.RemediationCaseId
+                && task.OwnerTeamId == defaultTeamId
+                && task.Status != PatchingTaskStatus.Completed,
+                ct);
 
-        var tasks = teamGroups.Keys
-            .Where(teamId => !existingOpenTeamIds.Contains(teamId))
-            .Select(teamId => PatchingTask.Create(
-                decision.TenantId,
-                decision.Id,
-                decision.TenantSoftwareId,
-                decision.SoftwareAssetId,
-                teamId,
-                dueDate
-            ))
-            .ToList();
-
-        if (tasks.Count == 0)
+        if (existingOpenForTeam)
             return 0;
 
-        foreach (var task in tasks)
-        {
-            await remediationWorkflowService.AttachPatchingTaskAsync(task, decision, ct);
-        }
+        var task = PatchingTask.Create(
+            decision.TenantId,
+            decision.RemediationCaseId,
+            decision.Id,
+            defaultTeamId,
+            dueDate
+        );
 
-        await dbContext.PatchingTasks.AddRangeAsync(tasks, ct);
+        await remediationWorkflowService.AttachPatchingTaskAsync(task, decision, ct);
+        await dbContext.PatchingTasks.AddAsync(task, ct);
         await dbContext.SaveChangesAsync(ct);
 
-        var softwareName = await dbContext.TenantSoftware
+        // Resolve software name via RemediationCase → SoftwareProduct
+        var softwareName = await dbContext.RemediationCases
             .IgnoreQueryFilters()
-            .Where(item => item.TenantId == decision.TenantId && item.Id == decision.TenantSoftwareId)
+            .Where(c => c.Id == decision.RemediationCaseId && c.TenantId == decision.TenantId)
             .Join(
-                dbContext.NormalizedSoftware.IgnoreQueryFilters(),
-                tenantSoftware => tenantSoftware.NormalizedSoftwareId,
-                normalizedSoftware => normalizedSoftware.Id,
-                (tenantSoftware, normalizedSoftware) => normalizedSoftware.CanonicalName
+                dbContext.SoftwareProducts,
+                c => c.SoftwareProductId,
+                sp => sp.Id,
+                (c, sp) => sp.Name
             )
             .FirstOrDefaultAsync(ct)
             ?? "Unknown software";
 
         var severityLabel = highestSeverity.ToString();
+        var maintenanceWindowText = decision.MaintenanceWindowDate is DateTimeOffset maintenanceWindowDate
+            ? $" Maintenance window: {maintenanceWindowDate:yyyy-MM-dd}."
+            : string.Empty;
 
-        foreach (var task in tasks)
-        {
-            var affectedDeviceCount = teamGroups.GetValueOrDefault(task.OwnerTeamId);
-            var maintenanceWindowText = decision.MaintenanceWindowDate is DateTimeOffset maintenanceWindowDate
-                ? $" Maintenance window: {maintenanceWindowDate:yyyy-MM-dd}."
-                : string.Empty;
-            await notificationService.SendToTeamAsync(
-                task.OwnerTeamId,
-                decision.TenantId,
-                NotificationType.TaskAssigned,
-                $"Remediation task assigned: {softwareName}",
-                $"Patch {softwareName}. Highest severity: {severityLabel}. Affected devices for your team: {affectedDeviceCount}.{maintenanceWindowText}",
-                "PatchingTask",
-                task.Id,
-                ct
-            );
-        }
+        await notificationService.SendToTeamAsync(
+            task.OwnerTeamId,
+            decision.TenantId,
+            NotificationType.TaskAssigned,
+            $"Remediation task assigned: {softwareName}",
+            $"Patch {softwareName}. Highest severity: {severityLabel}.{maintenanceWindowText}",
+            "PatchingTask",
+            task.Id,
+            ct
+        );
 
-        return tasks.Count;
+        return 1;
     }
 }

--- a/src/PatchHound.Infrastructure/Services/RemediationAiJobService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationAiJobService.cs
@@ -10,23 +10,23 @@ public class RemediationAiJobService(PatchHoundDbContext dbContext)
 {
     public async Task<Result<RemediationAiJob>> EnqueueAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         string inputHash,
         CancellationToken ct
     )
     {
-        var tenantSoftwareExists = await dbContext.TenantSoftware
-            .AnyAsync(item => item.TenantId == tenantId && item.Id == tenantSoftwareId, ct);
-        if (!tenantSoftwareExists)
+        var caseExists = await dbContext.RemediationCases
+            .AnyAsync(item => item.TenantId == tenantId && item.Id == remediationCaseId, ct);
+        if (!caseExists)
         {
-            return Result<RemediationAiJob>.Failure("Tenant software was not found.");
+            return Result<RemediationAiJob>.Failure("Remediation case was not found.");
         }
 
         var existingActiveJob = await dbContext.RemediationAiJobs
             .IgnoreQueryFilters()
             .Where(item =>
                 item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
+                && item.RemediationCaseId == remediationCaseId
                 && (
                     item.Status == RemediationAiJobStatus.Pending
                     || item.Status == RemediationAiJobStatus.Running
@@ -46,7 +46,7 @@ public class RemediationAiJobService(PatchHoundDbContext dbContext)
 
         var latestCompletedJob = await dbContext.RemediationAiJobs
             .IgnoreQueryFilters()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId)
+            .Where(item => item.TenantId == tenantId && item.RemediationCaseId == remediationCaseId)
             .OrderByDescending(item => item.RequestedAt)
             .FirstOrDefaultAsync(ct);
         if (latestCompletedJob is not null
@@ -56,18 +56,18 @@ public class RemediationAiJobService(PatchHoundDbContext dbContext)
             return Result<RemediationAiJob>.Success(latestCompletedJob);
         }
 
-        var job = RemediationAiJob.Create(tenantId, tenantSoftwareId, inputHash, DateTimeOffset.UtcNow);
+        var job = RemediationAiJob.Create(tenantId, remediationCaseId, inputHash, DateTimeOffset.UtcNow);
         await dbContext.RemediationAiJobs.AddAsync(job, ct);
         await dbContext.SaveChangesAsync(ct);
 
         return Result<RemediationAiJob>.Success(job);
     }
 
-    public Task<RemediationAiJob?> GetLatestAsync(Guid tenantId, Guid tenantSoftwareId, CancellationToken ct)
+    public Task<RemediationAiJob?> GetLatestAsync(Guid tenantId, Guid remediationCaseId, CancellationToken ct)
     {
         return dbContext.RemediationAiJobs
             .AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId)
+            .Where(item => item.TenantId == tenantId && item.RemediationCaseId == remediationCaseId)
             .OrderByDescending(item => item.RequestedAt)
             .FirstOrDefaultAsync(ct);
     }

--- a/src/PatchHound.Infrastructure/Services/RemediationCaseService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationCaseService.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class RemediationCaseService(PatchHoundDbContext db)
+{
+    public async Task<RemediationCase> GetOrCreateAsync(
+        Guid tenantId,
+        Guid softwareProductId,
+        CancellationToken ct)
+    {
+        var existing = await db.RemediationCases
+            .FirstOrDefaultAsync(
+                c => c.TenantId == tenantId && c.SoftwareProductId == softwareProductId,
+                ct);
+        if (existing is not null)
+            return existing;
+
+        var productExists = await db.SoftwareProducts
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == softwareProductId, ct);
+        if (!productExists)
+            throw new InvalidOperationException(
+                $"SoftwareProduct {softwareProductId} does not exist; cannot create remediation case.");
+
+        var created = RemediationCase.Create(tenantId, softwareProductId);
+        db.RemediationCases.Add(created);
+        await db.SaveChangesAsync(ct);
+        return created;
+    }
+
+    public async Task<RemediationCase?> GetAsync(Guid caseId, CancellationToken ct)
+    {
+        return await db.RemediationCases.FirstOrDefaultAsync(c => c.Id == caseId, ct);
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
@@ -16,9 +16,9 @@ public class RemediationDecisionService(
 {
     private const int DefaultApprovalExpiryHours = 24;
 
-    public async Task<Result<RemediationDecision>> CreateDecisionAsync(
+    public async Task<Result<RemediationDecision>> CreateDecisionForCaseAsync(
         Guid tenantId,
-        Guid softwareAssetId,
+        Guid remediationCaseId,
         RemediationOutcome outcome,
         string? justification,
         Guid decidedBy,
@@ -28,14 +28,15 @@ public class RemediationDecisionService(
         DateTimeOffset? maintenanceWindowDate = null
     )
     {
-        var remediationScope = await ResolveScopeAsync(tenantId, softwareAssetId, ct);
-        if (remediationScope is null)
-            return Result<RemediationDecision>.Failure("No tenant software scope was found for this software.");
+        var caseExists = await dbContext.RemediationCases
+            .AnyAsync(c => c.TenantId == tenantId && c.Id == remediationCaseId, ct);
+        if (!caseExists)
+            return Result<RemediationDecision>.Failure("Remediation case not found.");
 
         var hasOpenDecision = await dbContext.RemediationDecisions
             .Where(d =>
                 d.TenantId == tenantId
-                && d.TenantSoftwareId == remediationScope.TenantSoftwareId
+                && d.RemediationCaseId == remediationCaseId
                 && d.ApprovalStatus != DecisionApprovalStatus.Rejected
                 && d.ApprovalStatus != DecisionApprovalStatus.Expired)
             .AnyAsync(
@@ -48,12 +49,12 @@ public class RemediationDecisionService(
 
         if (hasOpenDecision)
             return Result<RemediationDecision>.Failure(
-                "An active remediation decision already exists for this software. Reject or expire the current decision before creating a new one.");
+                "An active remediation decision already exists for this case. Reject or expire the current decision before creating a new one.");
 
         var existingWorkflow = await dbContext.RemediationWorkflows.AsNoTracking()
             .Where(workflow =>
                 workflow.TenantId == tenantId
-                && workflow.TenantSoftwareId == remediationScope.TenantSoftwareId
+                && workflow.RemediationCaseId == remediationCaseId
                 && workflow.Status == RemediationWorkflowStatus.Active)
             .OrderByDescending(workflow => workflow.CreatedAt)
             .FirstOrDefaultAsync(ct);
@@ -65,8 +66,7 @@ public class RemediationDecisionService(
 
         var decision = RemediationDecision.Create(
             tenantId,
-            remediationScope.TenantSoftwareId,
-            remediationScope.RepresentativeSoftwareAssetId,
+            remediationCaseId,
             outcome,
             justification,
             decidedBy,
@@ -97,35 +97,6 @@ public class RemediationDecisionService(
         return Result<RemediationDecision>.Success(decision);
     }
 
-    public async Task<Result<RemediationDecision>> CreateDecisionForTenantSoftwareAsync(
-        Guid tenantId,
-        Guid tenantSoftwareId,
-        RemediationOutcome outcome,
-        string? justification,
-        Guid decidedBy,
-        DateTimeOffset? expiryDate,
-        DateTimeOffset? reEvaluationDate,
-        CancellationToken ct,
-        DateTimeOffset? maintenanceWindowDate = null
-    )
-    {
-        var remediationScope = await ResolveScopeByTenantSoftwareAsync(tenantId, tenantSoftwareId, ct);
-        if (remediationScope is null)
-            return Result<RemediationDecision>.Failure("No tenant software scope was found for this software.");
-
-        return await CreateDecisionAsync(
-            tenantId,
-            remediationScope.RepresentativeSoftwareAssetId,
-            outcome,
-            justification,
-            decidedBy,
-            expiryDate,
-            reEvaluationDate,
-            ct,
-            maintenanceWindowDate
-        );
-    }
-
     public async Task<Result<RemediationDecision>> VerifyAndCarryForwardDecisionAsync(
         Guid tenantId,
         Guid workflowId,
@@ -144,18 +115,13 @@ public class RemediationDecisionService(
         if (!verificationResult.IsSuccess)
             return Result<RemediationDecision>.Failure(verificationResult.Error ?? "Verification failed.");
 
-        var remediationScope = await ResolveScopeByTenantSoftwareAsync(tenantId, previousDecision.TenantSoftwareId, ct);
-        if (remediationScope is null)
-            return Result<RemediationDecision>.Failure("No tenant software scope was found for this software.");
-
         var carriedApprovalStatus = previousDecision.Outcome == RemediationOutcome.ApprovedForPatching
             ? DecisionApprovalStatus.Approved
             : DecisionApprovalStatus.PendingApproval;
 
         var decision = RemediationDecision.Create(
             tenantId,
-            previousDecision.TenantSoftwareId,
-            remediationScope.RepresentativeSoftwareAssetId,
+            previousDecision.RemediationCaseId,
             previousDecision.Outcome,
             previousDecision.Justification,
             actedBy,
@@ -294,17 +260,17 @@ public class RemediationDecisionService(
         if (activeWorkflows.Count == 0)
             return 0;
 
-        var tenantSoftwareIds = activeWorkflows
-            .Select(workflow => workflow.TenantSoftwareId)
+        var remediationCaseIds = activeWorkflows
+            .Select(workflow => workflow.RemediationCaseId)
             .Distinct()
             .ToList();
 
         // Phase 2: canonical exposure data not yet available via DeviceVulnerabilityExposure.
         // Return empty — no open exposure means all active workflows are eligible to close.
-        var unresolvedTenantSoftwareIds = new List<Guid>();
+        var unresolvedCaseIds = new List<Guid>();
 
         var workflowsToClose = activeWorkflows
-            .Where(workflow => !unresolvedTenantSoftwareIds.Contains(workflow.TenantSoftwareId))
+            .Where(workflow => !unresolvedCaseIds.Contains(workflow.RemediationCaseId))
             .ToList();
 
         if (workflowsToClose.Count == 0)
@@ -362,7 +328,7 @@ public class RemediationDecisionService(
 
     public async Task<Result<RemediationDecisionVulnerabilityOverride>> AddVulnerabilityOverrideAsync(
         Guid decisionId,
-        Guid tenantVulnerabilityId,
+        Guid vulnerabilityId,
         RemediationOutcome outcome,
         string justification,
         CancellationToken ct
@@ -376,7 +342,7 @@ public class RemediationDecisionService(
 
         var existing = await dbContext.RemediationDecisionVulnerabilityOverrides
             .FirstOrDefaultAsync(
-                vo => vo.RemediationDecisionId == decisionId && vo.TenantVulnerabilityId == tenantVulnerabilityId,
+                vo => vo.RemediationDecisionId == decisionId && vo.VulnerabilityId == vulnerabilityId,
                 ct
             );
 
@@ -387,7 +353,7 @@ public class RemediationDecisionService(
 
         var overrideEntity = RemediationDecisionVulnerabilityOverride.Create(
             decisionId,
-            tenantVulnerabilityId,
+            vulnerabilityId,
             outcome,
             justification
         );
@@ -411,60 +377,4 @@ public class RemediationDecisionService(
 
         return await patchingTaskService.EnsurePatchingTasksAsync(decision, ct);
     }
-
-    private async Task<RemediationScope?> ResolveScopeAsync(
-        Guid tenantId,
-        Guid softwareAssetId,
-        CancellationToken ct
-    )
-    {
-        var scopeRow = await dbContext.NormalizedSoftwareInstallations
-            .IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.SoftwareAssetId == softwareAssetId
-                && item.IsActive)
-            .Select(item => new { item.TenantSoftwareId })
-            .FirstOrDefaultAsync(ct);
-
-        if (scopeRow is null)
-            return null;
-
-        var representativeSoftwareAssetId = await dbContext.NormalizedSoftwareInstallations
-            .IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.TenantSoftwareId == scopeRow.TenantSoftwareId
-                && item.IsActive)
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
-            .OrderBy(id => id)
-            .FirstAsync(ct);
-
-        return new RemediationScope(scopeRow.TenantSoftwareId, representativeSoftwareAssetId);
-    }
-
-    private async Task<RemediationScope?> ResolveScopeByTenantSoftwareAsync(
-        Guid tenantId,
-        Guid tenantSoftwareId,
-        CancellationToken ct
-    )
-    {
-        var representativeSoftwareAssetId = await dbContext.NormalizedSoftwareInstallations
-            .IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
-                && item.IsActive)
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
-            .OrderBy(id => id)
-            .FirstOrDefaultAsync(ct);
-
-        return representativeSoftwareAssetId == Guid.Empty
-            ? null
-            : new RemediationScope(tenantSoftwareId, representativeSoftwareAssetId);
-    }
-
-    private sealed record RemediationScope(Guid TenantSoftwareId, Guid RepresentativeSoftwareAssetId);
 }

--- a/src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
@@ -10,24 +10,24 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
 {
     public async Task<RemediationWorkflow> GetOrCreateActiveWorkflowAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         CancellationToken ct
     )
     {
         var existing = await dbContext.RemediationWorkflows
             .FirstOrDefaultAsync(workflow =>
                 workflow.TenantId == tenantId
-                && workflow.TenantSoftwareId == tenantSoftwareId
+                && workflow.RemediationCaseId == remediationCaseId
                 && workflow.Status == RemediationWorkflowStatus.Active,
                 ct);
         if (existing is not null)
             return existing;
 
-        var softwareOwnerTeamId = await ResolveSoftwareOwnerTeamIdAsync(tenantId, tenantSoftwareId, ct);
+        var softwareOwnerTeamId = await ResolveSoftwareOwnerTeamIdAsync(tenantId, ct);
         var previousWorkflow = await dbContext.RemediationWorkflows.AsNoTracking()
             .Where(item =>
                 item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
+                && item.RemediationCaseId == remediationCaseId
                 && item.Status != RemediationWorkflowStatus.Active
                 && item.ProposedOutcome != null)
             .OrderByDescending(item => item.CreatedAt)
@@ -39,7 +39,7 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
             : RemediationWorkflowStage.SecurityAnalysis;
         var workflow = RemediationWorkflow.Create(
             tenantId,
-            tenantSoftwareId,
+            remediationCaseId,
             softwareOwnerTeamId,
             initialStage,
             previousWorkflow?.Id
@@ -75,12 +75,12 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
 
     public async Task AttachRecommendationAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid remediationCaseId,
         AnalystRecommendation recommendation,
         CancellationToken ct
     )
     {
-        var workflow = await GetOrCreateActiveWorkflowAsync(tenantId, tenantSoftwareId, ct);
+        var workflow = await GetOrCreateActiveWorkflowAsync(tenantId, remediationCaseId, ct);
         recommendation.AttachToWorkflow(workflow.Id);
 
         var priority = ParsePriority(recommendation.PriorityOverride);
@@ -139,7 +139,7 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
         CancellationToken ct
     )
     {
-        var workflow = await GetOrCreateActiveWorkflowAsync(decision.TenantId, decision.TenantSoftwareId, ct);
+        var workflow = await GetOrCreateActiveWorkflowAsync(decision.TenantId, decision.RemediationCaseId, ct);
         decision.AttachToWorkflow(workflow.Id);
 
         var priority = workflow.Priority ?? RemediationWorkflowPriority.Normal;
@@ -472,7 +472,7 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
             var latestHistoricalDecision = await dbContext.RemediationDecisions.AsNoTracking()
                 .Where(item =>
                     item.TenantId == tenantId
-                    && item.TenantSoftwareId == workflow.TenantSoftwareId
+                    && item.RemediationCaseId == workflow.RemediationCaseId
                     && item.RemediationWorkflowId == workflow.RecurrenceSourceWorkflowId
                     && item.ApprovalStatus == DecisionApprovalStatus.Approved)
                 .OrderByDescending(item => item.DecidedAt)
@@ -545,28 +545,16 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
         openRecord.Complete(completedByUserId, systemCompleted, summary);
     }
 
+    /// <summary>
+    /// Resolves the software owner team for a remediation workflow.
+    /// TODO Phase 5: wire this to device owner teams via DeviceVulnerabilityExposure once
+    /// the canonical exposure model is available. For now falls back to the tenant default team.
+    /// </summary>
     private async Task<Guid> ResolveSoftwareOwnerTeamIdAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
         CancellationToken ct
     )
     {
-        var candidateTeamIds = await dbContext.NormalizedSoftwareInstallations
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-            .Join(
-                dbContext.Assets,
-                item => item.SoftwareAssetId,
-                asset => asset.Id,
-                (item, asset) => asset.OwnerTeamId ?? asset.FallbackTeamId
-            )
-            .Where(teamId => teamId != null)
-            .Select(teamId => teamId!.Value)
-            .Distinct()
-            .ToListAsync(ct);
-
-        if (candidateTeamIds.Count == 1)
-            return candidateTeamIds[0];
-
         var defaultTeam = await DefaultTeamHelper.EnsureDefaultTeamAsync(dbContext, tenantId, ct);
         return defaultTeam.Id;
     }

--- a/src/PatchHound.Infrastructure/Services/SoftwareDescriptionGenerationService.cs
+++ b/src/PatchHound.Infrastructure/Services/SoftwareDescriptionGenerationService.cs
@@ -13,13 +13,9 @@ namespace PatchHound.Infrastructure.Services;
 public class SoftwareDescriptionGenerationService
 {
     private sealed record AliasIdentity(
-        string SourceSystem,
-        string ExternalSoftwareId,
-        string RawName,
-        string? RawVendor,
-        string? RawVersion,
-        string AliasConfidence,
-        string MatchReason
+        string ExternalId,
+        string? ObservedVendor,
+        string? ObservedName
     );
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -44,58 +40,50 @@ public class SoftwareDescriptionGenerationService
 
     public async Task<Result<SoftwareDescriptionGenerationResult>> GenerateAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid softwareProductId,
         Guid? tenantAiProfileId,
         CancellationToken ct
     )
     {
-        var software = await _dbContext
-            .TenantSoftware
-            .Where(item => item.Id == tenantSoftwareId && item.TenantId == tenantId)
+        var product = await _dbContext
+            .SoftwareProducts
+            .Where(item => item.Id == softwareProductId)
             .Select(item => new
             {
                 item.Id,
-                item.TenantId,
-                item.NormalizedSoftwareId,
-                item.NormalizedSoftware.CanonicalName,
-                item.NormalizedSoftware.CanonicalVendor,
-                item.NormalizedSoftware.PrimaryCpe23Uri,
-                item.NormalizedSoftware.Description,
+                item.Vendor,
+                item.Name,
+                item.PrimaryCpe23Uri,
             })
             .FirstOrDefaultAsync(ct);
-        if (software is null)
+        if (product is null)
         {
             return Result<SoftwareDescriptionGenerationResult>.Failure(
-                "Tenant software was not found."
+                "Software product was not found."
             );
         }
 
         var aliases = await _dbContext
-            .NormalizedSoftwareAliases.AsNoTracking()
-            .Where(item => item.NormalizedSoftwareId == software.NormalizedSoftwareId)
-            .OrderBy(item => item.SourceSystem)
-            .ThenBy(item => item.ExternalSoftwareId)
+            .SoftwareAliases.AsNoTracking()
+            .Where(item => item.SoftwareProductId == softwareProductId)
+            .OrderBy(item => item.ExternalId)
             .Select(item => new AliasIdentity(
-                item.SourceSystem.ToString(),
-                item.ExternalSoftwareId,
-                item.RawName,
-                item.RawVendor,
-                item.RawVersion,
-                item.AliasConfidence.ToString(),
-                item.MatchReason
+                item.ExternalId,
+                item.ObservedVendor,
+                item.ObservedName
             ))
             .ToListAsync(ct);
 
         var identityCandidates = BuildIdentityCandidates(
-            software.CanonicalVendor,
-            software.CanonicalName,
+            product.Vendor,
+            product.Name,
             aliases
         );
 
         var observedVersions = await _dbContext
-            .NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-            .Select(item => item.DetectedVersion)
+            .InstalledSoftware.AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.SoftwareProductId == softwareProductId)
+            .Select(item => item.Version)
             .Where(item => !string.IsNullOrWhiteSpace(item))
             .Distinct()
             .OrderBy(item => item)
@@ -120,17 +108,17 @@ public class SoftwareDescriptionGenerationService
         var request = new AiTextGenerationRequest(
             "You are a PatchHound software analyst. Write a concise product-level markdown description for security and vulnerability analysts. Explain what the software product is, who publishes it, common enterprise use cases, and why it may appear in enterprise environments. Keep the description general to the product rather than version-specific. Use the strongest vendor/name evidence available from the provided identities and aliases. If the identity appears ambiguous or generic, say so briefly instead of guessing. Use at most two short paragraphs and up to three short bullet points.",
             BuildUserPrompt(
-                software.CanonicalVendor,
-                software.CanonicalName,
-                software.PrimaryCpe23Uri,
+                product.Vendor,
+                product.Name,
+                product.PrimaryCpe23Uri,
                 identityCandidates,
                 observedVersions,
                 activeVulnerabilityCount,
                 new
                 {
-                    canonicalName = software.CanonicalName,
-                    canonicalVendor = software.CanonicalVendor,
-                    primaryCpe23Uri = software.PrimaryCpe23Uri,
+                    vendor = product.Vendor,
+                    name = product.Name,
+                    primaryCpe23Uri = product.PrimaryCpe23Uri,
                     identityCandidates,
                     observedVersions,
                     activeVulnerabilityCount,
@@ -190,22 +178,25 @@ public class SoftwareDescriptionGenerationService
             );
         }
 
-        var normalizedSoftware = await _dbContext
-            .NormalizedSoftware
-            .FirstAsync(item => item.Id == software.NormalizedSoftwareId, ct);
-        normalizedSoftware.UpdateDescription(
-            generationResult.Value.Content,
-            generationResult.Value.GeneratedAt,
-            generationResult.Value.ProviderType,
-            generationResult.Value.ProfileName,
-            generationResult.Value.Model
-        );
+        // Store the description in TenantSoftwareProductInsight (upsert).
+        var insight = await _dbContext
+            .TenantSoftwareProductInsights
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item => item.TenantId == tenantId && item.SoftwareProductId == softwareProductId,
+                ct
+            );
+        if (insight is null)
+        {
+            insight = TenantSoftwareProductInsight.Create(tenantId, softwareProductId);
+            _dbContext.TenantSoftwareProductInsights.Add(insight);
+        }
+        insight.UpdateDescription(generationResult.Value.Content);
         await _dbContext.SaveChangesAsync(ct);
 
         return Result<SoftwareDescriptionGenerationResult>.Success(
             new SoftwareDescriptionGenerationResult(
-                tenantSoftwareId,
-                software.NormalizedSoftwareId,
+                softwareProductId,
                 generationResult.Value.Content,
                 generationResult.Value.ProviderType,
                 generationResult.Value.ProfileName,
@@ -234,26 +225,26 @@ public class SoftwareDescriptionGenerationService
     }
 
     private static IReadOnlyList<string> BuildIdentityCandidates(
-        string? canonicalVendor,
-        string canonicalName,
+        string vendor,
+        string name,
         IReadOnlyList<AliasIdentity> aliases
     )
     {
         var candidates = new List<string>();
 
-        if (!string.IsNullOrWhiteSpace(canonicalName))
+        if (!string.IsNullOrWhiteSpace(name))
         {
             candidates.Add(
-                string.IsNullOrWhiteSpace(canonicalVendor)
-                    ? canonicalName.Trim()
-                    : $"{canonicalVendor.Trim()} {canonicalName.Trim()}"
+                string.IsNullOrWhiteSpace(vendor)
+                    ? name.Trim()
+                    : $"{vendor.Trim()} {name.Trim()}"
             );
         }
 
         foreach (var alias in aliases)
         {
-            var rawName = alias.RawName;
-            var rawVendor = alias.RawVendor;
+            var rawName = alias.ObservedName;
+            var rawVendor = alias.ObservedVendor;
             if (string.IsNullOrWhiteSpace(rawName))
             {
                 continue;
@@ -273,8 +264,8 @@ public class SoftwareDescriptionGenerationService
     }
 
     private static string BuildUserPrompt(
-        string? canonicalVendor,
-        string canonicalName,
+        string vendor,
+        string name,
         string? primaryCpe23Uri,
         IReadOnlyList<string> identityCandidates,
         IReadOnlyList<string> observedVersions,
@@ -283,9 +274,9 @@ public class SoftwareDescriptionGenerationService
     )
     {
         return
-            $"Primary software identity: {identityCandidates.FirstOrDefault() ?? canonicalName}\n"
-            + $"Canonical name: {canonicalName}\n"
-            + $"Canonical vendor: {(canonicalVendor ?? "Unknown")}\n"
+            $"Primary software identity: {identityCandidates.FirstOrDefault() ?? name}\n"
+            + $"Canonical name: {name}\n"
+            + $"Canonical vendor: {vendor}\n"
             + $"Primary CPE: {(primaryCpe23Uri ?? "None")}\n"
             + $"Observed versions: {(observedVersions.Count == 0 ? "None" : string.Join(", ", observedVersions))}\n"
             + $"Open vulnerability count in tenant: {activeVulnerabilityCount}\n"

--- a/src/PatchHound.Infrastructure/Services/SoftwareDescriptionJobService.cs
+++ b/src/PatchHound.Infrastructure/Services/SoftwareDescriptionJobService.cs
@@ -10,19 +10,16 @@ public class SoftwareDescriptionJobService(PatchHoundDbContext dbContext)
 {
     public async Task<Result<SoftwareDescriptionJob>> EnqueueAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid softwareProductId,
         Guid? tenantAiProfileId,
         CancellationToken ct
     )
     {
-        var tenantSoftware = await dbContext
-            .TenantSoftware
-            .Where(item => item.Id == tenantSoftwareId && item.TenantId == tenantId)
-            .Select(item => new { item.Id, item.NormalizedSoftwareId })
-            .FirstOrDefaultAsync(ct);
-        if (tenantSoftware is null)
+        var softwareProductExists = await dbContext.SoftwareProducts
+            .AnyAsync(item => item.Id == softwareProductId, ct);
+        if (!softwareProductExists)
         {
-            return Result<SoftwareDescriptionJob>.Failure("Tenant software was not found.");
+            return Result<SoftwareDescriptionJob>.Failure("Software product was not found.");
         }
 
         if (tenantAiProfileId.HasValue)
@@ -41,7 +38,7 @@ public class SoftwareDescriptionJobService(PatchHoundDbContext dbContext)
             .Set<SoftwareDescriptionJob>()
             .Where(item =>
                 item.TenantId == tenantId
-                && item.TenantSoftwareId == tenantSoftwareId
+                && item.SoftwareProductId == softwareProductId
                 && (
                     item.Status == SoftwareDescriptionJobStatus.Pending
                     || item.Status == SoftwareDescriptionJobStatus.Running
@@ -56,8 +53,7 @@ public class SoftwareDescriptionJobService(PatchHoundDbContext dbContext)
 
         var job = SoftwareDescriptionJob.Create(
             tenantId,
-            tenantSoftwareId,
-            tenantSoftware.NormalizedSoftwareId,
+            softwareProductId,
             tenantAiProfileId,
             DateTimeOffset.UtcNow
         );
@@ -69,14 +65,14 @@ public class SoftwareDescriptionJobService(PatchHoundDbContext dbContext)
 
     public Task<SoftwareDescriptionJob?> GetLatestAsync(
         Guid tenantId,
-        Guid tenantSoftwareId,
+        Guid softwareProductId,
         CancellationToken ct
     )
     {
         return dbContext
             .Set<SoftwareDescriptionJob>()
             .AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId)
+            .Where(item => item.TenantId == tenantId && item.SoftwareProductId == softwareProductId)
             .OrderByDescending(item => item.RequestedAt)
             .FirstOrDefaultAsync(ct);
     }

--- a/src/PatchHound.Worker/RemediationAiWorker.cs
+++ b/src/PatchHound.Worker/RemediationAiWorker.cs
@@ -62,7 +62,7 @@ public class RemediationAiWorker(
 
         try
         {
-            var generated = await queryService.GenerateAndStoreAiDraftsAsync(job.TenantId, job.TenantSoftwareId, ct);
+            var generated = await queryService.GenerateAndStoreAiDraftsAsync(job.TenantId, job.RemediationCaseId, ct);
             var trackedJob = await dbContext.RemediationAiJobs.IgnoreQueryFilters()
                 .FirstAsync(item => item.Id == job.Id, ct);
 
@@ -70,9 +70,9 @@ public class RemediationAiWorker(
             {
                 trackedJob.CompleteSucceeded(DateTimeOffset.UtcNow);
                 logger.LogInformation(
-                    "Completed remediation AI job {JobId} for tenant software {TenantSoftwareId}",
+                    "Completed remediation AI job {JobId} for remediation case {RemediationCaseId}",
                     trackedJob.Id,
-                    trackedJob.TenantSoftwareId
+                    trackedJob.RemediationCaseId
                 );
             }
             else

--- a/src/PatchHound.Worker/SlaCheckWorker.cs
+++ b/src/PatchHound.Worker/SlaCheckWorker.cs
@@ -67,7 +67,7 @@ public class SlaCheckWorker(IServiceScopeFactory scopeFactory, ILogger<SlaCheckW
                 decision.TenantId,
                 NotificationType.SLAWarning,
                 "Deferred patching decision approaching re-evaluation",
-                $"Remediation decision {decision.Id} for software asset {decision.SoftwareAssetId} has a re-evaluation date of {decision.ReEvaluationDate!.Value:yyyy-MM-dd}.",
+                $"Remediation decision {decision.Id} for remediation case {decision.RemediationCaseId} has a re-evaluation date of {decision.ReEvaluationDate!.Value:yyyy-MM-dd}.",
                 "RemediationDecision",
                 decision.Id,
                 ct
@@ -96,7 +96,7 @@ public class SlaCheckWorker(IServiceScopeFactory scopeFactory, ILogger<SlaCheckW
                 decision.TenantId,
                 NotificationType.SLAWarning,
                 "Remediation decision approaching expiry",
-                $"Remediation decision {decision.Id} for software asset {decision.SoftwareAssetId} expires on {decision.ExpiryDate!.Value:yyyy-MM-dd}.",
+                $"Remediation decision {decision.Id} for remediation case {decision.RemediationCaseId} expires on {decision.ExpiryDate!.Value:yyyy-MM-dd}.",
                 "RemediationDecision",
                 decision.Id,
                 ct
@@ -124,8 +124,8 @@ public class SlaCheckWorker(IServiceScopeFactory scopeFactory, ILogger<SlaCheckW
                     ? "Patching task overdue"
                     : "Patching task nearing SLA deadline";
                 var body = status == SlaStatus.Overdue
-                    ? $"Patching task {patchingTask.Id} for software asset {patchingTask.SoftwareAssetId} is past its SLA due date of {patchingTask.DueDate:yyyy-MM-dd}."
-                    : $"Patching task {patchingTask.Id} for software asset {patchingTask.SoftwareAssetId} is approaching its SLA due date of {patchingTask.DueDate:yyyy-MM-dd}.";
+                    ? $"Patching task {patchingTask.Id} for remediation case {patchingTask.RemediationCaseId} is past its SLA due date of {patchingTask.DueDate:yyyy-MM-dd}."
+                    : $"Patching task {patchingTask.Id} for remediation case {patchingTask.RemediationCaseId} is approaching its SLA due date of {patchingTask.DueDate:yyyy-MM-dd}.";
 
                 // Notify team members
                 var teamMembers = await dbContext.TeamMembers.IgnoreQueryFilters()

--- a/src/PatchHound.Worker/SoftwareDescriptionWorker.cs
+++ b/src/PatchHound.Worker/SoftwareDescriptionWorker.cs
@@ -71,7 +71,7 @@ public class SoftwareDescriptionWorker(
         {
             var result = await generationService.GenerateAsync(
                 job.TenantId,
-                job.TenantSoftwareId,
+                job.SoftwareProductId,
                 job.TenantAiProfileId,
                 ct
             );
@@ -84,9 +84,9 @@ public class SoftwareDescriptionWorker(
             {
                 trackedJob.CompleteSucceeded(DateTimeOffset.UtcNow);
                 logger.LogInformation(
-                    "Completed software description job {JobId} for tenant software {TenantSoftwareId}",
+                    "Completed software description job {JobId} for software product {SoftwareProductId}",
                     trackedJob.Id,
-                    trackedJob.TenantSoftwareId
+                    trackedJob.SoftwareProductId
                 );
             }
             else

--- a/tests/PatchHound.Tests/Api/DevicesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/DevicesControllerTests.cs
@@ -81,8 +81,7 @@ public class DevicesControllerTests : IDisposable
             patchingTaskService
         );
         var remediationTaskQueryService = new PatchHound.Api.Services.RemediationTaskQueryService(
-            _dbContext,
-            remediationDecisionService
+            _dbContext
         );
         var detailQueryService = new PatchHound.Api.Services.DeviceDetailQueryService(
             _dbContext,

--- a/tests/PatchHound.Tests/Api/RemediationTasksControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationTasksControllerTests.cs
@@ -108,7 +108,7 @@ public class RemediationTasksControllerTests : IDisposable
         await CreateAndApproveDecisionAsync(remediationCase.Id, userId);
 
         var action = await _controller.List(
-            new RemediationTaskFilterQuery(TenantSoftwareId: remediationCase.Id),
+            new RemediationTaskFilterQuery(CaseId: remediationCase.Id),
             new PaginationQuery(1, 25),
             CancellationToken.None
         );

--- a/tests/PatchHound.Tests/Api/RemediationTasksControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationTasksControllerTests.cs
@@ -40,67 +40,75 @@ public class RemediationTasksControllerTests : IDisposable
             TestServiceProviderFactory.Create(_tenantContext)
         );
 
-        var workflowService = new RemediationWorkflowService(_dbContext);
-        var notificationService = Substitute.For<INotificationService>();
-        var patchingTaskService = new PatchingTaskService(_dbContext, new SlaService(), workflowService, notificationService);
-        var approvalTaskService = new ApprovalTaskService(_dbContext, notificationService, Substitute.For<IRealTimeNotifier>(), workflowService, patchingTaskService);
-        var decisionService = new RemediationDecisionService(_dbContext, approvalTaskService, workflowService, patchingTaskService);
-        var queryService = new RemediationTaskQueryService(_dbContext, decisionService);
+        var queryService = new RemediationTaskQueryService(_dbContext);
         _controller = new RemediationTasksController(queryService, _tenantContext);
     }
 
-    [Fact]
-    public async Task List_ReturnsOpenTasksForTenantSoftwareFilter()
+    // Seeds a SoftwareProduct + RemediationCase + Team, returns (remediationCase, team).
+    private async Task<(RemediationCase remediationCase, Team team)> SeedCaseAsync()
     {
-        var graph = await TenantSoftwareGraphFactory.SeedAsync(_dbContext, _tenantId);
+        var product = SoftwareProduct.Create("acme", "agent", null);
+        await _dbContext.SoftwareProducts.AddAsync(product);
+
+        var remediationCase = RemediationCase.Create(_tenantId, product.Id);
+        await _dbContext.RemediationCases.AddAsync(remediationCase);
+
         var team = Team.Create(_tenantId, "Platform");
         await _dbContext.Teams.AddAsync(team);
 
-        var devices = await _dbContext.Assets
-            .Where(item => item.AssetType == AssetType.Device)
-            .ToListAsync();
-
-        foreach (var device in devices)
-        {
-            device.AssignTeamOwner(team.Id);
-        }
-
         await _dbContext.SaveChangesAsync();
 
-        var softwareAssetIds = await _dbContext.NormalizedSoftwareInstallations
-            .Where(item => item.TenantSoftwareId == graph.TenantSoftware.Id)
-            .Select(item => item.SoftwareAssetId)
-            .Distinct()
-            .ToListAsync();
+        return (remediationCase, team);
+    }
 
+    // Creates decision + approves it, returning the resulting PatchingTask.
+    private async Task<PatchingTask> CreateAndApproveDecisionAsync(Guid remediationCaseId, Guid userId)
+    {
         var workflowService = new RemediationWorkflowService(_dbContext);
         var notificationService = Substitute.For<INotificationService>();
         var patchingTaskService = new PatchingTaskService(_dbContext, new SlaService(), workflowService, notificationService);
         var approvalTaskService = new ApprovalTaskService(_dbContext, notificationService, Substitute.For<IRealTimeNotifier>(), workflowService, patchingTaskService);
         var decisionService = new RemediationDecisionService(_dbContext, approvalTaskService, workflowService, patchingTaskService);
-        var createResult = await decisionService.CreateDecisionAsync(
+
+        var createResult = await decisionService.CreateDecisionForCaseAsync(
             _tenantId,
-            softwareAssetIds[0],
+            remediationCaseId,
             RemediationOutcome.ApprovedForPatching,
             "Create software task",
-            _tenantContext.CurrentUserId,
+            userId,
             null,
             null,
             CancellationToken.None
         );
         createResult.IsSuccess.Should().BeTrue();
 
-        var approvalTask = await _dbContext.ApprovalTasks.OrderByDescending(item => item.CreatedAt).FirstAsync();
+        var approvalTask = await _dbContext.ApprovalTasks
+            .OrderByDescending(item => item.CreatedAt)
+            .FirstAsync();
+
         await approvalTaskService.ApproveAsync(
             approvalTask.Id,
-            _tenantContext.CurrentUserId,
+            userId,
             "Approved for execution",
             new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero),
             CancellationToken.None
         );
 
+        return await _dbContext.PatchingTasks
+            .OrderByDescending(t => t.CreatedAt)
+            .FirstAsync();
+    }
+
+    [Fact]
+    public async Task List_ReturnsOpenTasksForCaseFilter()
+    {
+        var (remediationCase, _) = await SeedCaseAsync();
+        var userId = _tenantContext.CurrentUserId;
+
+        await CreateAndApproveDecisionAsync(remediationCase.Id, userId);
+
         var action = await _controller.List(
-            new RemediationTaskFilterQuery(TenantSoftwareId: graph.TenantSoftware.Id),
+            new RemediationTaskFilterQuery(TenantSoftwareId: remediationCase.Id),
             new PaginationQuery(1, 25),
             CancellationToken.None
         );
@@ -111,63 +119,25 @@ public class RemediationTasksControllerTests : IDisposable
         payload.TotalCount.Should().Be(1);
         payload.Items.Should().HaveCount(1);
         payload.Items.Should().OnlyContain(item => item.SoftwareName == "agent");
-        payload.Items.Should().OnlyContain(item => item.OwnerTeamName == "Platform");
     }
 
     [Fact]
-    public async Task CreateForSoftware_CreatesMissingTasksForCurrentExposure()
+    public async Task CreateForSoftware_ReturnsStubZeroCounts()
     {
-        var graph = await TenantSoftwareGraphFactory.SeedAsync(_dbContext, _tenantId);
-        var team = Team.Create(_tenantId, "Platform");
-        await _dbContext.Teams.AddAsync(team);
-        var devices = await _dbContext.Assets
-            .Where(item => item.AssetType == AssetType.Device)
-            .ToListAsync();
-        foreach (var device in devices)
-        {
-            device.AssignTeamOwner(team.Id);
-        }
-        await _dbContext.SaveChangesAsync();
+        // Phase 4: CreateMissingTasksForSoftwareAsync is stubbed to (0, 0).
+        // Phase 5 will re-implement device-level task creation.
+        var (remediationCase, _) = await SeedCaseAsync();
+        var userId = _tenantContext.CurrentUserId;
 
-        var softwareAssetId = await _dbContext.NormalizedSoftwareInstallations
-            .Where(item => item.TenantSoftwareId == graph.TenantSoftware.Id)
-            .Select(item => item.SoftwareAssetId)
-            .OrderBy(id => id)
-            .FirstAsync();
+        await CreateAndApproveDecisionAsync(remediationCase.Id, userId);
 
-        var workflowService = new RemediationWorkflowService(_dbContext);
-        var notificationService = Substitute.For<INotificationService>();
-        var patchingTaskService = new PatchingTaskService(_dbContext, new SlaService(), workflowService, notificationService);
-        var approvalTaskService = new ApprovalTaskService(_dbContext, notificationService, Substitute.For<IRealTimeNotifier>(), workflowService, patchingTaskService);
-        var decisionService = new RemediationDecisionService(_dbContext, approvalTaskService, workflowService, patchingTaskService);
-        var createResult = await decisionService.CreateDecisionAsync(
-            _tenantId,
-            softwareAssetId,
-            RemediationOutcome.ApprovedForPatching,
-            "Patch it",
-            _tenantContext.CurrentUserId,
-            null,
-            null,
-            CancellationToken.None
-        );
-        createResult.IsSuccess.Should().BeTrue();
-
-        var approvalTask = await _dbContext.ApprovalTasks.OrderByDescending(item => item.CreatedAt).FirstAsync();
-        await approvalTaskService.ApproveAsync(
-            approvalTask.Id,
-            _tenantContext.CurrentUserId,
-            "Approved for execution",
-            new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero),
-            CancellationToken.None
-        );
-
-        var action = await _controller.CreateForSoftware(graph.TenantSoftware.Id, CancellationToken.None);
+        var action = await _controller.CreateForSoftware(remediationCase.Id, CancellationToken.None);
 
         var result = action.Result.Should().BeOfType<OkObjectResult>().Subject;
         var payload = result.Value.Should().BeOfType<RemediationTaskCreateResultDto>().Subject;
 
         payload.CreatedCount.Should().Be(0);
-        payload.EligibleCount.Should().Be(2);
+        payload.EligibleCount.Should().Be(0);
         _dbContext.PatchingTasks.Should().HaveCount(1);
     }
 

--- a/tests/PatchHound.Tests/Core/ApprovalTaskTests.cs
+++ b/tests/PatchHound.Tests/Core/ApprovalTaskTests.cs
@@ -7,6 +7,7 @@ namespace PatchHound.Tests.Core;
 public class ApprovalTaskTests
 {
     private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid CaseId = Guid.NewGuid();
     private static readonly Guid DecisionId = Guid.NewGuid();
     private static readonly DateTimeOffset Expiry = DateTimeOffset.UtcNow.AddHours(24);
 
@@ -15,7 +16,7 @@ public class ApprovalTaskTests
     [InlineData(RemediationOutcome.AlternateMitigation)]
     public void Create_RiskAcceptanceOrAlternateMitigation_SetsPendingApproval(RemediationOutcome outcome)
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, outcome, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, outcome, null, Expiry);
 
         task.Id.Should().NotBeEmpty();
         task.TenantId.Should().Be(TenantId);
@@ -31,7 +32,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Create_ApprovedForPatching_SetsPendingApproval_WhenExplicitlyRequired()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.Pending, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.Pending, Expiry);
 
         task.Type.Should().Be(ApprovalTaskType.PatchingApproved);
         task.Status.Should().Be(ApprovalTaskStatus.Pending);
@@ -42,7 +43,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Create_PatchingDeferred_SetsAutoApproved()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.PatchingDeferred, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.PatchingDeferred, null, Expiry);
 
         task.Type.Should().Be(ApprovalTaskType.PatchingDeferred);
         task.Status.Should().Be(ApprovalTaskStatus.AutoApproved);
@@ -53,7 +54,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Approve_PendingTask_WithJustification_SetsApproved()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
         var userId = Guid.NewGuid();
 
         task.Approve(userId, "Accepted per review meeting");
@@ -67,7 +68,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Approve_PendingTask_RequiresJustification_ThrowsWhenMissing()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
 
         var act = () => task.Approve(Guid.NewGuid(), null);
 
@@ -77,7 +78,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Approve_NonPendingTask_Throws()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.AutoApproved, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.AutoApproved, Expiry);
 
         var act = () => task.Approve(Guid.NewGuid(), "reason");
 
@@ -87,7 +88,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Deny_PendingTask_WithJustification_SetsDenied()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.AlternateMitigation, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.AlternateMitigation, null, Expiry);
         var userId = Guid.NewGuid();
 
         task.Deny(userId, "Insufficient risk documentation");
@@ -100,7 +101,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Deny_PendingTask_RequiresJustification_ThrowsWhenMissing()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.AlternateMitigation, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.AlternateMitigation, null, Expiry);
 
         var act = () => task.Deny(Guid.NewGuid(), "");
 
@@ -110,7 +111,7 @@ public class ApprovalTaskTests
     [Fact]
     public void Deny_NonPendingTask_Throws()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
         task.Approve(Guid.NewGuid(), "approved");
 
         var act = () => task.Deny(Guid.NewGuid(), "reason");
@@ -121,7 +122,7 @@ public class ApprovalTaskTests
     [Fact]
     public void AutoDeny_PendingTask_SetsAutoDenied()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.RiskAcceptance, null, Expiry);
 
         task.AutoDeny();
 
@@ -133,7 +134,7 @@ public class ApprovalTaskTests
     [Fact]
     public void AutoDeny_NonPendingTask_Throws()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.AutoApproved, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.AutoApproved, Expiry);
 
         var act = () => task.AutoDeny();
 
@@ -143,7 +144,7 @@ public class ApprovalTaskTests
     [Fact]
     public void MarkAsRead_SetsReadAt()
     {
-        var task = ApprovalTask.Create(TenantId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.AutoApproved, Expiry);
+        var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.ApprovedForPatching, ApprovalTaskStatus.AutoApproved, Expiry);
 
         task.MarkAsRead();
 

--- a/tests/PatchHound.Tests/Core/Entities/RemediationCaseTests.cs
+++ b/tests/PatchHound.Tests/Core/Entities/RemediationCaseTests.cs
@@ -1,0 +1,68 @@
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using Xunit;
+
+namespace PatchHound.Tests.Core.Entities;
+
+public class RemediationCaseTests
+{
+    [Fact]
+    public void Create_sets_tenant_product_and_open_status()
+    {
+        var tenantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+
+        var c = RemediationCase.Create(tenantId, productId);
+
+        Assert.NotEqual(Guid.Empty, c.Id);
+        Assert.Equal(tenantId, c.TenantId);
+        Assert.Equal(productId, c.SoftwareProductId);
+        Assert.Equal(RemediationCaseStatus.Open, c.Status);
+        Assert.NotEqual(default, c.CreatedAt);
+        Assert.Equal(c.CreatedAt, c.UpdatedAt);
+        Assert.Null(c.ClosedAt);
+    }
+
+    [Fact]
+    public void Create_rejects_empty_tenant()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            RemediationCase.Create(Guid.Empty, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Create_rejects_empty_product()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            RemediationCase.Create(Guid.NewGuid(), Guid.Empty));
+    }
+
+    [Fact]
+    public void Close_sets_status_and_timestamp()
+    {
+        var c = RemediationCase.Create(Guid.NewGuid(), Guid.NewGuid());
+        c.Close();
+        Assert.Equal(RemediationCaseStatus.Closed, c.Status);
+        Assert.NotNull(c.ClosedAt);
+    }
+
+    [Fact]
+    public void Close_is_idempotent()
+    {
+        var c = RemediationCase.Create(Guid.NewGuid(), Guid.NewGuid());
+        c.Close();
+        var firstClosedAt = c.ClosedAt;
+        c.Close();
+        Assert.Equal(firstClosedAt, c.ClosedAt);
+    }
+
+    [Fact]
+    public void Reopen_from_closed_clears_timestamp()
+    {
+        var c = RemediationCase.Create(Guid.NewGuid(), Guid.NewGuid());
+        c.Close();
+        c.Reopen();
+        Assert.Equal(RemediationCaseStatus.Open, c.Status);
+        Assert.Null(c.ClosedAt);
+    }
+}

--- a/tests/PatchHound.Tests/Core/Entities/RemediationWorkflowTests.cs
+++ b/tests/PatchHound.Tests/Core/Entities/RemediationWorkflowTests.cs
@@ -1,0 +1,24 @@
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using Xunit;
+
+namespace PatchHound.Tests.Core.Entities;
+
+public class RemediationWorkflowTests
+{
+    [Fact]
+    public void Create_takes_tenant_case_and_owner_team()
+    {
+        var tenantId = Guid.NewGuid();
+        var caseId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+
+        var w = RemediationWorkflow.Create(tenantId, caseId, teamId);
+
+        Assert.Equal(tenantId, w.TenantId);
+        Assert.Equal(caseId, w.RemediationCaseId);
+        Assert.Equal(teamId, w.SoftwareOwnerTeamId);
+        Assert.Equal(RemediationWorkflowStatus.Active, w.Status);
+        Assert.Equal(RemediationWorkflowStage.SecurityAnalysis, w.CurrentStage);
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/ApprovalTaskServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/ApprovalTaskServiceTests.cs
@@ -61,12 +61,10 @@ public class ApprovalTaskServiceTests : IDisposable
 
     private RemediationDecision CreateDecision(RemediationOutcome outcome = RemediationOutcome.RiskAcceptance)
     {
-        var tenantSoftwareId = Guid.NewGuid();
-        var softwareAssetId = Guid.NewGuid();
+        var remediationCaseId = Guid.NewGuid();
         var decision = RemediationDecision.Create(
             _tenantId,
-            tenantSoftwareId,
-            softwareAssetId,
+            remediationCaseId,
             outcome,
             outcome == RemediationOutcome.ApprovedForPatching ? null : "Test justification",
             _userId,

--- a/tests/PatchHound.Tests/Infrastructure/EmailNotificationServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/EmailNotificationServiceTests.cs
@@ -239,20 +239,25 @@ public class EmailNotificationServiceTests : IDisposable
     {
         var user = User.Create("alice@example.com", "Alice", "entra-1");
         _dbContext.Users.Add(user);
-        var graph = await TenantSoftwareGraphFactory.SeedAsync(_dbContext, _tenantId);
+
+        // Phase 4 (#17): seed SoftwareProduct + RemediationCase instead of TenantSoftware graph
+        var product = SoftwareProduct.Create("contoso", "agent", "contoso:agent");
+        var remCase = RemediationCase.Create(_tenantId, product.Id);
+        _dbContext.SoftwareProducts.Add(product);
+        _dbContext.RemediationCases.Add(remCase);
+
         var decision = RemediationDecision.Create(
             _tenantId,
-            graph.TenantSoftware.Id,
-            await _dbContext.NormalizedSoftwareInstallations.Select(x => x.SoftwareAssetId).FirstAsync(),
+            remCase.Id,
             RemediationOutcome.RiskAcceptance,
             "Temporary exception proposed.",
             Guid.NewGuid(),
             DecisionApprovalStatus.PendingApproval,
-            DateTimeOffset.UtcNow.AddDays(14),
-            null
+            DateTimeOffset.UtcNow.AddDays(14)
         );
         var approvalTask = ApprovalTask.Create(
             _tenantId,
+            remCase.Id,
             decision.Id,
             RemediationOutcome.RiskAcceptance,
             ApprovalTaskStatus.Pending,
@@ -278,7 +283,7 @@ public class EmailNotificationServiceTests : IDisposable
             Arg.Is<string>(body =>
                 body.Contains("agent")
                 && body.Contains("Severity:")
-                && body.Contains("Affected devices: 2")
+                && body.Contains("Affected devices: 0") // Phase 5 TODO: will be actual count
                 && body.Contains("Open approval task")
                 && body.Contains("https://app.patchhound.test/approvals/")),
             Arg.Any<CancellationToken>()
@@ -293,30 +298,25 @@ public class EmailNotificationServiceTests : IDisposable
         var team = Team.Create(_tenantId, "Infrastructure");
         _dbContext.Teams.Add(team);
         _dbContext.TeamMembers.Add(TeamMember.Create(team.Id, user.Id));
-        var graph = await TenantSoftwareGraphFactory.SeedAsync(_dbContext, _tenantId);
-        var devices = await _dbContext.Assets.Where(item => item.AssetType == AssetType.Device).ToListAsync();
-        foreach (var device in devices)
-        {
-            device.AssignTeamOwner(team.Id);
-        }
 
-        var softwareAssetId = await _dbContext.NormalizedSoftwareInstallations.Select(x => x.SoftwareAssetId).FirstAsync();
+        // Phase 4 (#17): seed SoftwareProduct + RemediationCase instead of TenantSoftware graph
+        var product = SoftwareProduct.Create("contoso", "agent", "contoso:agent");
+        var remCase = RemediationCase.Create(_tenantId, product.Id);
+        _dbContext.SoftwareProducts.Add(product);
+        _dbContext.RemediationCases.Add(remCase);
+
         var decision = RemediationDecision.Create(
             _tenantId,
-            graph.TenantSoftware.Id,
-            softwareAssetId,
+            remCase.Id,
             RemediationOutcome.ApprovedForPatching,
             null,
             Guid.NewGuid(),
-            DecisionApprovalStatus.Approved,
-            null,
-            null
+            DecisionApprovalStatus.Approved
         );
         var patchingTask = PatchingTask.Create(
             _tenantId,
+            remCase.Id,
             decision.Id,
-            graph.TenantSoftware.Id,
-            softwareAssetId,
             team.Id,
             DateTimeOffset.UtcNow.AddDays(7)
         );
@@ -341,7 +341,7 @@ public class EmailNotificationServiceTests : IDisposable
             Arg.Is<string>(body =>
                 body.Contains("Stage: Execution")
                 && body.Contains("Open remediation tasks")
-                && body.Contains("https://app.patchhound.test/remediation/tasks?tenantSoftwareId=")),
+                && body.Contains("https://app.patchhound.test/remediation/tasks?caseId=")), // Phase 4 (#17): was tenantSoftwareId
             Arg.Any<CancellationToken>()
         );
     }

--- a/tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/RemediationCaseServiceTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+using PatchHound.Tests.TestData;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class RemediationCaseServiceTests
+{
+    [Fact]
+    public async Task GetOrCreate_returns_existing_case_for_same_tenant_and_product()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var product = CanonicalTestData.Product();
+        ctx.SoftwareProducts.Add(product);
+        await ctx.SaveChangesAsync();
+
+        var sut = new RemediationCaseService(ctx);
+        var first = await sut.GetOrCreateAsync(tenantId, product.Id, CancellationToken.None);
+        var second = await sut.GetOrCreateAsync(tenantId, product.Id, CancellationToken.None);
+
+        Assert.Equal(first.Id, second.Id);
+        Assert.Equal(1, await ctx.RemediationCases.CountAsync());
+    }
+
+    [Fact]
+    public async Task GetOrCreate_creates_separate_case_per_tenant()
+    {
+        using var ctx = TestDbContextFactory.CreateSystemContext();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var product = CanonicalTestData.Product();
+        ctx.SoftwareProducts.Add(product);
+        await ctx.SaveChangesAsync();
+
+        var sut = new RemediationCaseService(ctx);
+        var a = await sut.GetOrCreateAsync(tenantA, product.Id, CancellationToken.None);
+        var b = await sut.GetOrCreateAsync(tenantB, product.Id, CancellationToken.None);
+
+        Assert.NotEqual(a.Id, b.Id);
+        Assert.Equal(tenantA, a.TenantId);
+        Assert.Equal(tenantB, b.TenantId);
+    }
+
+    [Fact]
+    public async Task GetOrCreate_rejects_unknown_product()
+    {
+        using var ctx = TestDbContextFactory.CreateTenantContext(out var tenantId);
+        var sut = new RemediationCaseService(ctx);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetOrCreateAsync(tenantId, Guid.NewGuid(), CancellationToken.None));
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/TestDbContextFactory.cs
+++ b/tests/PatchHound.Tests/Infrastructure/TestDbContextFactory.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Tests.TestData;
@@ -32,6 +34,52 @@ internal static class TestDbContextFactory
         );
 
         await db.Database.EnsureCreatedAsync();
+        return db;
+    }
+
+    /// <summary>
+    /// Creates a system-context (IsSystemContext = true) in-memory DbContext.
+    /// No tenant filter is applied — all rows are visible.
+    /// </summary>
+    public static PatchHoundDbContext CreateSystemContext()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns((Guid?)null);
+        tenantContext.AccessibleTenantIds.Returns(Array.Empty<Guid>());
+        tenantContext.IsSystemContext.Returns(true);
+
+        return Build(tenantContext);
+    }
+
+    /// <summary>
+    /// Creates an in-memory DbContext scoped to a single new tenant.
+    /// <paramref name="tenantId"/> is set to the generated tenant id.
+    /// </summary>
+    public static PatchHoundDbContext CreateTenantContext(out Guid tenantId)
+    {
+        tenantId = Guid.NewGuid();
+        var tid = tenantId;
+
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns((Guid?)tid);
+        tenantContext.AccessibleTenantIds.Returns(new[] { tid });
+        tenantContext.IsSystemContext.Returns(false);
+
+        return Build(tenantContext);
+    }
+
+    private static PatchHoundDbContext Build(ITenantContext tenantContext)
+    {
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        var db = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(tenantContext)
+        );
+
+        db.Database.EnsureCreated();
         return db;
     }
 }

--- a/tests/PatchHound.Tests/TestData/TestData.cs
+++ b/tests/PatchHound.Tests/TestData/TestData.cs
@@ -1,0 +1,56 @@
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Tests.TestData;
+
+/// <summary>
+/// Lightweight factory helpers for canonical entities used across service/integration tests.
+/// </summary>
+internal static class CanonicalTestData
+{
+    private static readonly Guid DefaultSourceSystemId = Guid.NewGuid();
+
+    public static SoftwareProduct Product(Guid? id = null)
+    {
+        var p = SoftwareProduct.Create(
+            vendor: "TestVendor",
+            name: "TestProduct",
+            primaryCpe23Uri: null
+        );
+        if (id.HasValue)
+            ForceSetId(p, id.Value);
+        return p;
+    }
+
+    public static Device MakeDevice(Guid tenantId, Guid? sourceSystemId = null) =>
+        Device.Create(
+            tenantId,
+            sourceSystemId ?? DefaultSourceSystemId,
+            externalId: $"dev-{Guid.NewGuid():N}",
+            name: "TestDevice",
+            baselineCriticality: Criticality.Medium
+        );
+
+    public static InstalledSoftware MakeInstalledSoftware(Guid tenantId, Guid deviceId, Guid softwareProductId) =>
+        InstalledSoftware.Observe(
+            tenantId,
+            deviceId,
+            softwareProductId,
+            sourceSystemId: DefaultSourceSystemId,
+            version: "1.0.0",
+            at: DateTimeOffset.UtcNow
+        );
+
+    /// <summary>
+    /// Uses reflection to force-set the Id on a <see cref="SoftwareProduct"/>
+    /// so tests can use a known Guid.
+    /// </summary>
+    private static void ForceSetId(SoftwareProduct product, Guid id)
+    {
+        var prop = typeof(SoftwareProduct).GetProperty(
+            nameof(SoftwareProduct.Id),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic
+        );
+        prop?.SetValue(product, id);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 of the canonical data model cleanup (refs #17).

Introduces `RemediationCase` as the tenant-scoped scope key for all remediation work, keyed by `(TenantId, SoftwareProductId)` — one case per tenant per product, created lazily. All remediation entities, services, controllers, and frontend components are rewritten to be case-first. `TenantSoftwareId`, `SoftwareAssetId`, and `TenantVulnerabilityId` are fully dropped from the remediation domain.

## What changed

### Entities (all re-anchored on `RemediationCaseId`)
- New: `RemediationCase` + `RemediationCaseStatus` enum
- `RemediationWorkflow`, `RemediationDecision`, `PatchingTask`, `ApprovalTask`, `RiskAcceptance`, `AnalystRecommendation`, `AIReport`, `RemediationAiJob` — all drop `TenantSoftwareId`/`SoftwareAssetId`/`TenantVulnerabilityId` and add `RemediationCaseId`
- `RemediationDecisionVulnerabilityOverride` — re-anchored on canonical `VulnerabilityId`
- `SoftwareDescriptionJob` — re-anchored on `SoftwareProductId`

### Services
- New: `RemediationCaseService` — lazy `GetOrCreateAsync(tenantId, softwareProductId)`
- `RemediationDecisionService` — `CreateDecisionForCaseAsync` replaces old `CreateDecisionForTenantSoftwareAsync`
- `RemediationWorkflowService` — all methods now take `remediationCaseId`
- `SoftwareDescriptionGenerationService` — rewrites to query `SoftwareProduct`/`SoftwareAliases`/`InstalledSoftware`, stores to `TenantSoftwareProductInsight`
- `RemediationDecisionQueryService` — `GenerateAndStoreAiDraftsAsync(tenantId, remediationCaseId)`

### API
- `RemediationDecisionsController` collapsed to `api/remediation/cases/{caseId}/*`
- All `ResolveCaseIdAsync` bridge code removed

### Workers
- `SoftwareDescriptionWorker` — `job.TenantSoftwareId` → `job.SoftwareProductId`
- `RemediationAiWorker` — `job.TenantSoftwareId` → `job.RemediationCaseId`
- `SlaCheckWorker` — `SoftwareAssetId` → `RemediationCaseId` on decisions and patching tasks

### Frontend
- New route: `remediation/cases/$caseId` (standalone case view)
- `SoftwareRemediationView` accepts optional `tenantSoftwareId` prop for embedded mode
- `RemediationTaskListItemDto`, `RemediationTaskFilterQuery`, and dashboard DTOs all use `RemediationCaseId`

## Verification

- **557 backend tests pass, 4 skipped** (`dotnet test --no-build`)
- **0 build errors, 0 warnings** (`dotnet build PatchHound.slnx`)
- **Frontend typecheck clean** (0 errors)
- **22 Vitest tests pass**
- Legacy identifier sweep clean (only pre-Phase-4 inventory entities + migration designer files)
- No EF migrations generated in this phase (Phase 6 only), except Task 7b's `RemediationOverrideVulnerabilityReanchor`