### PR TITLE
fix(ingestion): link DeviceVulnerabilityExposure to SoftwareProduct and InstalledSoftware

### DIFF
--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -2115,6 +2115,28 @@ public class IngestionService
             .Select(d => new { d.ExternalId, d.Id })
             .ToDictionaryAsync(d => d.ExternalId, d => d.Id, ct);
 
+        // ── Step 2b: Build a (DeviceId, CanonicalProductKey) → InstalledSoftware lookup ──
+        // Used below to populate SoftwareProductId/InstalledSoftwareId on new exposures.
+        var deviceIds = deviceIdByExternalId.Values.ToList();
+        var installedSoftwareLookup = await _dbContext.InstalledSoftware
+            .Where(i => i.TenantId == tenantId && deviceIds.Contains(i.DeviceId))
+            .Select(i => new
+            {
+                i.DeviceId,
+                i.SoftwareProductId,
+                i.Id,
+                ProductKey = _dbContext.SoftwareProducts
+                    .Where(p => p.Id == i.SoftwareProductId)
+                    .Select(p => p.CanonicalProductKey)
+                    .FirstOrDefault()
+            })
+            .ToListAsync(ct);
+        var installedByDeviceAndProduct = installedSoftwareLookup
+            .Where(i => i.ProductKey != null)
+            .ToDictionary(
+                i => (i.DeviceId, i.ProductKey!),
+                i => (i.SoftwareProductId, i.Id));
+
         // ── Step 3: Load existing DeviceVulnerabilityExposures for this tenant (for upsert) ──
         var existing = await _dbContext.DeviceVulnerabilityExposures
             .Where(e => e.TenantId == tenantId)
@@ -2178,12 +2200,37 @@ public class IngestionService
                 }
                 else
                 {
+                    // Attempt to resolve the software product for this exposure from the staged payload.
+                    Guid? softwareProductId = null;
+                    Guid? installedSoftwareId = null;
+                    IngestionAffectedAsset? affectedAssetPayload = null;
+                    if (!string.IsNullOrWhiteSpace(exposure.PayloadJson))
+                    {
+                        try
+                        {
+                            affectedAssetPayload = JsonSerializer.Deserialize<IngestionAffectedAsset>(
+                                exposure.PayloadJson, StagingSerializerOptions.Instance);
+                        }
+                        catch (JsonException) { /* best-effort */ }
+                    }
+
+                    if (affectedAssetPayload is { ProductVendor: not null, ProductName: not null })
+                    {
+                        var canonicalKey =
+                            $"{affectedAssetPayload.ProductVendor.Trim().ToLowerInvariant()}::{affectedAssetPayload.ProductName.Trim().ToLowerInvariant()}";
+                        if (installedByDeviceAndProduct.TryGetValue((deviceId, canonicalKey), out var swInfo))
+                        {
+                            softwareProductId = swInfo.SoftwareProductId;
+                            installedSoftwareId = swInfo.Id;
+                        }
+                    }
+
                     var fresh = DeviceVulnerabilityExposure.Observe(
                         tenantId,
                         deviceId,
                         vulnerabilityId,
-                        softwareProductId: null,
-                        installedSoftwareId: null,
+                        softwareProductId: softwareProductId,
+                        installedSoftwareId: installedSoftwareId,
                         matchedVersion: string.Empty,
                         ExposureMatchSource.Product,
                         now);

--- a/src/PatchHound.Infrastructure/Services/Inventory/SoftwareProductResolver.cs
+++ b/src/PatchHound.Infrastructure/Services/Inventory/SoftwareProductResolver.cs
@@ -24,7 +24,8 @@ public class SoftwareProductResolver(PatchHoundDbContext db) : ISoftwareProductR
         var product = await db.SoftwareProducts.FirstOrDefaultAsync(p => p.CanonicalProductKey == canonicalKey, ct);
         if (product is null)
         {
-            product = SoftwareProduct.Create(observation.Vendor, observation.Name, primaryCpe23Uri: null);
+            var derivedCpe = DeriveCpe(observation.Vendor, observation.Name);
+            product = SoftwareProduct.Create(observation.Vendor, observation.Name, primaryCpe23Uri: derivedCpe);
             db.SoftwareProducts.Add(product);
         }
 
@@ -37,5 +38,19 @@ public class SoftwareProductResolver(PatchHoundDbContext db) : ISoftwareProductR
         db.SoftwareAliases.Add(newAlias);
         await db.SaveChangesAsync(ct);
         return product;
+    }
+
+    /// <summary>
+    /// Derives a CPE 2.3 URI from vendor and product name using the same normalisation
+    /// as <c>DefenderVulnerabilitySource.BuildCpeCriteria</c>. This lets
+    /// <see cref="ExposureDerivationService"/> match CPE-keyed
+    /// <c>VulnerabilityApplicability</c> rows against installed software products
+    /// even when <c>SoftwareProductId</c> is not yet set on those rows.
+    /// </summary>
+    internal static string DeriveCpe(string vendor, string name)
+    {
+        var v = string.IsNullOrWhiteSpace(vendor) ? "*" : vendor.Trim().ToLowerInvariant();
+        var n = string.IsNullOrWhiteSpace(name) ? "*" : name.Trim().ToLowerInvariant();
+        return $"cpe:2.3:a:{v}:{n}:*:*:*:*:*:*:*:*";
     }
 }

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -5,6 +6,7 @@ using NSubstitute;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Tests.TestData;
@@ -64,6 +66,156 @@ public class IngestionServicePhase3Tests
         (await db.ExposureEpisodes.ToListAsync()).Should().NotBeEmpty();
         (await db.ExposureAssessments.ToListAsync()).Should().NotBeEmpty();
     }
