### PR TITLE
fix(ingestion): dedupe InstalledSoftware lookup by (DeviceId, ProductKey)

### DIFF
--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -2133,9 +2133,10 @@ public class IngestionService
             .ToListAsync(ct);
         var installedByDeviceAndProduct = installedSoftwareLookup
             .Where(i => i.ProductKey != null)
+            .GroupBy(i => (i.DeviceId, i.ProductKey!))
             .ToDictionary(
-                i => (i.DeviceId, i.ProductKey!),
-                i => (i.SoftwareProductId, i.Id));
+                g => g.Key,
+                g => (g.First().SoftwareProductId, g.First().Id));
 
         // ── Step 3: Load existing DeviceVulnerabilityExposures for this tenant (for upsert) ──
         var existing = await _dbContext.DeviceVulnerabilityExposures

--- a/src/PatchHound.Worker/PatchHound.Worker.csproj
+++ b/src/PatchHound.Worker/PatchHound.Worker.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="4.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PatchHound.Api\PatchHound.Api.csproj">

--- a/tests/PatchHound.Tests/PatchHound.Tests.csproj
+++ b/tests/PatchHound.Tests/PatchHound.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
## Summary
- Fixes worker crash during Microsoft Defender ingestion: `ArgumentException: An item with the same key has already been added. Key: (<deviceId>, openssl::openssl)` thrown from `ProcessStagedResultsAsync`.
- Two `InstalledSoftware` rows on the same device can share a canonical product key; group before `ToDictionary` and take the first row per `(DeviceId, ProductKey)` pair.

## Test plan
- [ ] Re-run Defender ingestion for the affected tenant; ingestion run completes instead of aborting.
- [ ] Confirm DVE rows populate `SoftwareProductId` / `InstalledSoftwareId` correctly for devices with duplicate installed-software rows.