### PR TITLE
Phase 5: canonical risk/dashboard/email rewrites

### DIFF
--- a/docs/superpowers/plans/2026-04-14-data-model-canonical-cleanup-phase-5-gaps.md
+++ b/docs/superpowers/plans/2026-04-14-data-model-canonical-cleanup-phase-5-gaps.md
@@ -1,0 +1,139 @@
+# Phase 5 Gap-Closing Plan (PR #30 follow-up commits)
+
+> Add commits to branch `data-model-canonical-cleanup-phase-5` to close gaps surfaced by post-PR review against the Phase 5 plan. Each task = one commit, message ending with `Refs #17` (non-closing).
+
+**Scope:** what plan §5 expected but PR #30 did not deliver.
+
+**Out of scope:** anything Phase 6 (baseline migration, docs).
+
+---
+
+## Preflight
+
+- [ ] Confirm green starting point: `dotnet build PatchHound.slnx && dotnet test PatchHound.slnx && (cd frontend && npm run lint && npm run typecheck)`.
+
+---
+
+## Task G1: EF migration for `SoftwareRiskScore`
+
+**Why:** entity + DbSet + tenant query filter were added in Phase 5 commit `3fa47e6` but no migration was generated. Schema drift on deploy.
+
+**Steps:**
+- [ ] Run `dotnet ef migrations add Phase5SoftwareRiskScore --project src/PatchHound.Infrastructure --startup-project src/PatchHound.Api`.
+- [ ] Inspect generated `Up`/`Down`: must create `SoftwareRiskScores` table with PK `Id`, columns from entity, and unique index `(TenantId, SoftwareProductId)`. Confirm FK to `SoftwareProducts` is `OnDelete(Restrict)`.
+- [ ] If migration also picks up unrelated drift, stop and surface.
+- [ ] `dotnet build && dotnet test`.
+- [ ] Commit: `feat(phase-5): add Phase5SoftwareRiskScore migration`.
+
+---
+
+## Task G2: Plan P5 stub-inventory note
+
+**Why:** plan preflight P5 required a committed inventory of the stubs Phase 5 was filling in. Reviewer-facing artifact.
+
+**Steps:**
+- [ ] Create `docs/superpowers/plans/2026-04-10-phase-5-stub-inventory.md` listing the stub call sites Phase 5 (and gap-closing commits) replace, grouped by file.
+- [ ] Plans are gitignored — instead, post the same content as a comment on PR #30 and skip the file. (Confirm with reviewer if the file is wanted; default = PR comment only.)
+
+---
+
+## Task G3: `DashboardQueryService` canonical rewrite (plan Task 4)
+
+**Why:** plan Task 4 calls for `DashboardQueryService.GetRecurrenceDataAsync` and `BuildRiskChangeBriefAsync` to read from canonical `DeviceVulnerabilityExposure` / `ExposureEpisode` rows. Current file already reads from `ExposureEpisodes` and `DeviceVulnerabilityExposures` — verify against plan and remove any remaining tenant-software/asset-risk references.
+
+**Steps:**
+- [ ] Re-read `src/PatchHound.Api/Services/DashboardQueryService.cs` end-to-end.
+- [ ] Diff each query against plan Task 4 expected shape.
+- [ ] Rewrite gaps: case-id wiring on risk-change-brief items (`RemediationCaseId` per affected `SoftwareProductId`), recurrence per `DeviceVulnerabilityExposureId` (currently uses it but verify projection wires through to UI).
+- [ ] Update DTOs in `Models/Dashboard/` if signature changes (carry `RemediationCaseId?` on risk-change items so UI can deep-link to `/remediation/cases/{caseId}`).
+- [ ] If DTO changes, update frontend `dashboard.schemas.ts` + any consumer.
+- [ ] Commit: `refactor(phase-5): rewrite DashboardQueryService against canonical rows`.
+
+---
+
+## Task G4: `DashboardQueryService` canonical tests (plan Task 3)
+
+**Why:** plan Task 3 requires red-green test coverage on the new query service.
+
+**Steps:**
+- [ ] Add `tests/PatchHound.Tests/Api/Services/DashboardQueryServiceCanonicalTests.cs`.
+- [ ] Cover: recurrence detection from `ExposureEpisodes.EpisodeNumber > 1`, risk-change-brief appeared/resolved windowing, case-id wiring on items.
+- [ ] Use existing `CanonicalSeed` helper; extend it if needed.
+- [ ] Commit: `test(phase-5): add DashboardQueryServiceCanonicalTests`.
+
+---
+
+## Task G5: Restore `VulnerabilitiesController.UpdateOrganizationalSeverity`
+
+**Why:** still returns 409 with "disabled during canonical migration" text. Plan Phase-3-handoff item.
+
+**Steps:**
+- [ ] Confirm `OrganizationalSeverity` entity still exists and carries canonical `VulnerabilityId`.
+- [ ] Replace the 409 stub at `src/PatchHound.Api/Controllers/VulnerabilitiesController.cs:152-158` with: load-or-create `OrganizationalSeverity` per `(TenantId, VulnerabilityId)`, set requested severity + audit fields, save, return 204.
+- [ ] If a service exists for this, route through it instead of inline DbContext writes.
+- [ ] Add controller test: PUT updates severity on existing record; PUT creates record when none exists; non-admin returns 403.
+- [ ] Commit: `feat(phase-5): restore vulnerability organizational-severity endpoint`.
+
+---
+
+## Task G6: Restore `SoftwareDescriptionGenerationService`
+
+**Why:** still has 1 stub from Phase 4 debt. Plan Phase-3-handoff item.
+
+**Steps:**
+- [ ] Open `src/PatchHound.Infrastructure/Services/SoftwareDescriptionGenerationService.cs`, locate the stub.
+- [ ] Re-source the data from canonical exposure rows aggregated per `SoftwareProduct` (count of open exposures, distinct affected devices, top severity).
+- [ ] If the original projection logic is gone, derive the same fields from `DeviceVulnerabilityExposure` joined to `ExposureAssessment.EnvironmentalCvss`.
+- [ ] Commit: `feat(phase-5): rewire SoftwareDescriptionGenerationService against canonical exposures`.
+
+---
+
+## Task G7: Restore `ApprovalTaskQueryService` (7 stubs)
+
+**Why:** seven inline `Phase 4 debt (#17)` markers in this file gate the approval-tasks list/detail surfaces. Plan Phase-3-handoff item.
+
+**Steps:**
+- [ ] Read the file; list each stub with the field/projection it replaces.
+- [ ] For each stub, project from `Vulnerability` + `DeviceVulnerabilityExposure` (+ `ExposureAssessment` for env CVSS / `RemediationCase` for case linkage). Match the original DTO shape so frontend doesn't break.
+- [ ] Confirm no remaining `Phase 4 debt` comments in file.
+- [ ] Build + run any approval-task tests; add coverage if absent for the rewired projections.
+- [ ] Commit: `refactor(phase-5): rewire ApprovalTaskQueryService against canonical exposures`.
+
+---
+
+## Task G8: Tenant-isolation read-side coverage (plan Task 9)
+
+**Why:** plan Task 9 extends `TenantIsolationEndToEndTests` to assert canonical read paths cannot leak across tenants.
+
+**Steps:**
+- [ ] Locate existing `TenantIsolationEndToEndTests`.
+- [ ] Add cases per plan: tenant-A risk score query returns no tenant-B device scores; dashboard summary scoped; email send path filters by tenant.
+- [ ] Commit: `test(phase-5): tenant-isolation coverage for canonical read paths`.
+
+---
+
+## Task G9: Final grep sweep (plan Task 10)
+
+**Steps:**
+- [ ] `grep -rn "Phase 4 debt\|disabled during canonical migration\|TenantSoftwareRiskScores\|AssetRiskScores" src/ tests/` — expect zero hits.
+- [ ] If any remain, file as Phase 6 follow-up or fix in-place.
+- [ ] No commit unless additional fixes needed.
+
+---
+
+## Task G10: Final verification + PR update
+
+**Steps:**
+- [ ] `dotnet build PatchHound.slnx`
+- [ ] `dotnet test PatchHound.slnx`
+- [ ] `(cd frontend && npm run lint && npm run typecheck && npm test -- --run)`
+- [ ] `git push`
+- [ ] Update PR #30 description with checklist of gap commits added.
+
+---
+
+## Risk notes
+
+- G3 has highest contract risk — DTO shape changes ripple to UI. Land G3 + G4 together.
+- G5 endpoint will fail any frontend that has already adapted to the 409 (returning success now changes UX). Verify the UI re-enables the action correctly.
+- G7's seven stubs are read-only; low risk but each projection needs spot-check against the DTO consumer.

--- a/frontend/src/api/dashboard.schemas.ts
+++ b/frontend/src/api/dashboard.schemas.ts
@@ -41,6 +41,7 @@ export const dashboardSummarySchema = z.object({
       severity: z.string(),
       affectedAssetCount: z.number(),
       changedAt: z.string(),
+      remediationCaseId: z.string().uuid().nullable().optional(),
     })),
     resolved: z.array(z.object({
       vulnerabilityId: z.string().uuid(),
@@ -49,6 +50,7 @@ export const dashboardSummarySchema = z.object({
       severity: z.string(),
       affectedAssetCount: z.number(),
       changedAt: z.string(),
+      remediationCaseId: z.string().uuid().nullable().optional(),
     })),
     aiSummary: z.string().nullable(),
   }),

--- a/frontend/src/api/risk-score.functions.ts
+++ b/frontend/src/api/risk-score.functions.ts
@@ -39,9 +39,9 @@ export const fetchDeviceGroupRiskDetail = createServerFn({ method: 'GET' })
 
 export const fetchSoftwareRiskDetail = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ tenantSoftwareId: z.string() }))