+
+    /// <summary>
+    /// Verifies that when a <see cref="StagedVulnerabilityExposure"/> carries
+    /// ProductVendor/ProductName in its payload and a matching <see cref="InstalledSoftware"/>
+    /// row exists for the device, <see cref="ProcessStagedResultsAsync"/> populates
+    /// <c>SoftwareProductId</c> and <c>InstalledSoftwareId</c> on the resulting
+    /// <see cref="DeviceVulnerabilityExposure"/> instead of leaving them null.
+    /// </summary>
+    [Fact]
+    public async Task ProcessStagedResultsAsync_links_exposure_to_software_product_when_installed_software_exists()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = await CreateTenantDbAsync(tenantId);
+
+        // Seed canonical entities
+        var product = SoftwareProduct.Create("Microsoft", "Edge", "cpe:2.3:a:microsoft:edge:*:*:*:*:*:*:*:*");
+        db.SoftwareProducts.Add(product);
+
+        var vuln = Vulnerability.Create(
+            "microsoft-defender", "CVE-2026-LINK", "Edge vuln", "desc",
+            Severity.High, 7.5m, null, DateTimeOffset.UtcNow);
+        db.Vulnerabilities.Add(vuln);
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, product.Id, null, true, null, null, null, null));
+
+        var sourceSystem = SourceSystem.Create("microsoft-defender", "Defender");
+        db.SourceSystems.Add(sourceSystem);
+
+        var device = Device.Create(tenantId, sourceSystem.Id, "machine-abc", "Machine ABC", Criticality.Medium);
+        db.Devices.Add(device);
+
+        var installed = InstalledSoftware.Observe(
+            tenantId, device.Id, product.Id, sourceSystem.Id, "120.0", DateTimeOffset.UtcNow);
+        db.InstalledSoftware.Add(installed);
+
+        var run = IngestionRun.Start(tenantId, "microsoft-defender", DateTimeOffset.UtcNow);
+        db.IngestionRuns.Add(run);
+
+        // Stage vulnerability + exposure (mimics what DefenderVulnerabilitySource produces)
+        db.StagedVulnerabilities.Add(StagedVulnerability.Create(
+            run.Id, tenantId, "microsoft-defender",
+            externalId: "CVE-2026-LINK",
+            title: "Edge vuln",
+            vendorSeverity: Severity.High,
+            payloadJson: "{}",
+            stagedAt: DateTimeOffset.UtcNow));
+
+        var affectedAssetPayload = new IngestionAffectedAsset(
+            ExternalAssetId: "machine-abc",
+            AssetName: "Machine ABC",
+            AssetType: AssetType.Device,
+            ProductVendor: "Microsoft",
+            ProductName: "Edge",
+            ProductVersion: "120.0");
+
+        db.StagedVulnerabilityExposures.Add(StagedVulnerabilityExposure.Create(
+            run.Id, tenantId, "microsoft-defender",
+            vulnerabilityExternalId: "CVE-2026-LINK",
+            assetExternalId: "machine-abc",
+            assetName: "Machine ABC",
+            assetType: AssetType.Device,
+            payloadJson: JsonSerializer.Serialize(affectedAssetPayload),
+            stagedAt: DateTimeOffset.UtcNow));
+
+        await db.SaveChangesAsync();
+
+        var ingestion = CreateIngestionService(db);
+
+        await ingestion.ProcessStagedResultsAsync(
+            run.Id, tenantId, "microsoft-defender", snapshotId: null, "Defender", CancellationToken.None);
+
+        var exposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+        exposures.Should().ContainSingle();
+        exposures[0].VulnerabilityId.Should().Be(vuln.Id);
+        exposures[0].DeviceId.Should().Be(device.Id);
+        exposures[0].SoftwareProductId.Should().Be(product.Id,
+            "the exposure must be linked to the matching SoftwareProduct");
+        exposures[0].InstalledSoftwareId.Should().Be(installed.Id,
+            "the exposure must be linked to the matching InstalledSoftware row");
+    }
+
+    /// <summary>
+    /// When no <see cref="InstalledSoftware"/> row exists for the device+product,
+    /// the exposure should still be created — just without software linkage.
+    /// </summary>
+    [Fact]
+    public async Task ProcessStagedResultsAsync_creates_exposure_without_software_link_when_no_installed_software()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = await CreateTenantDbAsync(tenantId);
+
+        var vuln = Vulnerability.Create(
+            "microsoft-defender", "CVE-2026-NOLINK", "t", "d",
+            Severity.Medium, 5.0m, null, DateTimeOffset.UtcNow);
+        db.Vulnerabilities.Add(vuln);
+
+        var sourceSystem = SourceSystem.Create("microsoft-defender", "Defender");
+        db.SourceSystems.Add(sourceSystem);
+
+        var device = Device.Create(tenantId, sourceSystem.Id, "machine-xyz", "Machine XYZ", Criticality.Low);
+        db.Devices.Add(device);
+
+        var run = IngestionRun.Start(tenantId, "microsoft-defender", DateTimeOffset.UtcNow);
+        db.IngestionRuns.Add(run);
+
+        db.StagedVulnerabilities.Add(StagedVulnerability.Create(
+            run.Id, tenantId, "microsoft-defender",
+            "CVE-2026-NOLINK", "t", Severity.Medium, "{}", DateTimeOffset.UtcNow));
+
+        var affectedAssetPayload = new IngestionAffectedAsset(
+            ExternalAssetId: "machine-xyz",
+            AssetName: "Machine XYZ",
+            AssetType: AssetType.Device,
+            ProductVendor: "Unknown",
+            ProductName: "SomeApp");
+
+        db.StagedVulnerabilityExposures.Add(StagedVulnerabilityExposure.Create(
+            run.Id, tenantId, "microsoft-defender",
+            "CVE-2026-NOLINK", "machine-xyz", "Machine XYZ",
+            AssetType.Device,
+            JsonSerializer.Serialize(affectedAssetPayload),
+            DateTimeOffset.UtcNow));
+
+        await db.SaveChangesAsync();
+
+        var ingestion = CreateIngestionService(db);
+
+        await ingestion.ProcessStagedResultsAsync(
+            run.Id, tenantId, "microsoft-defender", snapshotId: null, "Defender", CancellationToken.None);
+
+        var exposures = await db.DeviceVulnerabilityExposures.ToListAsync();
+        exposures.Should().ContainSingle();
+        exposures[0].SoftwareProductId.Should().BeNull(
+            "no InstalledSoftware exists for this device+product so linkage should be absent");
+        exposures[0].InstalledSoftwareId.Should().BeNull();
+    }
+
+    private static IngestionService CreateIngestionService(PatchHoundDbContext db) =>
+        new(
+            db,
+            Enumerable.Empty<IVulnerabilitySource>(),
+            new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance),
+            Substitute.For<IStagedDeviceMergeService>(),
+            Substitute.For<IDeviceRuleEvaluationService>(),
+            new ExposureDerivationService(db, NullLogger<ExposureDerivationService>.Instance),
+            new ExposureEpisodeService(db),
+            new ExposureAssessmentService(db, new EnvironmentalSeverityCalculator()),
+            new RiskScoreService(db, NullLogger<RiskScoreService>.Instance),
+            new VulnerabilityResolver(db),
+            NullLogger<IngestionService>.Instance);
 
     private static async Task<PatchHoundDbContext> CreateTenantDbAsync(Guid tenantId)
     {

--- a/tests/PatchHound.Tests/Infrastructure/Services/SoftwareProductResolverTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/SoftwareProductResolverTests.cs
@@ -106,4 +106,46 @@ public class SoftwareProductResolverTests : IAsyncLifetime
         allAliases.Select(a => a.ExternalId).Should().BeEquivalentTo(new[] { "sw-A", "sw-B" });
         allAliases.Should().OnlyContain(a => a.SoftwareProductId == first.Id);
     }
+
+    [Fact]
+    public async Task Resolve_derives_primary_cpe_from_vendor_and_name()
+    {
+        var observation = new SoftwareObservation(
+            SourceSystemId: _sourceSystem.Id,
+            ExternalId: "sw-003",
+            Vendor: "Microsoft",
+            Name: "Edge");
+
+        var product = await _sut.ResolveAsync(observation, CancellationToken.None);
+
+        product.PrimaryCpe23Uri.Should().Be("cpe:2.3:a:microsoft:edge:*:*:*:*:*:*:*:*");
+    }
+
+    [Fact]
+    public async Task Resolve_reuses_existing_product_cpe_unchanged_on_second_observation()
+    {
+        // First observation creates the product with a derived CPE.
+        var observation = new SoftwareObservation(
+            SourceSystemId: _sourceSystem.Id,
+            ExternalId: "sw-004",
+            Vendor: "Google",
+            Name: "Chrome");
+
+        var first = await _sut.ResolveAsync(observation, CancellationToken.None);
+        first.PrimaryCpe23Uri.Should().Be("cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*");
+
+        // Second observation should return the same product without overwriting the CPE.
+        var second = await _sut.ResolveAsync(observation, CancellationToken.None);
+        second.Id.Should().Be(first.Id);
+        second.PrimaryCpe23Uri.Should().Be("cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*");
+    }
+
+    [Theory]
+    [InlineData("Microsoft", "Edge", "cpe:2.3:a:microsoft:edge:*:*:*:*:*:*:*:*")]
+    [InlineData("mozilla", "firefox", "cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*")]
+    [InlineData("  Acme Corp  ", "  My App  ", "cpe:2.3:a:acme corp:my app:*:*:*:*:*:*:*:*")]
+    public void DeriveCpe_normalises_vendor_and_name(string vendor, string name, string expected)
+    {
+        SoftwareProductResolver.DeriveCpe(vendor, name).Should().Be(expected);
+    }
 }