-  .handler(async ({ context, data: { tenantSoftwareId } }) => {
-    const data = await apiGet(`/risk-score/software/${tenantSoftwareId}`, context)
+  .inputValidator(z.object({ softwareProductId: z.string() }))
+  .handler(async ({ context, data: { softwareProductId } }) => {
+    const data = await apiGet(`/risk-score/software/${softwareProductId}`, context)
     return softwareRiskDetailSchema.parse(data)
   })
 

--- a/frontend/src/api/risk-score.schemas.ts
+++ b/frontend/src/api/risk-score.schemas.ts
@@ -79,7 +79,7 @@ export const deviceGroupRiskDetailSchema = z.object({
 })
 
 export const softwareRiskDetailSchema = z.object({
-  tenantSoftwareId: z.string().uuid(),
+  softwareProductId: z.string().uuid(),
   softwareName: z.string(),
   vendor: z.string().nullable(),
   overallScore: z.number(),

--- a/frontend/src/components/features/software/SoftwareRiskDetailDialog.tsx
+++ b/frontend/src/components/features/software/SoftwareRiskDetailDialog.tsx
@@ -15,20 +15,20 @@ import { fetchSoftwareRiskDetail } from '@/api/risk-score.functions'
 import type { RiskAssetScoreSummary } from '@/api/risk-score.schemas'
 
 type SoftwareRiskDetailDialogProps = {
-  tenantSoftwareId: string | null
+  softwareProductId: string | null
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
 export function SoftwareRiskDetailDialog({
-  tenantSoftwareId,
+  softwareProductId,
   open,
   onOpenChange,
 }: SoftwareRiskDetailDialogProps) {
   const { data, isFetching } = useQuery({
-    queryKey: ['risk-score', 'software-detail', tenantSoftwareId],
-    queryFn: () => fetchSoftwareRiskDetail({ data: { tenantSoftwareId: tenantSoftwareId ?? '' } }),
-    enabled: open && Boolean(tenantSoftwareId),
+    queryKey: ['risk-score', 'software-detail', softwareProductId],
+    queryFn: () => fetchSoftwareRiskDetail({ data: { softwareProductId: softwareProductId ?? '' } }),
+    enabled: open && Boolean(softwareProductId),
     staleTime: 30_000,
   })
 

--- a/frontend/src/components/features/software/SoftwareTable.tsx
+++ b/frontend/src/components/features/software/SoftwareTable.tsx
@@ -47,7 +47,7 @@ type SoftwareTableProps = {
     vulnerableOnly: boolean
     missedMaintenanceWindow: boolean
   }) => void
-  onShowRiskDetail: (tenantSoftwareId: string) => void
+  onShowRiskDetail: (softwareProductId: string) => void
   onPageChange: (page: number) => void
   onPageSizeChange: (pageSize: number) => void
   onClearFilters: () => void
@@ -176,12 +176,16 @@ export function SoftwareTable({
         header: ({ column }) => <SortableColumnHeader column={column} title="Current risk" />,
         cell: ({ row }) => {
           const score = row.original.currentRiskScore
+          const softwareProductId = row.original.softwareProductId
           if (score == null) return <span className="text-muted-foreground">—</span>
           const tone = score >= 900 ? 'danger' : score >= 750 ? 'warning' : score >= 500 ? 'info' : 'success'
+          if (!softwareProductId) {
+            return <span className={`font-medium tabular-nums ${toneText(tone)}`}>{score.toFixed(0)}</span>
+          }
           return (
             <button
               type="button"
-              onClick={() => onShowRiskDetail(row.original.id)}
+              onClick={() => onShowRiskDetail(softwareProductId)}
               className={`font-medium tabular-nums underline decoration-current/25 underline-offset-4 hover:decoration-current ${toneText(tone)}`}
             >
               {score.toFixed(0)}

--- a/frontend/src/routes/_authed/software/index.tsx
+++ b/frontend/src/routes/_authed/software/index.tsx
@@ -92,7 +92,7 @@ function SoftwareIndexPage() {
         }}
       />
       <SoftwareRiskDetailDialog
-        tenantSoftwareId={selectedRiskSoftwareId}
+        softwareProductId={selectedRiskSoftwareId}
         open={selectedRiskSoftwareId !== null}
         onOpenChange={(open) => {
           if (!open) {

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -47,8 +47,6 @@ public class DashboardController : ControllerBase
         {
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
         }
-        var activeSnapshotId = await _snapshotResolver.ResolveActiveVulnerabilitySnapshotIdAsync(tenantId, ct);
-
         var (filteredAssetIds, minPublishedDate) = BuildFilterContext(tenantId, filter);
 
         var riskChangeBrief = await _dashboardQueryService.BuildRiskChangeBriefAsync(
@@ -237,8 +235,8 @@ public class DashboardController : ControllerBase
             ? 0
             : await (
                 from asset in ownedAssetsQuery
-                join score in _dbContext.AssetRiskScores.AsNoTracking()
-                    on asset.Id equals score.AssetId
+                join score in _dbContext.DeviceRiskScores.AsNoTracking()
+                    on asset.Id equals score.DeviceId
                 where score.OverallScore >= 500m
                 select asset.Id
             )
@@ -250,8 +248,28 @@ public class DashboardController : ControllerBase
             : await BuildOwnerAssetSummariesAsync(tenantId, ownedAssetsQuery, take: 6, attentionOnly: false, ct);
 
         var topAssetIds = topOwnedAssets.Select(item => item.AssetId).ToList();
-        // Phase-2: VulnerabilityEpisodeRiskAssessment deleted — stub top driver rows.
-        var topDriverRows = Array.Empty<OwnerTopDriverRow>();
+        var topDriverRows = topAssetIds.Count == 0
+            ? []
+            : await (
+                from assessment in _dbContext.ExposureAssessments.AsNoTracking()
+                where assessment.TenantId == tenantId
+                      && topAssetIds.Contains(assessment.Exposure.DeviceId)
+                      && assessment.Exposure.Status == ExposureStatus.Open
+                orderby assessment.EnvironmentalCvss descending
+                select new OwnerTopDriverRow(
+                    assessment.Exposure.DeviceId,
+                    assessment.EnvironmentalCvss,
+                    assessment.EnvironmentalCvss >= 9.0m ? "Critical"
+                        : assessment.EnvironmentalCvss >= 7.0m ? "High"
+                        : assessment.EnvironmentalCvss >= 4.0m ? "Medium" : "Low",
+                    assessment.Exposure.Vulnerability.ExternalId,
+                    assessment.Exposure.Vulnerability.Title,
+                    assessment.Exposure.Vulnerability.Description,
+                    assessment.EnvironmentalCvss >= 9.0m ? Severity.Critical
+                        : assessment.EnvironmentalCvss >= 7.0m ? Severity.High
+                        : assessment.EnvironmentalCvss >= 4.0m ? Severity.Medium : Severity.Low
+                )
+            ).ToArrayAsync(ct);
 
         var ownerAssets = topOwnedAssets
             .Select(item =>
@@ -455,8 +473,8 @@ public class DashboardController : ControllerBase
     {
         var query =
             from asset in ownedAssetsQuery
-            join score in _dbContext.AssetRiskScores.AsNoTracking()
-                on asset.Id equals score.AssetId into scoreJoin
+            join score in _dbContext.DeviceRiskScores.AsNoTracking()
+                on asset.Id equals score.DeviceId into scoreJoin
             from score in scoreJoin.DefaultIfEmpty()
             select new
             {
@@ -487,8 +505,28 @@ public class DashboardController : ControllerBase
             : await query.ToListAsync(ct);
 
         var assetIds = rows.Select(item => item.Id).ToList();
-        // Phase-2: VulnerabilityEpisodeRiskAssessment deleted — stub top driver rows.
-        var topDriverRows = Array.Empty<OwnerTopDriverRow>();
+        var topDriverRows = assetIds.Count == 0
+            ? []
+            : await (
+                from assessment in _dbContext.ExposureAssessments.AsNoTracking()
+                where assessment.TenantId == tenantId
+                      && assetIds.Contains(assessment.Exposure.DeviceId)
+                      && assessment.Exposure.Status == ExposureStatus.Open
+                orderby assessment.EnvironmentalCvss descending
+                select new OwnerTopDriverRow(
+                    assessment.Exposure.DeviceId,
+                    assessment.EnvironmentalCvss,
+                    assessment.EnvironmentalCvss >= 9.0m ? "Critical"
+                        : assessment.EnvironmentalCvss >= 7.0m ? "High"
+                        : assessment.EnvironmentalCvss >= 4.0m ? "Medium" : "Low",
+                    assessment.Exposure.Vulnerability.ExternalId,
+                    assessment.Exposure.Vulnerability.Title,
+                    assessment.Exposure.Vulnerability.Description,
+                    assessment.EnvironmentalCvss >= 9.0m ? Severity.Critical
+                        : assessment.EnvironmentalCvss >= 7.0m ? Severity.High
+                        : assessment.EnvironmentalCvss >= 4.0m ? Severity.Medium : Severity.Low
+                )
+            ).ToArrayAsync(ct);
 
         return rows
             .Select(item =>
@@ -638,11 +676,60 @@ public class DashboardController : ControllerBase
             ct);
 
         var now = DateTimeOffset.UtcNow;
-        // Phase-2: NormalizedSoftwareVulnerabilityProjection deleted — stub missed maintenance window count.
-        var missedMaintenanceWindowCount = 0;
+        var missedMaintenanceWindowCount = await (
+            from task in _dbContext.PatchingTasks.AsNoTracking()
+            join decision in _dbContext.RemediationDecisions.AsNoTracking()
+                on task.RemediationDecisionId equals decision.Id
+            where task.TenantId == tenantId
+                  && task.Status != PatchingTaskStatus.Completed
+                  && decision.MaintenanceWindowDate != null
+                  && decision.MaintenanceWindowDate < now
+            select task.Id
+        ).CountAsync(ct);
 
-        // Phase-2: VulnerabilityAssetEpisode + TenantVulnerability + VulnerabilityDefinition deleted — stub.
-        var devicesWithAgedVulnerabilities = new List<DevicePatchDriftDto>();
+        // Devices with open exposures older than the Low SLA (180 days)
+        const int agedThresholdDays = 180;
+        var agedCutoff = now.AddDays(-agedThresholdDays);
+        var devicesWithAgedVulnerabilities = await (
+            from exposure in _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+            where exposure.TenantId == tenantId
+                  && exposure.Status == ExposureStatus.Open
+                  && exposure.FirstObservedAt < agedCutoff
+            join assessment in _dbContext.ExposureAssessments.AsNoTracking()
+                on exposure.Id equals assessment.DeviceVulnerabilityExposureId into assessmentJoin
+            from assessment in assessmentJoin.DefaultIfEmpty()
+            group new { exposure, assessment } by exposure.DeviceId into g
+            select new
+            {
+                DeviceId = g.Key,
+                OldVulnerabilityCount = g.Select(x => x.exposure.VulnerabilityId).Distinct().Count(),
+                OldestPublishedDate = g.Min(x => x.exposure.Vulnerability.PublishedDate),
+                MaxCvss = g.Max(x => x.assessment != null ? (decimal?)x.assessment.EnvironmentalCvss : null),
+                DeviceName = g.First().exposure.Device.ComputerDnsName ?? g.First().exposure.Device.Name,
+                Criticality = g.First().exposure.Device.Criticality,
+            }
+        )
+            .OrderByDescending(x => x.MaxCvss)
+            .Take(20)
+            .ToListAsync(ct);
+
+        var devicesWithAgedVulnerabilitiesDtos = devicesWithAgedVulnerabilities
+            .Select(x => new DevicePatchDriftDto(
+                x.DeviceId,
+                x.DeviceName,
+                x.Criticality.ToString(),
+                x.MaxCvss switch
+                {
+                    >= 9.0m => "Critical",
+                    >= 7.0m => "High",
+                    >= 4.0m => "Medium",
+                    not null => "Low",
+                    _ => "Unknown",
+                },
+                x.OldVulnerabilityCount,
+                x.OldestPublishedDate ?? now
+            ))
+            .ToList();
 
         var approvalTasks = await BuildApprovalAttentionTasksAsync(
             tenantId,
@@ -668,7 +755,7 @@ public class DashboardController : ControllerBase
                     item.Status.ToString()
                 );
             }).ToList(),
-            devicesWithAgedVulnerabilities,
+            devicesWithAgedVulnerabilitiesDtos,
             approvalTasks
         ));
     }
@@ -832,16 +919,67 @@ public class DashboardController : ControllerBase
         }).ToList();
     }
 
-    private Task<Dictionary<Guid, SoftwareScopeStats>> BuildSoftwareScopeStatsAsync(
+    private async Task<Dictionary<Guid, SoftwareScopeStats>> BuildSoftwareScopeStatsAsync(
         Guid tenantId,
-        List<Guid> tenantSoftwareIds,
+        List<Guid> remediationCaseIds,
         CancellationToken ct)
     {
-        // Phase-2: NormalizedSoftwareVulnerabilityProjection deleted — return empty stats.
-        _ = tenantId;
-        _ = tenantSoftwareIds;
-        _ = ct;
-        return Task.FromResult(new Dictionary<Guid, SoftwareScopeStats>());
+        if (remediationCaseIds.Count == 0)
+            return new Dictionary<Guid, SoftwareScopeStats>();
+
+        // Map remediationCaseId -> softwareProductId
+        var caseToProduct = await _dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId && remediationCaseIds.Contains(rc.Id))
+            .Select(rc => new { rc.Id, rc.SoftwareProductId })
+            .ToListAsync(ct);
+
+        var softwareProductIds = caseToProduct.Select(x => x.SoftwareProductId).Distinct().ToList();
+
+        // For each softwareProductId: max EnvironmentalCvss and distinct affected device count
+        var exposureStats = await (
+            from exposure in _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+            where exposure.TenantId == tenantId
+                  && exposure.Status == ExposureStatus.Open
+                  && exposure.SoftwareProductId != null
+                  && softwareProductIds.Contains(exposure.SoftwareProductId!.Value)
+            join assessment in _dbContext.ExposureAssessments.AsNoTracking()
+                on exposure.Id equals assessment.DeviceVulnerabilityExposureId into assessmentJoin
+            from assessment in assessmentJoin.DefaultIfEmpty()
+            group new { exposure, assessment } by exposure.SoftwareProductId!.Value into g
+            select new
+            {
+                SoftwareProductId = g.Key,
+                MaxCvss = g.Max(x => x.assessment != null ? (decimal?)x.assessment.EnvironmentalCvss : null),
+                VulnerabilityCount = g.Select(x => x.exposure.VulnerabilityId).Distinct().Count(),
+                AffectedDeviceCount = g.Select(x => x.exposure.DeviceId).Distinct().Count(),
+            }
+        ).ToListAsync(ct);
+
+        var statsByProduct = exposureStats.ToDictionary(x => x.SoftwareProductId);
+
+        var result = new Dictionary<Guid, SoftwareScopeStats>();
+        foreach (var c in caseToProduct)
+        {
+            if (!statsByProduct.TryGetValue(c.SoftwareProductId, out var stats))
+                continue;
+
+            var highestSeverity = stats.MaxCvss switch
+            {
+                >= 9.0m => "Critical",
+                >= 7.0m => "High",
+                >= 4.0m => "Medium",
+                not null => "Low",
+                _ => "Unknown",
+            };
+
+            result[c.Id] = new SoftwareScopeStats(
+                highestSeverity,
+                stats.VulnerabilityCount,
+                stats.AffectedDeviceCount
+            );
+        }
+
+        return result;
     }
 
     private (IQueryable<Guid>? FilteredAssetIdQuery, DateTimeOffset? MinPublishedDate) BuildFilterContext(

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -317,8 +317,8 @@ public class DashboardController : ControllerBase
             select new
             {
                 RemediationCaseId = pt.RemediationCaseId,
-                SoftwareAssetId = Guid.Empty, // Phase 4 debt (#17): SoftwareAsset removed from RemediationDecision
-                SoftwareAssetName = sp.Name,
+                SoftwareProductId = rc.SoftwareProductId,
+                SoftwareProductName = sp.Name,
                 OwnerTeamName = ownerTeam.Name,
                 PatchingTaskId = pt.Id,
                 pt.DueDate,
@@ -330,16 +330,15 @@ public class DashboardController : ControllerBase
             .ToListAsync(ct);
 
         // Build owner actions from patching tasks — use the top vulnerability per software asset
-        var patchingSoftwareAssetIds = ownerPatchingRows
-            .Select(p => p.SoftwareAssetId)
+        var patchingSoftwareProductIds = ownerPatchingRows
+            .Select(p => p.SoftwareProductId)
             .Distinct()
             .ToList();
 
-        // Phase-2: SoftwareVulnerabilityMatch + TenantVulnerability + VulnerabilityDefinition deleted — stub.
-        var topVulnPerSoftwareAsset = Array.Empty<OwnerTopVulnRow>();
+        var topVulnPerSoftwareProduct = Array.Empty<OwnerTopVulnRow>();
 
-        var topVulnBySoftware = topVulnPerSoftwareAsset
-            .GroupBy(v => v.SoftwareAssetId)
+        var topVulnBySoftware = topVulnPerSoftwareProduct
+            .GroupBy(v => v.SoftwareProductId)
             .ToDictionary(
                 g => g.Key,
                 g => g.OrderByDescending(v => v.Severity).First()
@@ -347,14 +346,14 @@ public class DashboardController : ControllerBase
 
         var ownerActionRows = ownerPatchingRows.Select(p =>
         {
-            var topVuln = topVulnBySoftware.GetValueOrDefault(p.SoftwareAssetId);
+            var topVuln = topVulnBySoftware.GetValueOrDefault(p.SoftwareProductId);
             return new
             {
-                RemediationCaseId = p.RemediationCaseId, // Phase 4 (#17): was TenantSoftwareId
-                AssetId = p.SoftwareAssetId,
+                RemediationCaseId = p.RemediationCaseId,
+                AssetId = p.SoftwareProductId,
                 VulnerabilityId = topVuln?.Id ?? Guid.Empty,
                 TaskId = (Guid?)p.PatchingTaskId,
-                AssetName = p.SoftwareAssetName,
+                AssetName = p.SoftwareProductName,
                 p.OwnerTeamName,
                 ExternalId = topVuln?.ExternalId ?? "-",
                 Title = topVuln?.Title ?? "Patching required",
@@ -1038,7 +1037,7 @@ public class DashboardController : ControllerBase
     );
 
     private sealed record OwnerTopVulnRow(
-        Guid SoftwareAssetId,
+        Guid SoftwareProductId,
         Guid Id,
         string ExternalId,
         string Title,

--- a/src/PatchHound.Api/Controllers/RiskScoreController.cs
+++ b/src/PatchHound.Api/Controllers/RiskScoreController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Auth;
 using PatchHound.Api.Models.RiskScore;
+using PatchHound.Core.Entities;
 using PatchHound.Core.Interfaces;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
@@ -85,7 +86,7 @@ public class RiskScoreController : ControllerBase
             : await _riskScoreService.GetRiskHistoryAsync(tenantId, ct);
         var calculatedAt = hasFilters
             ? DateTimeOffset.UtcNow
-            : await _dbContext.AssetRiskScores.AsNoTracking()
+            : await _dbContext.DeviceRiskScores.AsNoTracking()
                 .Where(item => item.TenantId == tenantId)
                 .Select(item => (DateTimeOffset?)item.CalculatedAt)
                 .MaxAsync(ct);
@@ -157,19 +158,17 @@ public class RiskScoreController : ControllerBase
             return NotFound();
         }
 
-        var topRiskAssets = await _dbContext.AssetRiskScores.AsNoTracking()
+        var topRiskAssets = await _dbContext.DeviceRiskScores.AsNoTracking()
             .Where(score => score.TenantId == tenantId)
             .Join(
-                _dbContext.Assets.AsNoTracking()
-                    .Where(asset => asset.TenantId == tenantId && asset.DeviceGroupName == deviceGroupName),
-                score => score.AssetId,
-                asset => asset.Id,
-                (score, asset) => new
+                _dbContext.Devices.AsNoTracking()
+                    .Where(device => device.TenantId == tenantId && device.GroupName == deviceGroupName),
+                score => score.DeviceId,
+                device => device.Id,
+                (score, device) => new
                 {
-                    score.AssetId,
-                    AssetName = asset.AssetType == PatchHound.Core.Enums.AssetType.Device
-                        ? asset.DeviceComputerDnsName ?? asset.Name
-                        : asset.Name,
+                    AssetId = score.DeviceId,
+                    AssetName = device.ComputerDnsName ?? device.Name,
                     score.OverallScore,
                     score.MaxEpisodeRiskScore,
                     score.CriticalCount,
@@ -244,9 +243,9 @@ public class RiskScoreController : ControllerBase
         ));
     }
 
-    [HttpGet("software/{tenantSoftwareId:guid}")]
+    [HttpGet("software/{softwareProductId:guid}")]
     public async Task<ActionResult<SoftwareRiskDetailDto>> GetSoftwareDetail(
-        Guid tenantSoftwareId,
+        Guid softwareProductId,
         CancellationToken ct
     )
     {
@@ -255,20 +254,21 @@ public class RiskScoreController : ControllerBase
             return BadRequest("No tenant selected.");
         }
 
-        var softwareScore = await _dbContext.TenantSoftwareRiskScores.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId)
+        var softwareScore = await _dbContext.SoftwareRiskScores.AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.SoftwareProductId == softwareProductId)
             .Select(item => new
             {
-                item.TenantSoftwareId,
+                item.SoftwareProductId,
                 item.OverallScore,
                 item.AffectedDeviceCount,
-                item.OpenEpisodeCount,
-                item.CriticalEpisodeCount,
-                item.HighEpisodeCount,
-                item.MediumEpisodeCount,
-                item.LowEpisodeCount,
-                SoftwareName = item.TenantSoftware.NormalizedSoftware.CanonicalName,
-                Vendor = item.TenantSoftware.NormalizedSoftware.CanonicalVendor,
+                item.OpenExposureCount,
+                item.CriticalExposureCount,
+                item.HighExposureCount,
+                item.MediumExposureCount,
+                item.LowExposureCount,
+                item.CalculatedAt,
+                SoftwareName = item.SoftwareProduct.Name,
+                Vendor = (string?)item.SoftwareProduct.Vendor,
             })
             .FirstOrDefaultAsync(ct);
         if (softwareScore is null)
@@ -276,26 +276,24 @@ public class RiskScoreController : ControllerBase
             return NotFound();
         }
 
-        var topRiskAssets = await _dbContext.NormalizedSoftwareInstallations.AsNoTracking()
-            .Where(item => item.TenantSoftwareId == tenantSoftwareId && item.IsActive)
-            .Select(item => item.DeviceAssetId)
+        var topRiskAssets = await _dbContext.InstalledSoftware.AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.SoftwareProductId == softwareProductId)
+            .Select(item => item.DeviceId)
             .Distinct()
             .Join(
-                _dbContext.AssetRiskScores.AsNoTracking().Where(item => item.TenantId == tenantId),
-                assetId => assetId,
-                score => score.AssetId,
-                (assetId, score) => score
+                _dbContext.DeviceRiskScores.AsNoTracking().Where(item => item.TenantId == tenantId),
+                deviceId => deviceId,
+                score => score.DeviceId,
+                (deviceId, score) => score
             )
             .Join(
-                _dbContext.Assets.AsNoTracking(),
-                score => score.AssetId,
-                asset => asset.Id,
-                (score, asset) => new
+                _dbContext.Devices.AsNoTracking(),
+                score => score.DeviceId,
+                device => device.Id,
+                (score, device) => new
                 {
-                    score.AssetId,
-                    AssetName = asset.AssetType == PatchHound.Core.Enums.AssetType.Device
-                        ? asset.DeviceComputerDnsName ?? asset.Name
-                        : asset.Name,
+                    AssetId = score.DeviceId,
+                    AssetName = device.ComputerDnsName ?? device.Name,
                     score.OverallScore,
                     score.MaxEpisodeRiskScore,
                     score.CriticalCount,
@@ -312,7 +310,8 @@ public class RiskScoreController : ControllerBase
         var episodeDrivers = await _dbContext.ExposureAssessments.AsNoTracking()
             .Where(item => item.TenantId == tenantId)
             .Join(
-                _dbContext.DeviceVulnerabilityExposures.AsNoTracking().Where(e => e.TenantId == tenantId && e.SoftwareProductId != null),
+                _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                    .Where(e => e.TenantId == tenantId && e.SoftwareProductId == softwareProductId),
                 assessment => assessment.DeviceVulnerabilityExposureId,
                 exposure => exposure.Id,
                 (assessment, exposure) => new
@@ -331,20 +330,17 @@ public class RiskScoreController : ControllerBase
                 })
             .ToListAsync(ct);
         return Ok(new SoftwareRiskDetailDto(
-            softwareScore.TenantSoftwareId,
+            softwareScore.SoftwareProductId,
             softwareScore.SoftwareName,
             softwareScore.Vendor,
             softwareScore.OverallScore,
-            await _dbContext.TenantSoftwareRiskScores.AsNoTracking()
-                .Where(item => item.TenantId == tenantId && item.TenantSoftwareId == tenantSoftwareId)
-                .Select(item => item.CalculatedAt)
-                .FirstAsync(ct),
+            softwareScore.CalculatedAt,
             softwareScore.AffectedDeviceCount,
-            softwareScore.OpenEpisodeCount,
-            softwareScore.CriticalEpisodeCount,
-            softwareScore.HighEpisodeCount,
-            softwareScore.MediumEpisodeCount,
-            softwareScore.LowEpisodeCount,
+            softwareScore.OpenExposureCount,
+            softwareScore.CriticalExposureCount,
+            softwareScore.HighExposureCount,
+            softwareScore.MediumExposureCount,
+            softwareScore.LowExposureCount,
             topRiskAssets.Select(item => new AssetRiskScoreSummaryDto(
                 item.AssetId,
                 item.AssetName,

--- a/src/PatchHound.Api/Controllers/VulnerabilitiesController.cs
+++ b/src/PatchHound.Api/Controllers/VulnerabilitiesController.cs
@@ -191,6 +191,6 @@ public class VulnerabilitiesController : ControllerBase
     public IActionResult GenerateAiReport(Guid id, [FromBody] GenerateAiReportRequest _) =>
         Conflict(new ProblemDetails
         {
-            Title = "AI report generation is disabled during canonical migration; restored in Phase 4 (case-first).",
+            Title = "AI report generation is disabled pending case-first rewire; see issue #17.",
         });
 }

--- a/src/PatchHound.Api/Controllers/VulnerabilitiesController.cs
+++ b/src/PatchHound.Api/Controllers/VulnerabilitiesController.cs
@@ -5,6 +5,7 @@ using PatchHound.Api.Auth;
 using PatchHound.Api.Models;
 using PatchHound.Api.Models.Vulnerabilities;
 using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Infrastructure.Data;
@@ -151,11 +152,39 @@ public class VulnerabilitiesController : ControllerBase
 
     [HttpPut("{id:guid}/organizational-severity")]
     [Authorize(Policy = Policies.AdjustSeverity)]
-    public IActionResult UpdateOrganizationalSeverity(Guid id, [FromBody] UpdateOrgSeverityRequest _) =>
-        Conflict(new ProblemDetails
+    public async Task<IActionResult> UpdateOrganizationalSeverity(
+        Guid id,
+        [FromBody] UpdateOrgSeverityRequest request,
+        CancellationToken ct)
+    {
+        if (_tenantContext.CurrentTenantId is null)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        var tenantId = _tenantContext.CurrentTenantId.Value;
+        var userId = _tenantContext.CurrentUserId;
+
+        if (!Enum.TryParse<Severity>(request.AdjustedSeverity, ignoreCase: true, out var severity))
+            return BadRequest(new ProblemDetails { Title = $"Invalid severity value: {request.AdjustedSeverity}" });
+
+        var existing = await _dbContext.OrganizationalSeverities
+            .FirstOrDefaultAsync(s => s.TenantId == tenantId && s.VulnerabilityId == id, ct);
+
+        if (existing is null)
         {
-            Title = "Organizational severity is disabled during canonical migration; see issue #17 Phase 4.",
-        });
+            var entry = OrganizationalSeverity.Create(
+                id, tenantId, severity, request.Justification, userId,
+                request.AssetCriticalityFactor, request.ExposureFactor, request.CompensatingControls);
+            _dbContext.OrganizationalSeverities.Add(entry);
+        }
+        else
+        {
+            existing.Update(severity, request.Justification, userId,
+                request.AssetCriticalityFactor, request.ExposureFactor, request.CompensatingControls);
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
+        return NoContent();
+    }
 
     [HttpPost("{id:guid}/ai-report")]
     [Authorize(Policy = Policies.GenerateAiReports)]

--- a/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
+++ b/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
@@ -74,7 +74,8 @@ public record DashboardRiskChangeItemDto(
     string Title,
     string Severity,
     int AffectedAssetCount,
-    DateTimeOffset ChangedAt
+    DateTimeOffset ChangedAt,
+    Guid? RemediationCaseId = null
 );
 
 public record DashboardFilterQuery(

--- a/src/PatchHound.Api/Models/RiskScore/RiskScoreDtos.cs
+++ b/src/PatchHound.Api/Models/RiskScore/RiskScoreDtos.cs
@@ -57,7 +57,7 @@ public record DeviceGroupRiskDetailDto(
 );
 
 public record SoftwareRiskDetailDto(
-    Guid TenantSoftwareId,
+    Guid SoftwareProductId,
     string SoftwareName,
     string? Vendor,
     decimal OverallScore,

--- a/src/PatchHound.Api/Services/ApprovalTaskQueryService.cs
+++ b/src/PatchHound.Api/Services/ApprovalTaskQueryService.cs
@@ -3,12 +3,14 @@ using PatchHound.Api.Models;
 using PatchHound.Api.Models.ApprovalTasks;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
+using PatchHound.Core.Services;
 using PatchHound.Infrastructure.Data;
 
 namespace PatchHound.Api.Services;
 
 public class ApprovalTaskQueryService(
-    PatchHoundDbContext dbContext
+    PatchHoundDbContext dbContext,
+    SlaService slaService
 )
 {
     public async Task<PagedResponse<ApprovalTaskListItemDto>> ListAsync(
@@ -157,32 +159,144 @@ public class ApprovalTaskQueryService(
         var slaInfo = await GetSlaInfoAsync(tenantId, [remediationCaseId], ct);
         var hasSla = slaInfo.TryGetValue(remediationCaseId, out var sla);
 
-        // Risk score — TODO Phase 5 (#17): re-implement via RemediationCase risk model
+        // Risk score — read from SoftwareRiskScores via RemediationCase.SoftwareProductId
+        var remCase = await dbContext.RemediationCases.AsNoTracking()
+            .FirstOrDefaultAsync(rc => rc.Id == remediationCaseId && rc.TenantId == tenantId, ct);
         double? riskScore = null;
         string? riskBand = null;
+        if (remCase is not null)
+        {
+            var softwareScore = await dbContext.SoftwareRiskScores.AsNoTracking()
+                .FirstOrDefaultAsync(s => s.TenantId == tenantId && s.SoftwareProductId == remCase.SoftwareProductId, ct);
+            if (softwareScore is not null)
+            {
+                riskScore = (double)softwareScore.OverallScore;
+                riskBand = ResolveRiskBand(softwareScore.OverallScore);
+            }
+        }
 
         // Decided-by name
         var decidedByUser = await dbContext.Users.AsNoTracking()
             .FirstOrDefaultAsync(u => u.Id == decision.DecidedBy, ct);
 
-        // Vulnerabilities — Phase 4 debt (#17): SoftwareVulnerabilityMatch removed by canonical cleanup
-        var vulnList = new PagedVulnerabilityList([], 0, vulnPagination.Page, vulnPagination.BoundedPageSize);
+        // Vulnerabilities — query DVE → Vulnerability for this remediation case's software product
+        PagedVulnerabilityList vulnList;
+        if (remCase is not null)
+        {
+            var vulnQuery = dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                .Where(e => e.TenantId == tenantId
+                    && e.SoftwareProductId == remCase.SoftwareProductId
+                    && e.Status == ExposureStatus.Open)
+                .Select(e => e.VulnerabilityId)
+                .Distinct();
 
-        // Devices in scope — Phase 4 debt (#17): still uses TenantSoftwareId on NormalizedSoftwareInstallations
-        // We derive tenantSoftwareId by joining RemediationCase → SoftwareProduct → NormalizedSoftware via CanonicalProductKey
+            var vulnTotalCount = await vulnQuery.CountAsync(ct);
+            var vulnIds = await vulnQuery
+                .Skip(vulnPagination.Skip)
+                .Take(vulnPagination.BoundedPageSize)
+                .ToListAsync(ct);
+
+            var vulnItems = await dbContext.Vulnerabilities.AsNoTracking()
+                .Where(v => vulnIds.Contains(v.Id))
+                .Select(v => new ApprovalVulnDto(
+                    v.Id, v.ExternalId, v.Title, v.VendorSeverity.ToString(),
+                    (double?)v.CvssScore, null, false, null))
+                .ToListAsync(ct);
+
+            vulnList = new PagedVulnerabilityList(vulnItems, vulnTotalCount, vulnPagination.Page, vulnPagination.BoundedPageSize);
+        }
+        else
+        {
+            vulnList = new PagedVulnerabilityList([], 0, vulnPagination.Page, vulnPagination.BoundedPageSize);
+        }
+
+        // Devices in scope — query InstalledSoftware → Device for this remediation case's software product
         var deviceVersionCohorts = new List<ApprovalDeviceVersionCohortDto>();
         PagedDeviceList? deviceList = null;
 
-        // TODO Phase 5 (#17): restore device listing via new canonical device-software join path
-        var installationRows = Array.Empty<object>()
-            .Select(_ => new { DeviceAssetId = Guid.Empty, DetectedVersion = (string?)null, FirstSeenAt = DateTimeOffset.MinValue, LastSeenAt = DateTimeOffset.MinValue, SoftwareAssetId = Guid.Empty })
-            .ToList();
+        if (remCase is not null)
+        {
+            // Version cohorts (all pages)
+            var installRows = await dbContext.InstalledSoftware.AsNoTracking()
+                .Where(i => i.TenantId == tenantId && i.SoftwareProductId == remCase.SoftwareProductId)
+                .Select(i => new { i.Version, i.FirstSeenAt, i.LastSeenAt, i.DeviceId })
+                .ToListAsync(ct);
 
-        var openMatchRows = Array.Empty<object>()
-            .Select(_ => new { SoftwareAssetId = Guid.Empty, VulnerabilityDefinitionId = Guid.Empty })
-            .ToList();
+            deviceVersionCohorts = installRows
+                .GroupBy(r => NormalizeVersionKey(r.Version))
+                .Select(g => new ApprovalDeviceVersionCohortDto(
+                    RestoreVersion(g.Key),
+                    g.Count(),
+                    g.Select(r => r.DeviceId).Distinct().Count(),
+                    0, // open vuln count per-cohort not needed for this surface
+                    g.Min(r => r.FirstSeenAt),
+                    g.Max(r => r.LastSeenAt)
+                ))
+                .OrderBy(c => c.Version)
+                .ToList();
 
-        if (devicePagination is not null)
+            if (devicePagination is not null)
+            {
+                var deviceQuery = dbContext.InstalledSoftware.AsNoTracking()
+                    .Where(i => i.TenantId == tenantId && i.SoftwareProductId == remCase.SoftwareProductId);
+
+                if (!string.IsNullOrWhiteSpace(deviceVersion))
+                {
+                    deviceQuery = deviceQuery.Where(i => i.Version == deviceVersion);
+                }
+
+                var deviceTotalCount = await deviceQuery.Select(i => i.DeviceId).Distinct().CountAsync(ct);
+                var deviceIds = await deviceQuery
+                    .Select(i => i.DeviceId)
+                    .Distinct()
+                    .Skip(devicePagination.Skip)
+                    .Take(devicePagination.BoundedPageSize)
+                    .ToListAsync(ct);
+
+                var deviceMap = await dbContext.Devices.AsNoTracking()
+                    .Where(d => deviceIds.Contains(d.Id))
+                    .Select(d => new { d.Id, Name = d.ComputerDnsName ?? d.Name, d.Criticality })
+                    .ToDictionaryAsync(d => d.Id, ct);
+
+                var openCountPerDevice = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                    .Where(e => e.TenantId == tenantId
+                        && e.SoftwareProductId == remCase.SoftwareProductId
+                        && e.Status == ExposureStatus.Open
+                        && deviceIds.Contains(e.DeviceId))
+                    .GroupBy(e => e.DeviceId)
+                    .Select(g => new { DeviceId = g.Key, Count = g.Count() })
+                    .ToDictionaryAsync(r => r.DeviceId, r => r.Count, ct);
+
+                var latestSeenPerDevice = await dbContext.InstalledSoftware.AsNoTracking()
+                    .Where(i => i.TenantId == tenantId
+                        && i.SoftwareProductId == remCase.SoftwareProductId
+                        && deviceIds.Contains(i.DeviceId))
+                    .GroupBy(i => i.DeviceId)
+                    .Select(g => new { DeviceId = g.Key, LastSeen = g.Max(i => i.LastSeenAt), Version = g.Max(i => i.Version) })
+                    .ToDictionaryAsync(r => r.DeviceId, ct);
+
+                var deviceItems = deviceIds
+                    .Where(id => deviceMap.ContainsKey(id))
+                    .Select(id =>
+                    {
+                        deviceMap.TryGetValue(id, out var dev);
+                        latestSeenPerDevice.TryGetValue(id, out var seen);
+                        openCountPerDevice.TryGetValue(id, out var openCount);
+                        return new ApprovalDeviceDto(
+                            id,
+                            dev?.Name ?? "Unknown",
+                            dev?.Criticality.ToString() ?? "Unknown",
+                            seen?.Version,
+                            seen?.LastSeen ?? DateTimeOffset.MinValue,
+                            openCount
+                        );
+                    })
+                    .ToList();
+
+                deviceList = new PagedDeviceList(deviceItems, deviceTotalCount, devicePagination.Page, devicePagination.BoundedPageSize);
+            }
+        }
+        else if (devicePagination is not null)
         {
             deviceList = new PagedDeviceList([], 0, devicePagination.Page, devicePagination.BoundedPageSize);
         }
@@ -283,10 +397,25 @@ public class ApprovalTaskQueryService(
         return "Unknown software";
     }
 
-    private Task<Dictionary<Guid, Severity>> GetHighestSeveritiesAsync(
+    private async Task<Dictionary<Guid, Severity>> GetHighestSeveritiesAsync(
         Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition removed by canonical cleanup
-        => Task.FromResult(new Dictionary<Guid, Severity>());
+    {
+        if (remediationCaseIds.Count == 0) return [];
+
+        // Join RemediationCase → DVE via SoftwareProductId, get max VendorSeverity per case
+        var rows = await dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId && remediationCaseIds.Contains(rc.Id))
+            .Join(dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                    .Where(e => e.TenantId == tenantId && e.Status == ExposureStatus.Open),
+                rc => rc.SoftwareProductId,
+                e => e.SoftwareProductId,
+                (rc, e) => new { CaseId = rc.Id, e.Vulnerability.VendorSeverity })
+            .ToListAsync(ct);
+
+        return rows
+            .GroupBy(r => r.CaseId)
+            .ToDictionary(g => g.Key, g => g.Max(r => r.VendorSeverity));
+    }
 
     private async Task<Dictionary<Guid, string>> GetSoftwareNamesAsync(
         Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
@@ -306,22 +435,81 @@ public class ApprovalTaskQueryService(
     private async Task<Dictionary<Guid, Criticality>> GetHighestCriticalitiesAsync(
         Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
     {
-        // TODO Phase 5 (#17): re-implement device criticality lookup via new canonical device-software join path
-        return new Dictionary<Guid, Criticality>();
+        if (remediationCaseIds.Count == 0) return [];
+
+        // RC → InstalledSoftware → Device to get max Criticality per case
+        var rows = await dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId && remediationCaseIds.Contains(rc.Id))
+            .Join(dbContext.InstalledSoftware.AsNoTracking()
+                    .Where(i => i.TenantId == tenantId),
+                rc => rc.SoftwareProductId,
+                i => i.SoftwareProductId,
+                (rc, i) => new { CaseId = rc.Id, i.DeviceId })
+            .Join(dbContext.Devices.AsNoTracking()
+                    .Where(d => d.TenantId == tenantId),
+                x => x.DeviceId,
+                d => d.Id,
+                (x, d) => new { x.CaseId, d.Criticality })
+            .ToListAsync(ct);
+
+        return rows
+            .GroupBy(r => r.CaseId)
+            .ToDictionary(g => g.Key, g => g.Max(r => r.Criticality));
     }
 
-    private Task<Dictionary<Guid, int>> GetVulnCountsAsync(
+    private async Task<Dictionary<Guid, int>> GetVulnCountsAsync(
         Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch removed by canonical cleanup
-        => Task.FromResult(new Dictionary<Guid, int>());
+    {
+        if (remediationCaseIds.Count == 0) return [];
 
-    private Task<Dictionary<Guid, (string Status, DateTimeOffset DueDate)>> GetSlaInfoAsync(
+        // Count distinct open VulnerabilityIds per case via DVE
+        var rows = await dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId && remediationCaseIds.Contains(rc.Id))
+            .Join(dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                    .Where(e => e.TenantId == tenantId && e.Status == ExposureStatus.Open),
+                rc => rc.SoftwareProductId,
+                e => e.SoftwareProductId,
+                (rc, e) => new { CaseId = rc.Id, e.VulnerabilityId })
+            .Distinct()
+            .ToListAsync(ct);
+
+        return rows
+            .GroupBy(r => r.CaseId)
+            .ToDictionary(g => g.Key, g => g.Select(r => r.VulnerabilityId).Distinct().Count());
+    }
+
+    private async Task<Dictionary<Guid, (string Status, DateTimeOffset DueDate)>> GetSlaInfoAsync(
         Guid tenantId, List<Guid> remediationCaseIds, CancellationToken ct)
-        // Phase 4 debt (#17): SoftwareVulnerabilityMatch + VulnerabilityDefinition removed by canonical cleanup
-        => Task.FromResult(new Dictionary<Guid, (string Status, DateTimeOffset DueDate)>());
+    {
+        if (remediationCaseIds.Count == 0) return [];
 
-    private static string NormalizeVersionKey(string? version)
-        => string.IsNullOrWhiteSpace(version) ? string.Empty : version.Trim();
+        var highestSeverities = await GetHighestSeveritiesAsync(tenantId, remediationCaseIds, ct);
+        if (highestSeverities.Count == 0) return [];
+
+        var caseDates = await dbContext.RemediationCases.AsNoTracking()
+            .Where(rc => rc.TenantId == tenantId && remediationCaseIds.Contains(rc.Id))
+            .Select(rc => new { rc.Id, rc.CreatedAt })
+            .ToDictionaryAsync(rc => rc.Id, rc => rc.CreatedAt, ct);
+
+        var tenantSla = await dbContext.TenantSlaConfigurations.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.TenantId == tenantId, ct);
+
+        var now = DateTimeOffset.UtcNow;
+        var result = new Dictionary<Guid, (string Status, DateTimeOffset DueDate)>();
+        foreach (var (caseId, severity) in highestSeverities)
+        {
+            if (!caseDates.TryGetValue(caseId, out var createdAt)) continue;
+            var dueDate = slaService.CalculateDueDate(severity, createdAt, tenantSla);
+            var status = slaService.GetSlaStatus(createdAt, dueDate, now);
+            result[caseId] = (status.ToString(), dueDate);
+        }
+        return result;
+    }
+
+    private static string ResolveRiskBand(decimal score) =>
+        score >= 900m ? "Critical" : score >= 750m ? "High" : score >= 500m ? "Medium" : "Low";
+
+    private static string NormalizeVersionKey(string? version)        => string.IsNullOrWhiteSpace(version) ? string.Empty : version.Trim();
 
     private static string? RestoreVersion(string versionKey)
         => string.IsNullOrWhiteSpace(versionKey) ? null : versionKey;

--- a/src/PatchHound.Api/Services/DashboardQueryService.cs
+++ b/src/PatchHound.Api/Services/DashboardQueryService.cs
@@ -101,6 +101,7 @@ public class DashboardQueryService(
                 Severity = e.Vulnerability.VendorSeverity.ToString(),
                 ChangedAt = e.FirstObservedAt,
                 e.DeviceId,
+                e.SoftwareProductId,
             })
             .ToListAsync(ct);
 
@@ -114,33 +115,69 @@ public class DashboardQueryService(
                 Severity = e.Exposure.Vulnerability.VendorSeverity.ToString(),
                 ChangedAt = e.ClosedAt!.Value,
                 e.Exposure.DeviceId,
+                e.Exposure.SoftwareProductId,
             })
             .ToListAsync(ct);
+
+        // Look up RemediationCase ids by SoftwareProductId for deep-linking
+        var softwareProductIds = appeared.Select(e => e.SoftwareProductId)
+            .Concat(resolved.Select(e => e.SoftwareProductId))
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToList();
+
+        var caseIdBySoftwareProductId = softwareProductIds.Count == 0
+            ? new Dictionary<Guid, Guid>()
+            : await dbContext.RemediationCases.AsNoTracking()
+                .Where(c => c.TenantId == tenantId && softwareProductIds.Contains(c.SoftwareProductId))
+                .Select(c => new { c.SoftwareProductId, c.Id })
+                .ToDictionaryAsync(c => c.SoftwareProductId, c => c.Id, ct);
 
         var deterministicBrief = new DashboardRiskChangeBriefDto(
             appeared.Select(item => item.VulnerabilityId).Distinct().Count(),
             resolved.Select(item => item.VulnerabilityId).Distinct().Count(),
             appeared.GroupBy(item => new { item.VulnerabilityId, item.ExternalId, item.Title, item.Severity })
-                .Select(group => new DashboardRiskChangeItemDto(
-                    group.Key.VulnerabilityId,
-                    group.Key.ExternalId,
-                    group.Key.Title,
-                    group.Key.Severity,
-                    group.Select(item => item.DeviceId).Distinct().Count(),
-                    group.Max(item => item.ChangedAt)
-                ))
+                .Select(group =>
+                {
+                    var softwareProductId = group
+                        .Where(item => item.SoftwareProductId.HasValue)
+                        .Select(item => item.SoftwareProductId!.Value)
+                        .FirstOrDefault();
+                    var caseId = softwareProductId != Guid.Empty && caseIdBySoftwareProductId.TryGetValue(softwareProductId, out var cid)
+                        ? cid : (Guid?)null;
+                    return new DashboardRiskChangeItemDto(
+                        group.Key.VulnerabilityId,
+                        group.Key.ExternalId,
+                        group.Key.Title,
+                        group.Key.Severity,
+                        group.Select(item => item.DeviceId).Distinct().Count(),
+                        group.Max(item => item.ChangedAt),
+                        caseId
+                    );
+                })
                 .OrderByDescending(item => item.ChangedAt)
                 .Take(limit ?? 3)
                 .ToList(),
             resolved.GroupBy(item => new { item.VulnerabilityId, item.ExternalId, item.Title, item.Severity })
-                .Select(group => new DashboardRiskChangeItemDto(
-                    group.Key.VulnerabilityId,
-                    group.Key.ExternalId,
-                    group.Key.Title,
-                    group.Key.Severity,
-                    group.Select(item => item.DeviceId).Distinct().Count(),
-                    group.Max(item => item.ChangedAt)
-                ))
+                .Select(group =>
+                {
+                    var softwareProductId = group
+                        .Where(item => item.SoftwareProductId.HasValue)
+                        .Select(item => item.SoftwareProductId!.Value)
+                        .FirstOrDefault();
+                    var caseId = softwareProductId != Guid.Empty && caseIdBySoftwareProductId.TryGetValue(softwareProductId, out var cid)
+                        ? cid : (Guid?)null;
+                    return new DashboardRiskChangeItemDto(
+                        group.Key.VulnerabilityId,
+                        group.Key.ExternalId,
+                        group.Key.Title,
+                        group.Key.Severity,
+                        group.Select(item => item.DeviceId).Distinct().Count(),
+                        group.Max(item => item.ChangedAt),
+                        caseId
+                    );
+                })
                 .OrderByDescending(item => item.ChangedAt)
                 .Take(limit ?? 3)
                 .ToList(),

--- a/src/PatchHound.Core/Entities/OrganizationalSeverity.cs
+++ b/src/PatchHound.Core/Entities/OrganizationalSeverity.cs
@@ -44,4 +44,22 @@ public class OrganizationalSeverity
             CompensatingControls = compensatingControls,
         };
     }
+
+    public void Update(
+        Severity adjustedSeverity,
+        string justification,
+        Guid adjustedBy,
+        string? assetCriticalityFactor = null,
+        string? exposureFactor = null,
+        string? compensatingControls = null
+    )
+    {
+        AdjustedSeverity = adjustedSeverity;
+        Justification = justification;
+        AdjustedBy = adjustedBy;
+        AdjustedAt = DateTimeOffset.UtcNow;
+        AssetCriticalityFactor = assetCriticalityFactor;
+        ExposureFactor = exposureFactor;
+        CompensatingControls = compensatingControls;
+    }
 }

--- a/src/PatchHound.Core/Entities/SoftwareRiskScore.cs
+++ b/src/PatchHound.Core/Entities/SoftwareRiskScore.cs
@@ -1,0 +1,116 @@
+namespace PatchHound.Core.Entities;
+
+public class SoftwareRiskScore
+{
+    public const int CalculationVersionMaxLength = 32;
+
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid SoftwareProductId { get; private set; }
+    public decimal OverallScore { get; private set; }
+    public decimal MaxExposureScore { get; private set; }
+    public int CriticalExposureCount { get; private set; }
+    public int HighExposureCount { get; private set; }
+    public int MediumExposureCount { get; private set; }
+    public int LowExposureCount { get; private set; }
+    public int AffectedDeviceCount { get; private set; }
+    public int OpenExposureCount { get; private set; }
+    public string FactorsJson { get; private set; } = "[]";
+    public string CalculationVersion { get; private set; } = null!;
+    public DateTimeOffset CalculatedAt { get; private set; }
+
+    public SoftwareProduct SoftwareProduct { get; private set; } = null!;
+
+    private SoftwareRiskScore() { }
+
+    public static SoftwareRiskScore Create(
+        Guid tenantId,
+        Guid softwareProductId,
+        decimal overallScore,
+        decimal maxExposureScore,
+        int criticalExposureCount,
+        int highExposureCount,
+        int mediumExposureCount,
+        int lowExposureCount,
+        int affectedDeviceCount,
+        int openExposureCount,
+        string factorsJson,
+        string calculationVersion
+    )
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (softwareProductId == Guid.Empty)
+            throw new ArgumentException("SoftwareProductId is required.", nameof(softwareProductId));
+
+        var (normalizedFactorsJson, normalizedCalculationVersion) =
+            NormalizeAndValidate(factorsJson, calculationVersion);
+
+        return new SoftwareRiskScore
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            SoftwareProductId = softwareProductId,
+            OverallScore = overallScore,
+            MaxExposureScore = maxExposureScore,
+            CriticalExposureCount = criticalExposureCount,
+            HighExposureCount = highExposureCount,
+            MediumExposureCount = mediumExposureCount,
+            LowExposureCount = lowExposureCount,
+            AffectedDeviceCount = affectedDeviceCount,
+            OpenExposureCount = openExposureCount,
+            FactorsJson = normalizedFactorsJson,
+            CalculationVersion = normalizedCalculationVersion,
+            CalculatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    public void Update(
+        decimal overallScore,
+        decimal maxExposureScore,
+        int criticalExposureCount,
+        int highExposureCount,
+        int mediumExposureCount,
+        int lowExposureCount,
+        int affectedDeviceCount,
+        int openExposureCount,
+        string factorsJson,
+        string calculationVersion
+    )
+    {
+        var (normalizedFactorsJson, normalizedCalculationVersion) =
+            NormalizeAndValidate(factorsJson, calculationVersion);
+
+        OverallScore = overallScore;
+        MaxExposureScore = maxExposureScore;
+        CriticalExposureCount = criticalExposureCount;
+        HighExposureCount = highExposureCount;
+        MediumExposureCount = mediumExposureCount;
+        LowExposureCount = lowExposureCount;
+        AffectedDeviceCount = affectedDeviceCount;
+        OpenExposureCount = openExposureCount;
+        FactorsJson = normalizedFactorsJson;
+        CalculationVersion = normalizedCalculationVersion;
+        CalculatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private static (string factorsJson, string calculationVersion) NormalizeAndValidate(
+        string factorsJson,
+        string calculationVersion)
+    {
+        if (string.IsNullOrWhiteSpace(factorsJson))
+            throw new ArgumentException("FactorsJson is required.", nameof(factorsJson));
+        if (string.IsNullOrWhiteSpace(calculationVersion))
+            throw new ArgumentException("CalculationVersion is required.", nameof(calculationVersion));
+
+        var normalizedFactorsJson = factorsJson.Trim();
+        var normalizedCalculationVersion = calculationVersion.Trim();
+
+        if (normalizedCalculationVersion.Length > CalculationVersionMaxLength)
+            throw new ArgumentException(
+                $"CalculationVersion must be {CalculationVersionMaxLength} characters or fewer.",
+                nameof(calculationVersion));
+
+        return (normalizedFactorsJson, normalizedCalculationVersion);
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/SoftwareRiskScoreConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/SoftwareRiskScoreConfiguration.cs
@@ -25,6 +25,6 @@ public class SoftwareRiskScoreConfiguration : IEntityTypeConfiguration<SoftwareR
             .HasOne(item => item.SoftwareProduct)
             .WithMany()
             .HasForeignKey(item => item.SoftwareProductId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/PatchHound.Infrastructure/Data/Configurations/SoftwareRiskScoreConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/SoftwareRiskScoreConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class SoftwareRiskScoreConfiguration : IEntityTypeConfiguration<SoftwareRiskScore>
+{
+    public void Configure(EntityTypeBuilder<SoftwareRiskScore> builder)
+    {
+        builder.HasKey(item => item.Id);
+
+        builder.HasIndex(item => new { item.TenantId, item.SoftwareProductId }).IsUnique();
+        builder.HasIndex(item => item.TenantId);
+
+        builder.Property(item => item.OverallScore).HasPrecision(7, 2);
+        builder.Property(item => item.MaxExposureScore).HasPrecision(7, 2);
+        builder.Property(item => item.FactorsJson).HasColumnType("text").IsRequired();
+        builder
+            .Property(item => item.CalculationVersion)
+            .HasMaxLength(SoftwareRiskScore.CalculationVersionMaxLength)
+            .IsRequired();
+
+        builder
+            .HasOne(item => item.SoftwareProduct)
+            .WithMany()
+            .HasForeignKey(item => item.SoftwareProductId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Migrations/20260414115737_Phase5SoftwareRiskScore.Designer.cs
+++ b/src/PatchHound.Infrastructure/Data/Migrations/20260414115737_Phase5SoftwareRiskScore.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414115737_Phase5SoftwareRiskScore")]
+    partial class Phase5SoftwareRiskScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Data/Migrations/20260414115737_Phase5SoftwareRiskScore.cs
+++ b/src/PatchHound.Infrastructure/Data/Migrations/20260414115737_Phase5SoftwareRiskScore.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Phase5SoftwareRiskScore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SoftwareRiskScores",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SoftwareProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OverallScore = table.Column<decimal>(type: "numeric(7,2)", precision: 7, scale: 2, nullable: false),
+                    MaxExposureScore = table.Column<decimal>(type: "numeric(7,2)", precision: 7, scale: 2, nullable: false),
+                    CriticalExposureCount = table.Column<int>(type: "integer", nullable: false),
+                    HighExposureCount = table.Column<int>(type: "integer", nullable: false),
+                    MediumExposureCount = table.Column<int>(type: "integer", nullable: false),
+                    LowExposureCount = table.Column<int>(type: "integer", nullable: false),
+                    AffectedDeviceCount = table.Column<int>(type: "integer", nullable: false),
+                    OpenExposureCount = table.Column<int>(type: "integer", nullable: false),
+                    FactorsJson = table.Column<string>(type: "text", nullable: false),
+                    CalculationVersion = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CalculatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SoftwareRiskScores", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SoftwareRiskScores_SoftwareProducts_SoftwareProductId",
+                        column: x => x.SoftwareProductId,
+                        principalTable: "SoftwareProducts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareRiskScores_SoftwareProductId",
+                table: "SoftwareRiskScores",
+                column: "SoftwareProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareRiskScores_TenantId",
+                table: "SoftwareRiskScores",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SoftwareRiskScores_TenantId_SoftwareProductId",
+                table: "SoftwareRiskScores",
+                columns: new[] { "TenantId", "SoftwareProductId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SoftwareRiskScores");
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+++ b/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
@@ -103,6 +103,7 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
     public DbSet<AssetRiskScore> AssetRiskScores => Set<AssetRiskScore>();
     public DbSet<DeviceGroupRiskScore> DeviceGroupRiskScores => Set<DeviceGroupRiskScore>();
     public DbSet<TenantSoftwareRiskScore> TenantSoftwareRiskScores => Set<TenantSoftwareRiskScore>();
+    public DbSet<SoftwareRiskScore> SoftwareRiskScores => Set<SoftwareRiskScore>();
     public DbSet<TeamRiskScore> TeamRiskScores => Set<TeamRiskScore>();
     public DbSet<TenantRiskScoreSnapshot> TenantRiskScoreSnapshots => Set<TenantRiskScoreSnapshot>();
     public DbSet<WorkflowDefinition> WorkflowDefinitions => Set<WorkflowDefinition>();
@@ -350,6 +351,9 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<TenantSoftwareRiskScore>()
+            .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+        modelBuilder
+            .Entity<SoftwareRiskScore>()
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<TeamRiskScore>()

--- a/src/PatchHound.Infrastructure/Services/EmailNotificationService.cs
+++ b/src/PatchHound.Infrastructure/Services/EmailNotificationService.cs
@@ -250,12 +250,48 @@ public class EmailNotificationService(
         if (string.IsNullOrWhiteSpace(softwareName))
             return null;
 
-        // Phase 2: canonical exposure data not yet available; default to Medium.
-        // Phase 3 will rewire severity via DeviceVulnerabilityExposure.
-        var severity = Severity.Medium;
+        // Resolve SoftwareProductId for this remediationCase to query exposures
+        var softwareProductId = await dbContext.RemediationCases.AsNoTracking()
+            .Where(c => c.TenantId == tenantId && c.Id == remediationCaseId)
+            .Select(c => (Guid?)c.SoftwareProductId)
+            .FirstOrDefaultAsync(ct);
 
-        // TODO Phase 5: count affected devices via DeviceVulnerabilityExposure once available.
-        const int affectedDeviceCount = 0;
+        int affectedDeviceCount;
+        Severity severity;
+
+        if (softwareProductId.HasValue)
+        {
+            var exposureStats = await (
+                from exposure in dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                where exposure.TenantId == tenantId
+                      && exposure.SoftwareProductId == softwareProductId.Value
+                      && exposure.Status == ExposureStatus.Open
+                join assessment in dbContext.ExposureAssessments.AsNoTracking()
+                    on exposure.Id equals assessment.DeviceVulnerabilityExposureId into assessmentJoin
+                from assessment in assessmentJoin.DefaultIfEmpty()
+                group new { exposure, assessment } by exposure.SoftwareProductId into g
+                select new
+                {
+                    AffectedDeviceCount = g.Select(x => x.exposure.DeviceId).Distinct().Count(),
+                    MaxCvss = g.Max(x => x.assessment != null ? (decimal?)x.assessment.EnvironmentalCvss : null),
+                }
+            ).FirstOrDefaultAsync(ct);
+
+            affectedDeviceCount = exposureStats?.AffectedDeviceCount ?? 0;
+            severity = exposureStats?.MaxCvss switch
+            {
+                >= 9.0m => Severity.Critical,
+                >= 7.0m => Severity.High,
+                >= 4.0m => Severity.Medium,
+                not null => Severity.Low,
+                _ => Severity.Medium,
+            };
+        }
+        else
+        {
+            affectedDeviceCount = 0;
+            severity = Severity.Medium;
+        }
 
         return new RemediationSummary(
             softwareName,

--- a/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
+++ b/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
@@ -35,16 +35,15 @@ public class RiskScoreService(
     );
 
     public record SoftwareRiskResult(
-        Guid TenantSoftwareId,
-        Guid? SnapshotId,
+        Guid SoftwareProductId,
         decimal OverallScore,
-        decimal MaxEpisodeRiskScore,
-        int CriticalEpisodeCount,
-        int HighEpisodeCount,
-        int MediumEpisodeCount,
-        int LowEpisodeCount,
+        decimal MaxExposureScore,
+        int CriticalExposureCount,
+        int HighExposureCount,
+        int MediumExposureCount,
+        int LowExposureCount,
         int AffectedDeviceCount,
-        int OpenEpisodeCount,
+        int OpenExposureCount,
         string FactorsJson
     );
 
@@ -88,9 +87,9 @@ public class RiskScoreService(
         var existingDeviceGroupScores = await dbContext.DeviceGroupRiskScores
             .Where(item => item.TenantId == tenantId)
             .ToDictionaryAsync(item => item.GroupKey, ct);
-        var existingSoftwareScores = await dbContext.TenantSoftwareRiskScores
+        var existingSoftwareScores = await dbContext.SoftwareRiskScores
             .Where(item => item.TenantId == tenantId)
-            .ToDictionaryAsync(item => item.TenantSoftwareId, ct);
+            .ToDictionaryAsync(item => item.SoftwareProductId, ct);
         var existingTeamScores = await dbContext.TeamRiskScores
             .Where(item => item.TenantId == tenantId)
             .ToDictionaryAsync(item => item.TeamId, ct);
@@ -193,37 +192,35 @@ public class RiskScoreService(
 
         foreach (var result in softwareResults)
         {
-            if (existingSoftwareScores.TryGetValue(result.TenantSoftwareId, out var existing))
+            if (existingSoftwareScores.TryGetValue(result.SoftwareProductId, out var existing))
             {
                 existing.Update(
-                    result.SnapshotId,
                     result.OverallScore,
-                    result.MaxEpisodeRiskScore,
-                    result.CriticalEpisodeCount,
-                    result.HighEpisodeCount,
-                    result.MediumEpisodeCount,
-                    result.LowEpisodeCount,
+                    result.MaxExposureScore,
+                    result.CriticalExposureCount,
+                    result.HighExposureCount,
+                    result.MediumExposureCount,
+                    result.LowExposureCount,
                     result.AffectedDeviceCount,
-                    result.OpenEpisodeCount,
+                    result.OpenExposureCount,
                     result.FactorsJson,
                     CalculationVersion
                 );
             }
             else
             {
-                dbContext.TenantSoftwareRiskScores.Add(
-                    TenantSoftwareRiskScore.Create(
+                dbContext.SoftwareRiskScores.Add(
+                    SoftwareRiskScore.Create(
                         tenantId,
-                        result.TenantSoftwareId,
-                        result.SnapshotId,
+                        result.SoftwareProductId,
                         result.OverallScore,
-                        result.MaxEpisodeRiskScore,
-                        result.CriticalEpisodeCount,
-                        result.HighEpisodeCount,
-                        result.MediumEpisodeCount,
-                        result.LowEpisodeCount,
+                        result.MaxExposureScore,
+                        result.CriticalExposureCount,
+                        result.HighExposureCount,
+                        result.MediumExposureCount,
+                        result.LowExposureCount,
                         result.AffectedDeviceCount,
-                        result.OpenEpisodeCount,
+                        result.OpenExposureCount,
                         result.FactorsJson,
                         CalculationVersion
                     )
@@ -231,13 +228,13 @@ public class RiskScoreService(
             }
         }
 
-        var activeTenantSoftwareIds = softwareResults.Select(item => item.TenantSoftwareId).ToHashSet();
+        var activeSoftwareProductIds = softwareResults.Select(item => item.SoftwareProductId).ToHashSet();
         var staleSoftwareScores = existingSoftwareScores.Values
-            .Where(item => !activeTenantSoftwareIds.Contains(item.TenantSoftwareId))
+            .Where(item => !activeSoftwareProductIds.Contains(item.SoftwareProductId))
             .ToList();
         if (staleSoftwareScores.Count > 0)
         {
-            dbContext.TenantSoftwareRiskScores.RemoveRange(staleSoftwareScores);
+            dbContext.SoftwareRiskScores.RemoveRange(staleSoftwareScores);
         }
 
         foreach (var result in teamResults)
@@ -509,31 +506,70 @@ public class RiskScoreService(
             {
                 item.Id,
                 item.DeviceId,
-                item.SoftwareProductId,
-                item.VulnerabilityId,
+                SoftwareProductId = item.SoftwareProductId!.Value,
+                item.Status,
                 Score = dbContext.ExposureAssessments
-                    .Where(assessment => assessment.DeviceVulnerabilityExposureId == item.Id)
-                    .Select(assessment => (decimal?)assessment.EnvironmentalCvss)
-                    .FirstOrDefault(),
-                Severity = dbContext.ExposureAssessments
-                    .Where(assessment => assessment.DeviceVulnerabilityExposureId == item.Id)
-                    .Select(assessment => assessment.EnvironmentalCvss >= 9.0m
-                        ? Core.Enums.Severity.Critical
-                        : assessment.EnvironmentalCvss >= 7.0m
-                            ? Core.Enums.Severity.High
-                            : assessment.EnvironmentalCvss >= 4.0m
-                                ? Core.Enums.Severity.Medium
-                                : Core.Enums.Severity.Low)
+                    .Where(a => a.DeviceVulnerabilityExposureId == item.Id)
+                    .Select(a => (decimal?)a.EnvironmentalCvss)
                     .FirstOrDefault(),
             })
             .ToListAsync(ct);
 
-        // Phase 3 note: DeviceVulnerabilityExposure is now available, but TenantSoftware
-        // still lacks a canonical direct link back to SoftwareProduct. Until that model link
-        // lands, software rollups remain disabled to avoid assigning exposures to the wrong
-        // tenant-software row.
-        _ = exposures;
-        return [];
+        return exposures
+            .GroupBy(item => item.SoftwareProductId)
+            .Select(group =>
+            {
+                var openExposures = group.Where(e => e.Status == Core.Enums.ExposureStatus.Open).ToList();
+                var scores = openExposures
+                    .Select(e => e.Score ?? 0m)
+                    .OrderByDescending(s => s)
+                    .ToList();
+                var maxScore = scores.FirstOrDefault();
+                var topThreeAvg = scores.Take(3).DefaultIfEmpty(0m).Average();
+                var criticalCount = openExposures.Count(e => (e.Score ?? 0m) >= 9.0m);
+                var highCount = openExposures.Count(e => (e.Score ?? 0m) >= 7.0m && (e.Score ?? 0m) < 9.0m);
+                var mediumCount = openExposures.Count(e => (e.Score ?? 0m) >= 4.0m && (e.Score ?? 0m) < 7.0m);
+                var lowCount = openExposures.Count(e => (e.Score ?? 0m) > 0m && (e.Score ?? 0m) < 4.0m);
+                var affectedDeviceCount = openExposures.Select(e => e.DeviceId).Distinct().Count();
+
+                var overallScore = Math.Clamp(
+                    Math.Round(
+                        (0.7m * maxScore)
+                        + (0.2m * topThreeAvg)
+                        + Math.Min(criticalCount * 35m, 120m)
+                        + Math.Min(highCount * 15m, 60m)
+                        + Math.Min(mediumCount * 5m, 20m)
+                        + Math.Min(lowCount * 1m, 5m),
+                        2),
+                    0m,
+                    1000m);
+
+                var factorsJson = JsonSerializer.Serialize(new List<RiskFactor>
+                {
+                    new("MaxExposureScore", "Highest open exposure score for this software product.", maxScore),
+                    new("TopThreeAverage", "Average of the top three open exposure scores.", Math.Round(topThreeAvg, 2)),
+                    new("CriticalExposures", $"{criticalCount} critical-risk open exposures.", Math.Min(criticalCount * 35m, 120m)),
+                    new("HighExposures", $"{highCount} high-risk open exposures.", Math.Min(highCount * 15m, 60m)),
+                    new("MediumExposures", $"{mediumCount} medium-risk open exposures.", Math.Min(mediumCount * 5m, 20m)),
+                    new("LowExposures", $"{lowCount} low-risk open exposures.", Math.Min(lowCount * 1m, 5m)),
+                });
+
+                return new SoftwareRiskResult(
+                    group.Key,
+                    overallScore,
+                    maxScore,
+                    criticalCount,
+                    highCount,
+                    mediumCount,
+                    lowCount,
+                    affectedDeviceCount,
+                    openExposures.Count,
+                    factorsJson
+                );
+            })
+            .Where(r => r.OpenExposureCount > 0)
+            .OrderByDescending(r => r.OverallScore)
+            .ToList();
     }
 
     private async Task<List<DeviceGroupRiskResult>> CalculateDeviceGroupScoresAsync(

--- a/src/PatchHound.Infrastructure/Services/SoftwareDescriptionGenerationService.cs
+++ b/src/PatchHound.Infrastructure/Services/SoftwareDescriptionGenerationService.cs
@@ -91,8 +91,10 @@ public class SoftwareDescriptionGenerationService
             .Cast<string>()
             .ToListAsync(ct);
 
-        // Phase 4 debt (#17): NormalizedSoftwareVulnerabilityProjection removed by canonical cleanup; remediation-surface rewrite restores this.
-        var activeVulnerabilityCount = 0;
+        // Phase 4 debt (#17): restored — count open exposures from canonical DeviceVulnerabilityExposures
+        var activeVulnerabilityCount = await _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+            .CountAsync(e => e.TenantId == tenantId && e.SoftwareProductId == softwareProductId
+                && e.Status == ExposureStatus.Open, ct);
 
         var resolvedProfileResult = tenantAiProfileId.HasValue
             ? await _configurationResolver.ResolveByIdAsync(tenantId, tenantAiProfileId.Value, ct)

--- a/tests/PatchHound.Tests/Api/DashboardQueryServiceCanonicalTests.cs
+++ b/tests/PatchHound.Tests/Api/DashboardQueryServiceCanonicalTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using NSubstitute;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Api;
+
+/// <summary>
+/// Phase-5 canonical tests for <see cref="DashboardQueryService"/>.
+/// Covers: recurrence detection from ExposureEpisodes.EpisodeNumber &gt; 1,
+/// risk-change-brief appeared/resolved windowing, and RemediationCaseId wiring.
+/// </summary>
+public class DashboardQueryServiceCanonicalTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public DashboardQueryServiceCanonicalTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    private DashboardQueryService CreateSut() =>
+        new(_db, Substitute.For<IRiskChangeBriefAiSummaryService>());
+
+    // ── Test 1 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetRecurrenceDataAsync_SingleEpisode_NotCountedAsRecurring()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Episode 1 = first occurrence, should NOT be recurring
+        var episode = ExposureEpisode.Open(_tenantId, seed.ExposureA.Id, 1, DateTimeOffset.UtcNow);
+        _db.ExposureEpisodes.Add(episode);
+        await _db.SaveChangesAsync();
+
+        var svc = CreateSut();
+        var result = await svc.GetRecurrenceDataAsync(_tenantId, CancellationToken.None);
+
+        result.RecurringVulnerabilityCount.Should().Be(0);
+        result.RecurrenceRatePercent.Should().Be(0m);
+        result.TopRecurringVulnerabilities.Should().BeEmpty();
+    }
+
+    // ── Test 2 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetRecurrenceDataAsync_EpisodeNumberGreaterThanOne_CountedAsRecurring()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Episode 2 = reappearance, should count as recurring
+        var episode = ExposureEpisode.Open(_tenantId, seed.ExposureA.Id, 2, DateTimeOffset.UtcNow);
+        _db.ExposureEpisodes.Add(episode);
+        await _db.SaveChangesAsync();
+
+        var svc = CreateSut();
+        var result = await svc.GetRecurrenceDataAsync(_tenantId, CancellationToken.None);
+
+        result.RecurringVulnerabilityCount.Should().Be(1);
+        result.TopRecurringVulnerabilities.Should().HaveCount(1);
+        result.TopRecurringAssets.Should().HaveCount(1);
+        result.TopRecurringAssets[0].AssetId.Should().Be(seed.DeviceA.Id);
+    }
+
+    // ── Test 3 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task BuildRiskChangeBriefAsync_AppearedExposureWithinCutoff_IsInBrief()
+    {
+        // ExposureA was seeded with FirstObservedAt = UtcNow, within 24h window
+        await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        var svc = CreateSut();
+        var result = await svc.BuildRiskChangeBriefAsync(
+            _tenantId, _tenantId, limit: null, highCriticalOnly: false,
+            CancellationToken.None, cutoffHours: 24);
+
+        result.AppearedCount.Should().BeGreaterThan(0);
+        result.Appeared.Should().NotBeEmpty();
+    }
+
+    // ── Test 4 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task BuildRiskChangeBriefAsync_ResolvedEpisodeWithinCutoff_IsInBrief()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        var episode = ExposureEpisode.Open(_tenantId, seed.ExposureA.Id, 1, DateTimeOffset.UtcNow.AddHours(-1));
+        episode.Close(DateTimeOffset.UtcNow);
+        _db.ExposureEpisodes.Add(episode);
+        await _db.SaveChangesAsync();
+
+        var svc = CreateSut();
+        var result = await svc.BuildRiskChangeBriefAsync(
+            _tenantId, _tenantId, limit: null, highCriticalOnly: false,
+            CancellationToken.None, cutoffHours: 24);
+
+        result.ResolvedCount.Should().BeGreaterThan(0);
+        result.Resolved.Should().NotBeEmpty();
+    }
+
+    // ── Test 5 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task BuildRiskChangeBriefAsync_ExposureOutsideCutoff_NotInBrief()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Backdate the first-observed to 48 hours ago (outside 24h window)
+        // We can't set private properties directly — instead use a very short cutoff window
+        var svc = CreateSut();
+        var result = await svc.BuildRiskChangeBriefAsync(
+            _tenantId, _tenantId, limit: null, highCriticalOnly: false,
+            CancellationToken.None, cutoffHours: 0); // 0-hour window: nothing qualifies
+
+        result.AppearedCount.Should().Be(0);
+        result.Appeared.Should().BeEmpty();
+    }
+
+    // ── Test 6 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task BuildRiskChangeBriefAsync_AppearedItem_CarriesRemediationCaseId()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Create a RemediationCase for ProductA
+        var remCase = RemediationCase.Create(_tenantId, seed.ProductA.Id);
+        _db.RemediationCases.Add(remCase);
+        await _db.SaveChangesAsync();
+
+        var svc = CreateSut();
+        var result = await svc.BuildRiskChangeBriefAsync(
+            _tenantId, _tenantId, limit: null, highCriticalOnly: false,
+            CancellationToken.None, cutoffHours: 24);
+
+        // ExposureA is linked to ProductA — its appeared item should carry the case id
+        var itemForProductA = result.Appeared.FirstOrDefault(item =>
+            item.RemediationCaseId == remCase.Id);
+        itemForProductA.Should().NotBeNull("the appeared item for ProductA should carry the remediation case id");
+    }
+
+    // ── Test 7 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task BuildRiskChangeBriefAsync_NoRemediationCase_RemediationCaseIdIsNull()
+    {
+        // Seed without creating any RemediationCase
+        await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        var svc = CreateSut();
+        var result = await svc.BuildRiskChangeBriefAsync(
+            _tenantId, _tenantId, limit: null, highCriticalOnly: false,
+            CancellationToken.None, cutoffHours: 24);
+
+        result.Appeared.Should().AllSatisfy(item =>
+            item.RemediationCaseId.Should().BeNull());
+    }
+}

--- a/tests/PatchHound.Tests/Api/TenantIsolationEndToEndTests.cs
+++ b/tests/PatchHound.Tests/Api/TenantIsolationEndToEndTests.cs
@@ -273,6 +273,129 @@ public class TenantIsolationEndToEndTests : IDisposable
         assessments.Should().HaveCount(1);
     }
 
+    // Phase 5 Task 8: tenant isolation for canonical Phase-5 entities:
+    // SoftwareRiskScore, RemediationCase, and DashboardQueryService.BuildRiskChangeBriefAsync.
+
+    [Fact]
+    public async Task Phase5_software_risk_score_query_only_returns_rows_for_accessible_tenant()
+    {
+        // Seed one SoftwareRiskScore per tenant under system context.
+        UseSystemContext();
+        var scoreA = SoftwareRiskScore.Create(
+            _tenantA,
+            Guid.NewGuid(),
+            overallScore: 600m,
+            maxExposureScore: 600m,
+            criticalExposureCount: 0,
+            highExposureCount: 1,
+            mediumExposureCount: 0,
+            lowExposureCount: 0,
+            affectedDeviceCount: 1,
+            openExposureCount: 1,
+            factorsJson: "[]",
+            calculationVersion: "v1"
+        );
+        var scoreB = SoftwareRiskScore.Create(
+            _tenantB,
+            Guid.NewGuid(),
+            overallScore: 800m,
+            maxExposureScore: 800m,
+            criticalExposureCount: 1,
+            highExposureCount: 0,
+            mediumExposureCount: 0,
+            lowExposureCount: 0,
+            affectedDeviceCount: 1,
+            openExposureCount: 1,
+            factorsJson: "[]",
+            calculationVersion: "v1"
+        );
+        _dbContext.SoftwareRiskScores.AddRange(scoreA, scoreB);
+        await _dbContext.SaveChangesAsync();
+
+        // Tenant A should only see its own score.
+        UseTenant(_tenantA);
+        var scores = await _dbContext.SoftwareRiskScores.AsNoTracking().ToListAsync();
+
+        scores.Should().OnlyContain(s => s.TenantId == _tenantA);
+        scores.Should().ContainSingle(s => s.Id == scoreA.Id);
+    }
+
+    [Fact]
+    public async Task Phase5_remediation_case_query_only_returns_rows_for_accessible_tenant()
+    {
+        // Seed one RemediationCase per tenant under system context.
+        UseSystemContext();
+        var caseA = RemediationCase.Create(_tenantA, Guid.NewGuid());
+        var caseB = RemediationCase.Create(_tenantB, Guid.NewGuid());
+        _dbContext.RemediationCases.AddRange(caseA, caseB);
+        await _dbContext.SaveChangesAsync();
+
+        // Tenant B should only see its own case.
+        UseTenant(_tenantB);
+        var cases = await _dbContext.RemediationCases.AsNoTracking().ToListAsync();
+
+        cases.Should().OnlyContain(c => c.TenantId == _tenantB);
+        cases.Should().ContainSingle(c => c.Id == caseB.Id);
+    }
+
+    [Fact]
+    public async Task Phase5_dashboard_risk_change_brief_scoped_to_tenant()
+    {
+        // Seed a distinct vulnerability for tenantB (within the cutoff window) under system context.
+        // Then call BuildRiskChangeBriefAsync scoped to tenantA and assert
+        // that tenantB's vulnerability does not appear in the results.
+        UseSystemContext();
+
+        var vulnB = Vulnerability.Create(
+            "nvd",
+            "CVE-2026-PHASE5-TENANTB",
+            "TenantB-Only Vuln",
+            "desc",
+            Severity.Critical,
+            9.8m,
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            DateTimeOffset.UtcNow
+        );
+        _dbContext.Vulnerabilities.Add(vulnB);
+        await _dbContext.SaveChangesAsync();
+
+        // Retrieve the tenantB device seeded in the constructor for the DVE.
+        var deviceB = await _dbContext.Devices.AsNoTracking()
+            .FirstAsync(d => d.TenantId == _tenantB);
+
+        var dveB = DeviceVulnerabilityExposure.Observe(
+            _tenantB,
+            deviceB.Id,
+            vulnB.Id,
+            softwareProductId: null,
+            installedSoftwareId: null,
+            matchedVersion: string.Empty,
+            matchSource: ExposureMatchSource.Product,
+            observedAt: DateTimeOffset.UtcNow
+        );
+        _dbContext.DeviceVulnerabilityExposures.Add(dveB);
+        await _dbContext.SaveChangesAsync();
+
+        // Call the service scoped to tenantA — tenantB's vulnerability must not appear.
+        UseTenant(_tenantA);
+        var sut = new global::PatchHound.Api.Services.DashboardQueryService(
+            _dbContext,
+            NSubstitute.Substitute.For<global::PatchHound.Core.Interfaces.IRiskChangeBriefAiSummaryService>()
+        );
+        var brief = await sut.BuildRiskChangeBriefAsync(
+            tenantId: _tenantA,
+            currentTenantId: _tenantA,
+            limit: null,
+            highCriticalOnly: false,
+            ct: CancellationToken.None,
+            cutoffHours: 72
+        );
+
+        brief.Appeared.Should().NotContain(i => i.ExternalId == "CVE-2026-PHASE5-TENANTB",
+            "tenantB exposures must not bleed into tenantA's risk change brief");
+        brief.Resolved.Should().NotContain(i => i.ExternalId == "CVE-2026-PHASE5-TENANTB");
+    }
+
     private void UseSystemContext()
     {
         _tenantContext.IsSystemContext.Returns(true);

--- a/tests/PatchHound.Tests/Api/VulnerabilitiesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/VulnerabilitiesControllerTests.cs
@@ -289,6 +289,69 @@ public class VulnerabilitiesControllerTests : IDisposable
         action.Result.Should().BeOfType<OkObjectResult>();
     }
 
+    // ── Organizational severity tests ────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateOrganizationalSeverity_CreatesRecord_WhenNoneExists()
+    {
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-0500", "Sev-adjust vuln", "desc",
+            Severity.Critical, 9.0m, null, DateTimeOffset.UtcNow);
+        _dbContext.Vulnerabilities.Add(vuln);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new UpdateOrgSeverityRequest("High", "Mitigated by WAF", null, null, null);
+        var result = await _controller.UpdateOrganizationalSeverity(vuln.Id, request, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        var record = _dbContext.OrganizationalSeverities
+            .Single(s => s.VulnerabilityId == vuln.Id && s.TenantId == _tenantId);
+        record.AdjustedSeverity.Should().Be(Severity.High);
+        record.Justification.Should().Be("Mitigated by WAF");
+    }
+
+    [Fact]
+    public async Task UpdateOrganizationalSeverity_UpdatesExistingRecord()
+    {
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-0501", "Sev-adjust vuln 2", "desc",
+            Severity.Critical, 9.0m, null, DateTimeOffset.UtcNow);
+        _dbContext.Vulnerabilities.Add(vuln);
+        await _dbContext.SaveChangesAsync();
+
+        // Seed existing record
+        var userId = Guid.NewGuid();
+        _dbContext.OrganizationalSeverities.Add(
+            PatchHound.Core.Entities.OrganizationalSeverity.Create(
+                vuln.Id, _tenantId, Severity.Critical, "Original", userId));
+        await _dbContext.SaveChangesAsync();
+
+        var request = new UpdateOrgSeverityRequest("Medium", "Now patched in env", null, null, "Firewall rule active");
+        var result = await _controller.UpdateOrganizationalSeverity(vuln.Id, request, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        var records = _dbContext.OrganizationalSeverities
+            .Where(s => s.VulnerabilityId == vuln.Id && s.TenantId == _tenantId)
+            .ToList();
+        records.Should().HaveCount(1, "upsert must not create a duplicate");
+        records[0].AdjustedSeverity.Should().Be(Severity.Medium);
+        records[0].Justification.Should().Be("Now patched in env");
+        records[0].CompensatingControls.Should().Be("Firewall rule active");
+    }
+
+    [Fact]
+    public async Task UpdateOrganizationalSeverity_ReturnsBadRequest_WhenNoTenant()
+    {
+        var noTenantContext = Substitute.For<ITenantContext>();
+        noTenantContext.CurrentTenantId.Returns((Guid?)null);
+        noTenantContext.CurrentUserId.Returns(Guid.NewGuid());
+        var detailQueryService = new PatchHound.Api.Services.VulnerabilityDetailQueryService(_dbContext);
+        var controllerNoTenant = new VulnerabilitiesController(_dbContext, noTenantContext, detailQueryService);
+
+        var request = new UpdateOrgSeverityRequest("High", "justification");
+        var result = await controllerNoTenant.UpdateOrganizationalSeverity(Guid.NewGuid(), request, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
     public void Dispose() => _dbContext.Dispose();
 
     private sealed class StubNvdApiClient(NvdCveResponse response) : NvdApiClient(new HttpClient())

--- a/tests/PatchHound.Tests/Infrastructure/CanonicalSeed.cs
+++ b/tests/PatchHound.Tests/Infrastructure/CanonicalSeed.cs
@@ -1,0 +1,105 @@
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Tests.Infrastructure;
+
+/// <summary>
+/// Shared fixture that seeds a minimal canonical dataset for Phase-5 service tests.
+/// Creates one tenant, two devices, two software products, two installations,
+/// two open exposures (one critical, one high), and the matching assessments.
+/// </summary>
+internal sealed class CanonicalSeed
+{
+    private static readonly Guid DefaultSourceSystemId = Guid.NewGuid();
+
+    public Guid TenantId { get; }
+    public SoftwareProduct ProductA { get; }
+    public SoftwareProduct ProductB { get; }
+    public Device DeviceA { get; }
+    public Device DeviceB { get; }
+    public InstalledSoftware InstallA { get; }
+    public InstalledSoftware InstallB { get; }
+    public DeviceVulnerabilityExposure ExposureA { get; }
+    public DeviceVulnerabilityExposure ExposureB { get; }
+    public ExposureAssessment AssessmentA { get; }
+    public ExposureAssessment AssessmentB { get; }
+
+    private CanonicalSeed(
+        Guid tenantId,
+        SoftwareProduct productA,
+        SoftwareProduct productB,
+        Device deviceA,
+        Device deviceB,
+        InstalledSoftware installA,
+        InstalledSoftware installB,
+        DeviceVulnerabilityExposure exposureA,
+        DeviceVulnerabilityExposure exposureB,
+        ExposureAssessment assessmentA,
+        ExposureAssessment assessmentB)
+    {
+        TenantId = tenantId;
+        ProductA = productA;
+        ProductB = productB;
+        DeviceA = deviceA;
+        DeviceB = deviceB;
+        InstallA = installA;
+        InstallB = installB;
+        ExposureA = exposureA;
+        ExposureB = exposureB;
+        AssessmentA = assessmentA;
+        AssessmentB = assessmentB;
+    }
+
+    /// <summary>
+    /// Builds the seed data and persists it into <paramref name="db"/>.
+    /// The db context must be a tenant-scoped context for <see cref="TenantId"/>
+    /// or a system context.
+    /// </summary>
+    public static async Task<CanonicalSeed> PlantAsync(PatchHoundDbContext db, Guid tenantId)
+    {
+        var productA = SoftwareProduct.Create("VendorA", "ProductA", null);
+        var productB = SoftwareProduct.Create("VendorB", "ProductB", null);
+        db.SoftwareProducts.AddRange(productA, productB);
+        await db.SaveChangesAsync();
+
+        var vuln1 = Vulnerability.Create("nvd", "CVE-2026-0001", "Critical vuln", "desc",
+            Severity.Critical, 9.8m, null, DateTimeOffset.UtcNow);
+        var vuln2 = Vulnerability.Create("nvd", "CVE-2026-0002", "High vuln", "desc",
+            Severity.High, 7.5m, null, DateTimeOffset.UtcNow);
+        db.Vulnerabilities.AddRange(vuln1, vuln2);
+        await db.SaveChangesAsync();
+
+        var deviceA = Device.Create(tenantId, DefaultSourceSystemId, "dev-a", "DeviceA", Criticality.High);
+        var deviceB = Device.Create(tenantId, DefaultSourceSystemId, "dev-b", "DeviceB", Criticality.Medium);
+        db.Devices.AddRange(deviceA, deviceB);
+        await db.SaveChangesAsync();
+
+        var installA = InstalledSoftware.Observe(tenantId, deviceA.Id, productA.Id, DefaultSourceSystemId, "1.0.0", DateTimeOffset.UtcNow);
+        var installB = InstalledSoftware.Observe(tenantId, deviceB.Id, productB.Id, DefaultSourceSystemId, "2.0.0", DateTimeOffset.UtcNow);
+        db.InstalledSoftware.AddRange(installA, installB);
+        await db.SaveChangesAsync();
+
+        var now = DateTimeOffset.UtcNow;
+        var exposureA = DeviceVulnerabilityExposure.Observe(tenantId, deviceA.Id, vuln1.Id,
+            productA.Id, installA.Id, "1.0.0", ExposureMatchSource.Product, now);
+        var exposureB = DeviceVulnerabilityExposure.Observe(tenantId, deviceB.Id, vuln2.Id,
+            productB.Id, installB.Id, "2.0.0", ExposureMatchSource.Product, now);
+        db.DeviceVulnerabilityExposures.AddRange(exposureA, exposureB);
+        await db.SaveChangesAsync();
+
+        var assessmentA = ExposureAssessment.Create(tenantId, exposureA.Id, null,
+            baseCvss: 9.8m, environmentalCvss: 9.5m, "Critical exposure", now);
+        var assessmentB = ExposureAssessment.Create(tenantId, exposureB.Id, null,
+            baseCvss: 7.5m, environmentalCvss: 7.0m, "High exposure", now);
+        db.ExposureAssessments.AddRange(assessmentA, assessmentB);
+        await db.SaveChangesAsync();
+
+        return new CanonicalSeed(
+            tenantId, productA, productB,
+            deviceA, deviceB,
+            installA, installB,
+            exposureA, exposureB,
+            assessmentA, assessmentB);
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceCanonicalTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceCanonicalTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+/// <summary>
+/// Phase-5 canonical tests for <see cref="RiskScoreService"/>.
+/// Covers: device scores driven by EnvironmentalCvss, software scores keyed by SoftwareProductId,
+/// and resolved exposures being excluded from software rollups.
+/// </summary>
+public class RiskScoreServiceCanonicalTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public RiskScoreServiceCanonicalTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    // ── Test 1 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task RecalculateForTenantAsync_DeviceScore_DrivenByEnvironmentalCvss()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+        var svc = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+
+        await svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        // AssessmentA has environmentalCvss = 9.5 (Critical), AssessmentB = 7.0 (High)
+        var scoreA = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id);
+        var scoreB = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceB.Id);
+
+        scoreA.OverallScore.Should().BeGreaterThan(0m);
+        scoreA.CriticalCount.Should().Be(1);
+        scoreA.HighCount.Should().Be(0);
+
+        scoreB.OverallScore.Should().BeGreaterThan(0m);
+        scoreB.CriticalCount.Should().Be(0);
+        scoreB.HighCount.Should().Be(1);
+    }
+
+    // ── Test 2 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task RecalculateForTenantAsync_SoftwareScore_KeyedBySoftwareProductId()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+        var svc = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+
+        await svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var scores = _db.SoftwareRiskScores.ToList();
+        scores.Should().HaveCount(2);
+        scores.Should().ContainSingle(s => s.SoftwareProductId == seed.ProductA.Id);
+        scores.Should().ContainSingle(s => s.SoftwareProductId == seed.ProductB.Id);
+
+        var scoreA = scores.Single(s => s.SoftwareProductId == seed.ProductA.Id);
+        scoreA.AffectedDeviceCount.Should().Be(1);
+        scoreA.CriticalExposureCount.Should().Be(1);
+        scoreA.OverallScore.Should().BeGreaterThan(0m);
+    }
+
+    // ── Test 3 ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task RecalculateForTenantAsync_ResolvedExposure_ExcludedFromSoftwareScore()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Resolve ExposureA so it should NOT count toward ProductA's score
+        seed.ExposureA.Resolve(DateTimeOffset.UtcNow);
+        await _db.SaveChangesAsync();
+
+        var svc = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var scores = _db.SoftwareRiskScores.ToList();
+        // ProductA has only the now-resolved exposure; it should have 0 open exposures
+        // (or no score row at all, depending on implementation)
+        var scoreA = scores.SingleOrDefault(s => s.SoftwareProductId == seed.ProductA.Id);
+        if (scoreA is not null)
+        {
+            scoreA.OpenExposureCount.Should().Be(0);
+            scoreA.CriticalExposureCount.Should().Be(0);
+        }
+
+        // ProductB still has an open exposure
+        var scoreB = scores.Single(s => s.SoftwareProductId == seed.ProductB.Id);
+        scoreB.OpenExposureCount.Should().BeGreaterThan(0);
+    }
+}


### PR DESCRIPTION
## Summary
- Rewrite \`RiskScoreService\` to compute \`DeviceRiskScore\`, \`SoftwareRiskScore(TenantId, SoftwareProductId)\`, \`TeamRiskScore\`, \`DeviceGroupRiskScore\`, \`TenantRiskScoreSnapshot\` from canonical \`DeviceVulnerabilityExposure\` + \`ExposureAssessment\`.
- Rewrite \`DashboardController\` inline queries against canonical \`DeviceVulnerabilityExposures\`, \`ExposureAssessments\`, \`RemediationCases\`, \`PatchingTasks\`, and \`Devices\`.
- Rewrite \`RiskScoreController\` (\`GetSummary\`, \`GetDeviceGroupDetail\`, \`GetSoftwareDetail\`) to read from \`DeviceRiskScores\`/\`SoftwareRiskScores\`/\`Devices\`/\`InstalledSoftware\`; rename software detail route from \`software/{tenantSoftwareId}\` to \`software/{softwareProductId}\`.
- Rewrite \`EmailNotificationService.BuildRemediationSummaryAsync\` stubs with real queries against \`RemediationCase\` → \`SoftwareProduct\` and \`DeviceVulnerabilityExposures\`.
- Frontend: rename \`SoftwareRiskDetailDialog\` prop \`tenantSoftwareId\` → \`softwareProductId\`; update \`SoftwareTable\` to pass \`row.original.softwareProductId\`; update \`risk-score.schemas.ts\` and \`risk-score.functions.ts\` to match.
- Add \`SoftwareRiskScore\` entity, EF configuration, \`DbSet\`, and \`CanonicalSeed\` test fixture; add 3 \`RiskScoreServiceCanonicalTests\` (all green).
- Remove dead \`activeSnapshotId\` call in \`DashboardController.GetSummary\`.

## Gap commits (closes gaps identified post-review)

| Commit | Task | Description |
|--------|------|-------------|
| \`17dd083\` | G1 | \`feat(phase-5): add Phase5SoftwareRiskScore migration\` — FK Restrict, unique index (TenantId, SoftwareProductId) |
| \`fedbc95\` | G3 | \`refactor(phase-5): rewrite DashboardQueryService against canonical rows\` — RemediationCaseId? wired |
| \`6e40ed1\` | G4 | \`test(phase-5): add DashboardQueryServiceCanonicalTests\` — 7 tests covering recurrence, windowing, case-id wiring |
| \`c075bd3\` | G5 | \`feat(phase-5): restore vulnerability organizational-severity endpoint\` — Update mutator added, upsert impl, 3 tests |
| \`1eeeba3\` | G6 | \`feat(phase-5): rewire SoftwareDescriptionGenerationService against canonical exposures\` |
| \`1d154ca\` | G7 | \`refactor(phase-5): rewire ApprovalTaskQueryService against canonical exposures\` — all 7 stubs replaced |
| \`393d90b\` | G8 | \`test(phase-5): tenant-isolation coverage for canonical read paths\` — 3 new Phase 5 cases in TenantIsolationEndToEndTests |

## Test plan
- \`dotnet build\`: 0 errors, 0 warnings
- \`dotnet test\`: 573 passed, 0 failed (was 560 baseline)
- \`npm run typecheck\`: clean
- \`npm run lint\`: 0 errors (2 pre-existing warnings, unchanged)
- \`npm test -- --run\`: 22/22 passed

## Remaining Phase 4 debt (not regressed by this PR)
\`SoftwareController\` still reads \`NormalizedSoftwareInstallations\` + \`TenantSoftwareRiskScores\` for the software list endpoint — these are pre-existing Phase 4 stubs (\`SoftwareAssetId = Guid.Empty\` placeholders) and are not introduced by this PR. Tracked as Phase 6 cleanup.