### PR DESCRIPTION
## Summary

- **Bug 1 fixed**: `SoftwareProductResolver` now derives `PrimaryCpe23Uri` at product-creation time using `cpe:2.3:a:{vendor_lower}:{name_lower}:*:*:*:*:*:*:*:*` — the same format emitted by `DefenderVulnerabilitySource.BuildCpeCriteria`. This enables `ExposureDerivationService`'s CPE-equality match (previously always zero results because `PrimaryCpe23Uri` was always `null`).

- **Bug 2 fixed**: `IngestionService.ProcessStagedResultsAsync` previously hard-coded `softwareProductId: null, installedSoftwareId: null` when merging staged Defender exposures. It now builds an `InstalledSoftware` lookup keyed by `(DeviceId, CanonicalProductKey)` and resolves both IDs from the staged payload's `ProductVendor` / `ProductName`, with a graceful null fallback if no match exists.

## Tests added

- `SoftwareProductResolverTests`: `DeriveCpe` normalisation (3 theory cases), CPE set on new product, CPE unchanged on re-resolution
- `IngestionServicePhase3Tests`: exposure linked when installed software exists; exposure created with null links when no installed software (graceful fallback)

## Build & test

```
Build succeeded. 0 Warning(s), 0 Error(s)
Passed! Failed: 0, Passed: 575, Skipped: 0, Total: 575
```