### PR TITLE
feat: replace per-CVE NVD lookups with bulk feed sync via NVD API 2.0

### DIFF
--- a/frontend/src/components/features/admin/GlobalEnrichmentSourceManagement.tsx
+++ b/frontend/src/components/features/admin/GlobalEnrichmentSourceManagement.tsx
@@ -146,9 +146,10 @@ export function GlobalEnrichmentSourceManagement({
                   <TableRow
                     key={source.key}
                     className={cn(
-                      'border-border/50',
+                      'cursor-pointer border-border/50',
                       editingSourceKey === source.key && 'bg-primary/[0.04]',
                     )}
+                    onClick={() => setEditingSourceKey(source.key)}
                   >
                     {/* Provider */}
                     <TableCell className="py-3 pl-4">
@@ -213,7 +214,10 @@ export function GlobalEnrichmentSourceManagement({
                           type="button"
                           variant="outline"
                           size="sm"
-                          onClick={() => setEditingSourceKey(source.key)}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setEditingSourceKey(source.key)
+                          }}
                         >
                           Edit
                         </Button>
@@ -221,7 +225,10 @@ export function GlobalEnrichmentSourceManagement({
                           type="button"
                           variant="ghost"
                           size="sm"
-                          onClick={() => setHistorySource({ key: source.key, displayName: source.displayName })}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setHistorySource({ key: source.key, displayName: source.displayName })
+                          }}
                         >
                           History
                         </Button>

--- a/src/PatchHound.Infrastructure/Services/NvdFeedModels.cs
+++ b/src/PatchHound.Infrastructure/Services/NvdFeedModels.cs
@@ -2,55 +2,52 @@ using System.Text.Json.Serialization;
 
 namespace PatchHound.Infrastructure.Services;
 
-internal class NvdFeedResponse
+internal class NvdApiResponse
 {
-    [JsonPropertyName("CVE_Items")]
-    public List<NvdFeedItem> Items { get; set; } = [];
+    [JsonPropertyName("resultsPerPage")]
+    public int ResultsPerPage { get; set; }
+
+    [JsonPropertyName("startIndex")]
+    public int StartIndex { get; set; }
+
+    [JsonPropertyName("totalResults")]
+    public int TotalResults { get; set; }
+
+    [JsonPropertyName("vulnerabilities")]
+    public List<NvdApiVulnerabilityItem> Vulnerabilities { get; set; } = [];
 }
 
-internal class NvdFeedItem
+internal class NvdApiVulnerabilityItem
 {
     [JsonPropertyName("cve")]
-    public NvdFeedCveSection? Cve { get; set; }
-
-    [JsonPropertyName("configurations")]
-    public NvdFeedConfigurations? Configurations { get; set; }
-
-    [JsonPropertyName("impact")]
-    public NvdFeedImpact? Impact { get; set; }
-
-    [JsonPropertyName("publishedDate")]
-    public string? PublishedDate { get; set; }
-
-    [JsonPropertyName("lastModifiedDate")]
-    public string? LastModifiedDate { get; set; }
+    public NvdApiCve? Cve { get; set; }
 }
 
-internal class NvdFeedCveSection
+internal class NvdApiCve
 {
-    [JsonPropertyName("CVE_data_meta")]
-    public NvdFeedMeta? Meta { get; set; }
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("description")]
-    public NvdFeedDescriptionWrapper? Description { get; set; }
+    [JsonPropertyName("published")]
+    public string? Published { get; set; }
+
+    [JsonPropertyName("lastModified")]
+    public string? LastModified { get; set; }
+
+    [JsonPropertyName("descriptions")]
+    public List<NvdApiDescription> Descriptions { get; set; } = [];
+
+    [JsonPropertyName("metrics")]
+    public NvdApiMetrics? Metrics { get; set; }
 
     [JsonPropertyName("references")]
-    public NvdFeedReferencesWrapper? References { get; set; }
+    public List<NvdApiReference> References { get; set; } = [];
+
+    [JsonPropertyName("configurations")]
+    public List<NvdApiConfiguration> Configurations { get; set; } = [];
 }
 
-internal class NvdFeedMeta
-{
-    [JsonPropertyName("ID")]
-    public string Id { get; set; } = string.Empty;
-}
-
-internal class NvdFeedDescriptionWrapper
-{
-    [JsonPropertyName("description_data")]
-    public List<NvdFeedDescriptionItem> Data { get; set; } = [];
-}
-
-internal class NvdFeedDescriptionItem
+internal class NvdApiDescription
 {
     [JsonPropertyName("lang")]
     public string Lang { get; set; } = string.Empty;
@@ -59,46 +56,67 @@ internal class NvdFeedDescriptionItem
     public string Value { get; set; } = string.Empty;
 }
 
-internal class NvdFeedReferencesWrapper
+internal class NvdApiMetrics
 {
-    [JsonPropertyName("reference_data")]
-    public List<NvdFeedReferenceItem> Data { get; set; } = [];
+    [JsonPropertyName("cvssMetricV31")]
+    public List<NvdApiCvssMetric> CvssMetricV31 { get; set; } = [];
+
+    [JsonPropertyName("cvssMetricV30")]
+    public List<NvdApiCvssMetric> CvssMetricV30 { get; set; } = [];
 }
 
-internal class NvdFeedReferenceItem
+internal class NvdApiCvssMetric
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("cvssData")]
+    public NvdApiCvssData? CvssData { get; set; }
+}
+
+internal class NvdApiCvssData
+{
+    [JsonPropertyName("baseScore")]
+    public decimal BaseScore { get; set; }
+
+    [JsonPropertyName("vectorString")]
+    public string? VectorString { get; set; }
+}
+
+internal class NvdApiReference
 {
     [JsonPropertyName("url")]
     public string Url { get; set; } = string.Empty;
 
-    [JsonPropertyName("refsource")]
-    public string RefSource { get; set; } = string.Empty;
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
 
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = [];
 }
 
-internal class NvdFeedConfigurations
+internal class NvdApiConfiguration
 {
     [JsonPropertyName("nodes")]
-    public List<NvdFeedNode> Nodes { get; set; } = [];
+    public List<NvdApiNode> Nodes { get; set; } = [];
 }
 
-internal class NvdFeedNode
+internal class NvdApiNode
 {
-    [JsonPropertyName("cpe_match")]
-    public List<NvdFeedCpeMatch> CpeMatch { get; set; } = [];
+    [JsonPropertyName("cpeMatch")]
+    public List<NvdApiCpeMatch> CpeMatch { get; set; } = [];
 
-    [JsonPropertyName("children")]
-    public List<NvdFeedNode> Children { get; set; } = [];
+    [JsonPropertyName("nodes")]
+    public List<NvdApiNode> Children { get; set; } = [];
 }
 
-internal class NvdFeedCpeMatch
+internal class NvdApiCpeMatch
 {
     [JsonPropertyName("vulnerable")]
     public bool Vulnerable { get; set; }
 
-    [JsonPropertyName("cpe23Uri")]
-    public string Cpe23Uri { get; set; } = string.Empty;
+    [JsonPropertyName("criteria")]
+    public string Criteria { get; set; } = string.Empty;
 
     [JsonPropertyName("versionStartIncluding")]
     public string? VersionStartIncluding { get; set; }
@@ -111,25 +129,4 @@ internal class NvdFeedCpeMatch
 
     [JsonPropertyName("versionEndExcluding")]
     public string? VersionEndExcluding { get; set; }
-}
-
-internal class NvdFeedImpact
-{
-    [JsonPropertyName("baseMetricV3")]
-    public NvdFeedBaseMetricV3? BaseMetricV3 { get; set; }
-}
-
-internal class NvdFeedBaseMetricV3
-{
-    [JsonPropertyName("cvssV3")]
-    public NvdFeedCvssV3? CvssV3 { get; set; }
-}
-
-internal class NvdFeedCvssV3
-{
-    [JsonPropertyName("baseScore")]
-    public decimal BaseScore { get; set; }
-
-    [JsonPropertyName("vectorString")]
-    public string? VectorString { get; set; }
 }

--- a/src/PatchHound.Infrastructure/Services/NvdFeedSyncService.cs
+++ b/src/PatchHound.Infrastructure/Services/NvdFeedSyncService.cs
@@ -1,76 +1,114 @@
-using System.IO.Compression;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using PatchHound.Core.Entities;
 using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Secrets;
+using PatchHound.Infrastructure.Tenants;
 
 namespace PatchHound.Infrastructure.Services;
 
 public class NvdFeedSyncService(
     HttpClient httpClient,
     PatchHoundDbContext db,
+    ISecretStore secretStore,
     ILogger<NvdFeedSyncService> logger)
 {
-    private const string FeedBaseUrl = "https://nvd.nist.gov/feeds/json/cve/1.1";
+    private const string ApiUrl = "https://services.nvd.nist.gov/rest/json/cves/2.0";
+    private const int PageSize = 2000;
+    private static readonly TimeSpan ApiKeyDelay = TimeSpan.FromMilliseconds(700);
+    private static readonly TimeSpan NoKeyDelay = TimeSpan.FromSeconds(7);
 
-    public Task SyncYearFeedAsync(int year, CancellationToken ct) =>
-        SyncFeedAsync(
-            feedName: year.ToString(),
-            feedUrl: $"{FeedBaseUrl}/nvdcve-1.1-{year}.json.gz",
-            ct);
-
-    public Task SyncModifiedFeedAsync(CancellationToken ct) =>
-        SyncFeedAsync(
-            feedName: "modified",
-            feedUrl: $"{FeedBaseUrl}/nvdcve-1.1-modified.json.gz",
-            ct);
-
-    private async Task SyncFeedAsync(string feedName, string feedUrl, CancellationToken ct)
+    public async Task SyncYearFeedAsync(int year, CancellationToken ct)
     {
-        var metaUrl = feedUrl.Replace(".json.gz", ".meta", StringComparison.OrdinalIgnoreCase);
-        var metaText = await httpClient.GetStringAsync(metaUrl, ct);
-        var feedLastModified = ParseMetaLastModified(metaText);
-
-        var checkpoint = await db.NvdFeedCheckpoints
-            .FirstOrDefaultAsync(c => c.FeedName == feedName, ct);
-
-        if (checkpoint is not null && checkpoint.FeedLastModified >= feedLastModified)
+        var feedName = year.ToString();
+        var checkpoint = await db.NvdFeedCheckpoints.FirstOrDefaultAsync(c => c.FeedName == feedName, ct);
+        if (checkpoint is not null)
         {
-            logger.LogDebug("NVD feed {FeedName} is up to date (last modified {LastModified})",
-                feedName, feedLastModified);
+            logger.LogDebug("NVD year feed {Year} already synced at {SyncedAt}, skipping.", year, checkpoint.SyncedAt);
             return;
         }
 
-        logger.LogInformation("Downloading NVD feed {FeedName} from {Url}", feedName, feedUrl);
+        var apiKey = await GetApiKeyAsync(ct);
+        logger.LogInformation("NVD: starting initial sync for year {Year}", year);
 
-        await using var responseStream = await httpClient.GetStreamAsync(feedUrl, ct);
-        await using var gz = new GZipStream(responseStream, CompressionMode.Decompress);
+        var startDate = new DateTimeOffset(year, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var endDate = new DateTimeOffset(year, 12, 31, 23, 59, 59, TimeSpan.Zero);
 
-        var feed = await JsonSerializer.DeserializeAsync<NvdFeedResponse>(gz,
-            cancellationToken: ct);
+        var count = await FetchAndUpsertAsync(
+            startIndex => $"{ApiUrl}?pubStartDate={FormatDate(startDate)}&pubEndDate={FormatDate(endDate)}&startIndex={startIndex}&resultsPerPage={PageSize}",
+            apiKey, ct);
 
-        if (feed is null)
-        {
-            logger.LogWarning("NVD feed {FeedName} returned null after deserialization", feedName);
-            return;
-        }
-
-        var upsertCount = await UpsertItemsAsync(feed.Items, ct);
-
-        if (checkpoint is null)
-            db.NvdFeedCheckpoints.Add(NvdFeedCheckpoint.Create(feedName, feedLastModified));
-        else
-            checkpoint.Update(feedLastModified);
-
+        db.NvdFeedCheckpoints.Add(NvdFeedCheckpoint.Create(feedName, DateTimeOffset.UtcNow));
         await db.SaveChangesAsync(ct);
-        logger.LogInformation("NVD feed {FeedName}: upserted {Count} CVEs", feedName, upsertCount);
+        logger.LogInformation("NVD year feed {Year}: upserted {Count} CVEs", year, count);
     }
 
-    private async Task<int> UpsertItemsAsync(List<NvdFeedItem> items, CancellationToken ct)
+    public async Task SyncModifiedFeedAsync(CancellationToken ct)
+    {
+        const string feedName = "modified";
+        var checkpoint = await db.NvdFeedCheckpoints.FirstOrDefaultAsync(c => c.FeedName == feedName, ct);
+
+        var lastModStart = checkpoint?.FeedLastModified.AddMinutes(-15)
+            ?? DateTimeOffset.UtcNow.AddHours(-2);
+        var lastModEnd = DateTimeOffset.UtcNow;
+
+        var apiKey = await GetApiKeyAsync(ct);
+
+        var count = await FetchAndUpsertAsync(
+            startIndex => $"{ApiUrl}?lastModStartDate={FormatDate(lastModStart)}&lastModEndDate={FormatDate(lastModEnd)}&startIndex={startIndex}&resultsPerPage={PageSize}",
+            apiKey, ct);
+
+        if (checkpoint is null)
+            db.NvdFeedCheckpoints.Add(NvdFeedCheckpoint.Create(feedName, lastModEnd));
+        else
+            checkpoint.Update(lastModEnd);
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("NVD modified feed: upserted {Count} CVEs (window: {Start} to {End})",
+            count, lastModStart, lastModEnd);
+    }
+
+    private async Task<int> FetchAndUpsertAsync(Func<int, string> urlBuilder, string? apiKey, CancellationToken ct)
+    {
+        var delay = apiKey is not null ? ApiKeyDelay : NoKeyDelay;
+        var totalCount = 0;
+        var startIndex = 0;
+
+        while (true)
+        {
+            var url = urlBuilder(startIndex);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (apiKey is not null)
+                request.Headers.Add("apiKey", apiKey);
+
+            var response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+
+            var page = await JsonSerializer.DeserializeAsync<NvdApiResponse>(
+                await response.Content.ReadAsStreamAsync(ct), cancellationToken: ct);
+
+            if (page is null || page.Vulnerabilities.Count == 0)
+                break;
+
+            totalCount += await UpsertItemsAsync(page.Vulnerabilities, ct);
+            await db.SaveChangesAsync(ct);
+            db.ChangeTracker.Clear();
+
+            if (startIndex + page.ResultsPerPage >= page.TotalResults)
+                break;
+
+            startIndex += page.ResultsPerPage;
+            await Task.Delay(delay, ct);
+        }
+
+        return totalCount;
+    }
+
+    private async Task<int> UpsertItemsAsync(List<NvdApiVulnerabilityItem> items, CancellationToken ct)
     {
         var cveIds = items
-            .Select(i => i.Cve?.Meta?.Id)
+            .Select(i => i.Cve?.Id)
             .Where(id => !string.IsNullOrEmpty(id))
             .Cast<string>()
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -82,93 +120,104 @@ public class NvdFeedSyncService(
         var count = 0;
         foreach (var item in items)
         {
-            var cveId = item.Cve?.Meta?.Id;
+            var cveId = item.Cve?.Id;
             if (string.IsNullOrEmpty(cveId)) continue;
 
-            var (description, cvssScore, cvssVector, publishedDate, feedLastMod,
-                refsJson, configsJson) = ExtractCveData(item);
+            var (description, cvssScore, cvssVector, publishedDate, lastMod, refsJson, configsJson) = ExtractCveData(item);
 
             if (string.IsNullOrWhiteSpace(description))
             {
-                logger.LogDebug("Skipping CVE {CveId} — no English description in feed item.", cveId);
+                logger.LogDebug("Skipping {CveId} — no English description.", cveId);
                 continue;
             }
 
             if (existing.TryGetValue(cveId, out var cached))
-                cached.Update(description, cvssScore, cvssVector, publishedDate,
-                    feedLastMod, refsJson, configsJson);
+                cached.Update(description, cvssScore, cvssVector, publishedDate, lastMod, refsJson, configsJson);
             else
                 db.NvdCveCache.Add(NvdCveCache.Create(cveId, description, cvssScore,
-                    cvssVector, publishedDate, feedLastMod, refsJson, configsJson));
-
+                    cvssVector, publishedDate, lastMod, refsJson, configsJson));
             count++;
         }
-
         return count;
     }
 
     private static (string? Description, decimal? CvssScore, string? CvssVector,
-        DateTimeOffset? PublishedDate, DateTimeOffset FeedLastModified,
-        string RefsJson, string ConfigsJson) ExtractCveData(NvdFeedItem item)
+        DateTimeOffset? PublishedDate, DateTimeOffset LastModified,
+        string RefsJson, string ConfigsJson) ExtractCveData(NvdApiVulnerabilityItem item)
     {
-        var description = item.Cve?.Description?.Data
+        var cve = item.Cve!;
+
+        var description = cve.Descriptions
             .FirstOrDefault(d => string.Equals(d.Lang, "en", StringComparison.OrdinalIgnoreCase))
             ?.Value;
 
-        var cvssV3 = item.Impact?.BaseMetricV3?.CvssV3;
-        decimal? cvssScore = cvssV3?.BaseScore;
-        string? cvssVector = cvssV3?.VectorString;
+        // Prefer CVSSv3.1 Primary, fall back to v3.0
+        var cvssMetric = cve.Metrics?.CvssMetricV31
+            .FirstOrDefault(m => string.Equals(m.Type, "Primary", StringComparison.OrdinalIgnoreCase))
+            ?? cve.Metrics?.CvssMetricV31.FirstOrDefault()
+            ?? cve.Metrics?.CvssMetricV30
+                .FirstOrDefault(m => string.Equals(m.Type, "Primary", StringComparison.OrdinalIgnoreCase))
+            ?? cve.Metrics?.CvssMetricV30.FirstOrDefault();
+
+        decimal? cvssScore = cvssMetric?.CvssData?.BaseScore;
+        string? cvssVector = cvssMetric?.CvssData?.VectorString;
 
         DateTimeOffset? publishedDate = null;
-        if (!string.IsNullOrEmpty(item.PublishedDate) &&
-            DateTimeOffset.TryParse(item.PublishedDate, out var pd))
+        if (!string.IsNullOrEmpty(cve.Published) && DateTimeOffset.TryParse(cve.Published, out var pd))
             publishedDate = pd;
 
-        var feedLastMod = DateTimeOffset.MinValue;
-        if (!string.IsNullOrEmpty(item.LastModifiedDate) &&
-            DateTimeOffset.TryParse(item.LastModifiedDate, out var lm))
-            feedLastMod = lm;
+        var lastMod = DateTimeOffset.MinValue;
+        if (!string.IsNullOrEmpty(cve.LastModified) && DateTimeOffset.TryParse(cve.LastModified, out var lm))
+            lastMod = lm;
 
-        var refs = (item.Cve?.References?.Data ?? [])
+        var refs = cve.References
             .Where(r => !string.IsNullOrWhiteSpace(r.Url))
-            .Select(r => new NvdCachedReference(r.Url, r.RefSource, r.Tags))
+            .Select(r => new NvdCachedReference(r.Url, r.Source, r.Tags))
             .ToList();
 
-        var configs = FlattenNodes(item.Configurations?.Nodes ?? [])
-            .Where(m => !string.IsNullOrWhiteSpace(m.Cpe23Uri))
-            .Select(m => new NvdCachedCpeMatch(m.Vulnerable, m.Cpe23Uri,
+        var configs = cve.Configurations
+            .SelectMany(c => FlattenNodes(c.Nodes))
+            .Where(m => !string.IsNullOrWhiteSpace(m.Criteria))
+            .Select(m => new NvdCachedCpeMatch(m.Vulnerable, m.Criteria,
                 m.VersionStartIncluding, m.VersionStartExcluding,
                 m.VersionEndIncluding, m.VersionEndExcluding))
             .ToList();
 
-        var refsJson = JsonSerializer.Serialize(refs);
-        var configsJson = JsonSerializer.Serialize(configs);
-
-        return (description, cvssScore, cvssVector, publishedDate, feedLastMod, refsJson, configsJson);
+        return (description, cvssScore, cvssVector, publishedDate, lastMod,
+            JsonSerializer.Serialize(refs), JsonSerializer.Serialize(configs));
     }
 
-    private static IEnumerable<NvdFeedCpeMatch> FlattenNodes(List<NvdFeedNode> nodes)
+    private static IEnumerable<NvdApiCpeMatch> FlattenNodes(List<NvdApiNode> nodes)
     {
         foreach (var node in nodes)
         {
-            foreach (var match in node.CpeMatch)
-                yield return match;
-            foreach (var match in FlattenNodes(node.Children))
-                yield return match;
+            foreach (var match in node.CpeMatch) yield return match;
+            foreach (var match in FlattenNodes(node.Children)) yield return match;
         }
     }
 
-    internal static DateTimeOffset ParseMetaLastModified(string metaText)
+    private async Task<string?> GetApiKeyAsync(CancellationToken ct)
     {
-        foreach (var line in metaText.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        try
         {
-            var trimmed = line.Trim();
-            if (!trimmed.StartsWith("lastModifiedDate:", StringComparison.OrdinalIgnoreCase))
-                continue;
-            var value = trimmed["lastModifiedDate:".Length..].Trim();
-            if (DateTimeOffset.TryParse(value, out var result))
-                return result.ToUniversalTime();
+            var source = await db.EnrichmentSourceConfigurations
+                .FirstOrDefaultAsync(s => s.SourceKey == EnrichmentSourceCatalog.NvdSourceKey, ct);
+
+            if (source is null || string.IsNullOrWhiteSpace(source.SecretRef))
+            {
+                logger.LogDebug("NVD source has no SecretRef configured; proceeding without API key.");
+                return null;
+            }
+
+            return await secretStore.GetSecretAsync(source.SecretRef, "apiKey", ct);
         }
-        return DateTimeOffset.MinValue;
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not resolve NVD API key; proceeding without key (rate limits apply).");
+            return null;
+        }
     }
+
+    private static string FormatDate(DateTimeOffset date) =>
+        date.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff");
 }

--- a/src/PatchHound.Infrastructure/Services/NvdFeedSyncService.cs
+++ b/src/PatchHound.Infrastructure/Services/NvdFeedSyncService.cs
@@ -50,7 +50,7 @@ public class NvdFeedSyncService(
         var checkpoint = await db.NvdFeedCheckpoints.FirstOrDefaultAsync(c => c.FeedName == feedName, ct);
 
         var lastModStart = checkpoint?.FeedLastModified.AddMinutes(-15)
-            ?? DateTimeOffset.UtcNow.AddHours(-2);
+            ?? DateTimeOffset.UtcNow.AddHours(-13);
         var lastModEnd = DateTimeOffset.UtcNow;
 
         var apiKey = await GetApiKeyAsync(ct);

--- a/src/PatchHound.Infrastructure/Tenants/EnrichmentSourceCatalog.cs
+++ b/src/PatchHound.Infrastructure/Tenants/EnrichmentSourceCatalog.cs
@@ -8,7 +8,7 @@ public static class EnrichmentSourceCatalog
     public const string DefenderSourceKey = TenantSourceCatalog.DefenderSourceKey;
     public const string EndOfLifeSourceKey = "endoflife";
     public const string SupplyChainSourceKey = "supply-chain";
-    public const string DefaultNvdFeedBaseUrl = "https://nvd.nist.gov/feeds/json/cve/1.1";
+    public const string DefaultNvdApiBaseUrl = "https://services.nvd.nist.gov/rest/json/cves/2.0";
     public const string DefaultEndOfLifeApiBaseUrl = "https://endoflife.date";
     public const int DefaultDefenderRefreshTtlHours = 24;
     public const int DefaultSupplyChainRefreshTtlHours = 24;
@@ -33,9 +33,9 @@ public static class EnrichmentSourceCatalog
     {
         return EnrichmentSourceConfiguration.Create(
             NvdSourceKey,
-            "NVD (Feed Sync)",
+            "NVD API",
             false,
-            apiBaseUrl: DefaultNvdFeedBaseUrl
+            apiBaseUrl: DefaultNvdApiBaseUrl
         );
     }
 

--- a/src/PatchHound.Worker/NvdFeedSyncWorker.cs
+++ b/src/PatchHound.Worker/NvdFeedSyncWorker.cs
@@ -9,7 +9,7 @@ public class NvdFeedSyncWorker(
     IServiceScopeFactory scopeFactory,
     ILogger<NvdFeedSyncWorker> logger) : BackgroundService
 {
-    private static readonly TimeSpan IncrementalInterval = TimeSpan.FromHours(2);
+    private static readonly TimeSpan IncrementalInterval = TimeSpan.FromHours(12);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/tests/PatchHound.Tests/Infrastructure/NvdFeedSyncServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/NvdFeedSyncServiceTests.cs
@@ -1,31 +1,39 @@
-using System.IO.Compression;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
 
 namespace PatchHound.Tests.Infrastructure;
 
 public class NvdFeedSyncServiceTests
 {
+    private static ISecretStore NullSecrets()
+    {
+        var store = Substitute.For<ISecretStore>();
+        store.GetSecretAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        return store;
+    }
+
     [Fact]
-    public async Task SyncFeedAsync_inserts_new_cve_entries()
+    public async Task SyncYearFeedAsync_inserts_new_cve_entries()
     {
         await using var db = await TestDbContextFactory.CreateAsync();
-        var feedJson = BuildFeedJson("CVE-2024-1234", "Test description", 7.5m,
+        var feedJson = BuildSinglePageResponse("CVE-2024-1234", "Test description", 7.5m,
             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "2024-01-01T00:00Z", "2024-01-10T00:00Z",
+            "2024-01-01T00:00:00.000", "2024-01-10T00:00:00.000",
             referenceUrl: "https://example.com/advisory",
             criteria: "cpe:2.3:a:acme:widget:1.0:*:*:*:*:*:*:*");
 
-        var metaContent = "lastModifiedDate:2024-01-10T00:00:00-04:00\nsha256:abc123";
-        var handler = new FakeFeedHttpHandler(feedJson, metaContent);
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://nvd.nist.gov") };
-        var service = new NvdFeedSyncService(httpClient, db,
+        var handler = new FakeApiHandler(feedJson);
+        var httpClient = new HttpClient(handler);
+        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
             NullLogger<NvdFeedSyncService>.Instance);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
@@ -48,29 +56,27 @@ public class NvdFeedSyncServiceTests
     }
 
     [Fact]
-    public async Task SyncFeedAsync_updates_existing_cve_entry()
+    public async Task SyncYearFeedAsync_updates_existing_cve_entry()
     {
         await using var db = await TestDbContextFactory.CreateAsync();
         db.NvdCveCache.Add(NvdCveCache.Create("CVE-2024-1234", "old description",
-            null, null, null,
-            new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            "[]", "[]"));
+            null, null, null, DateTimeOffset.MinValue, "[]", "[]"));
         db.NvdFeedCheckpoints.Add(NvdFeedCheckpoint.Create("2024",
             new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)));
         await db.SaveChangesAsync();
 
-        var feedJson = BuildFeedJson("CVE-2024-1234", "updated description", 9.8m,
+        // Year feed is skipped when checkpoint exists — so we simulate a direct call via modified feed
+        var feedJson = BuildSinglePageResponse("CVE-2024-1234", "updated description", 9.8m,
             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
-            "2024-01-01T00:00Z", "2024-01-15T00:00Z",
+            "2024-01-01T00:00:00.000", "2024-01-15T00:00:00.000",
             referenceUrl: null, criteria: "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*");
 
-        var metaContent = "lastModifiedDate:2024-01-15T00:00:00-04:00\nsha256:def456";
-        var handler = new FakeFeedHttpHandler(feedJson, metaContent);
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://nvd.nist.gov") };
-        var service = new NvdFeedSyncService(httpClient, db,
+        var handler = new FakeApiHandler(feedJson);
+        var httpClient = new HttpClient(handler);
+        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
             NullLogger<NvdFeedSyncService>.Instance);
 
-        await service.SyncYearFeedAsync(2024, CancellationToken.None);
+        await service.SyncModifiedFeedAsync(CancellationToken.None);
 
         var cached = await db.NvdCveCache.SingleAsync();
         cached.Description.Should().Be("updated description");
@@ -78,51 +84,49 @@ public class NvdFeedSyncServiceTests
     }
 
     [Fact]
-    public async Task SyncFeedAsync_skips_download_when_feed_not_modified()
+    public async Task SyncYearFeedAsync_skips_when_checkpoint_exists()
     {
         await using var db = await TestDbContextFactory.CreateAsync();
-        var existingModified = new DateTimeOffset(2024, 1, 10, 4, 0, 0, TimeSpan.Zero);
-        db.NvdFeedCheckpoints.Add(NvdFeedCheckpoint.Create("2024", existingModified));
+        db.NvdFeedCheckpoints.Add(NvdFeedCheckpoint.Create("2024", DateTimeOffset.UtcNow));
         await db.SaveChangesAsync();
 
-        var metaContent = "lastModifiedDate:2024-01-10T00:00:00-04:00\nsha256:abc123";
-        var handler = new FakeFeedHttpHandler(feedJson: "should-not-be-fetched", metaContent);
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://nvd.nist.gov") };
-        var service = new NvdFeedSyncService(httpClient, db,
+        var handler = new FakeApiHandler("{}");
+        var httpClient = new HttpClient(handler);
+        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
             NullLogger<NvdFeedSyncService>.Instance);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
 
-        handler.FeedRequested.Should().BeFalse("feed should be skipped when checkpoint is current");
+        handler.RequestCount.Should().Be(0, "no HTTP requests should be made when checkpoint exists");
         (await db.NvdCveCache.CountAsync()).Should().Be(0);
-
-        var checkpoint = await db.NvdFeedCheckpoints.SingleAsync();
-        checkpoint.FeedLastModified.Should().Be(existingModified, "checkpoint should not be updated when feed is current");
     }
 
     [Fact]
-    public async Task SyncFeedAsync_skips_cve_with_no_english_description()
+    public async Task SyncYearFeedAsync_skips_cve_with_no_english_description()
     {
         await using var db = await TestDbContextFactory.CreateAsync();
-        var feedJson = $$$"""
+        var feedJson = """
             {
-              "CVE_Items": [{
+              "resultsPerPage": 1,
+              "startIndex": 0,
+              "totalResults": 1,
+              "vulnerabilities": [{
                 "cve": {
-                  "CVE_data_meta": {"ID": "CVE-2024-9000"},
-                  "description": {"description_data": [{"lang": "es","value": "descripción en español"}]},
-                  "references": {"reference_data": []}
-                },
-                "configurations": {"nodes": []},
-                "impact": {},
-                "publishedDate": "2024-01-01T00:00Z",
-                "lastModifiedDate": "2024-01-10T00:00Z"
+                  "id": "CVE-2024-9000",
+                  "published": "2024-01-01T00:00:00.000",
+                  "lastModified": "2024-01-10T00:00:00.000",
+                  "descriptions": [{"lang": "es", "value": "descripción"}],
+                  "metrics": {},
+                  "references": [],
+                  "configurations": []
+                }
               }]
             }
             """;
-        var metaContent = "lastModifiedDate:2024-01-10T00:00:00-04:00\nsha256:abc123";
-        var handler = new FakeFeedHttpHandler(feedJson, metaContent);
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://nvd.nist.gov") };
-        var service = new NvdFeedSyncService(httpClient, db,
+
+        var handler = new FakeApiHandler(feedJson);
+        var httpClient = new HttpClient(handler);
+        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
             NullLogger<NvdFeedSyncService>.Instance);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
@@ -131,78 +135,55 @@ public class NvdFeedSyncServiceTests
         (await db.NvdFeedCheckpoints.CountAsync()).Should().Be(1, "checkpoint should still be created");
     }
 
-    private static string BuildFeedJson(
+    private static string BuildSinglePageResponse(
         string cveId, string description, decimal baseScore, string vector,
         string publishedDate, string lastModifiedDate,
         string? referenceUrl, string criteria)
     {
         var refs = referenceUrl is null ? "[]"
-            : $@"[{{""url"":""{referenceUrl}"",""refsource"":""MISC"",""tags"":[]}}]";
+            : $$$"""[{"url":"{{{referenceUrl}}}","source":"MISC","tags":[]}]""";
         return $$$"""
             {
-              "CVE_Items": [{
+              "resultsPerPage": 1,
+              "startIndex": 0,
+              "totalResults": 1,
+              "vulnerabilities": [{
                 "cve": {
-                  "CVE_data_meta": {"ID": "{{{cveId}}}"},
-                  "description": {"description_data": [{"lang": "en","value": "{{{description}}}"}]},
-                  "references": {"reference_data": {{{refs}}}}
-                },
-                "configurations": {
-                  "nodes": [{"cpe_match": [{"vulnerable": true,"cpe23Uri": "{{{criteria}}}"}],"children": []}]
-                },
-                "impact": {
-                  "baseMetricV3": {"cvssV3": {"baseScore": {{{baseScore}}},"vectorString": "{{{vector}}}"}}
-                },
-                "publishedDate": "{{{publishedDate}}}",
-                "lastModifiedDate": "{{{lastModifiedDate}}}"
+                  "id": "{{{cveId}}}",
+                  "published": "{{{publishedDate}}}",
+                  "lastModified": "{{{lastModifiedDate}}}",
+                  "descriptions": [{"lang": "en", "value": "{{{description}}}"}],
+                  "metrics": {
+                    "cvssMetricV31": [{
+                      "type": "Primary",
+                      "cvssData": {"baseScore": {{{baseScore}}}, "vectorString": "{{{vector}}}"}
+                    }]
+                  },
+                  "references": {{{refs}}},
+                  "configurations": [{
+                    "nodes": [{"cpeMatch": [{"vulnerable": true, "criteria": "{{{criteria}}}"}], "nodes": []}]
+                  }]
+                }
               }]
             }
             """;
     }
 
-    internal sealed class FakeFeedHttpHandler : HttpMessageHandler
+    internal sealed class FakeApiHandler : HttpMessageHandler
     {
-        private readonly string _feedJson;
-        private readonly string _metaContent;
-        public bool FeedRequested { get; private set; }
+        private readonly string _responseJson;
+        public int RequestCount { get; private set; }
 
-        public FakeFeedHttpHandler(string feedJson, string metaContent)
-        {
-            _feedJson = feedJson;
-            _metaContent = metaContent;
-        }
+        public FakeApiHandler(string responseJson) => _responseJson = responseJson;
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken ct)
         {
-            var url = request.RequestUri!.ToString();
-            if (url.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(_metaContent),
-                });
-            }
-
-            FeedRequested = true;
-            var compressed = CompressJson(_feedJson);
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new ByteArrayContent(compressed),
-            };
-            response.Content.Headers.ContentType =
-                new System.Net.Http.Headers.MediaTypeHeaderValue("application/gzip");
-            return Task.FromResult(response);
-        }
-
-        private static byte[] CompressJson(string json)
-        {
-            using var ms = new MemoryStream();
-            using (var gz = new GZipStream(ms, CompressionMode.Compress))
-            {
-                var bytes = Encoding.UTF8.GetBytes(json);
-                gz.Write(bytes);
-            }
-            return ms.ToArray();
+                Content = new StringContent(_responseJson, Encoding.UTF8, "application/json"),
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `NvdCveCache` and `NvdFeedCheckpoint` entities + EF migration to store a local NVD snapshot in PostgreSQL
- Replaces per-CVE NVD API calls in `NvdVulnerabilityEnrichmentRunner` with local cache reads (zero HTTP delay per enrichment job)
- Adds `NvdFeedSyncService` to bulk-fetch CVEs from the **NVD API 2.0** (`services.nvd.nist.gov/rest/json/cves/2.0`) with API key from OpenBao, paginated at 2000 results per page
- Adds `NvdFeedSyncWorker` (`BackgroundService`): syncs the last 5 years on startup, then runs a modified-feed sync every **12 hours** (twice per day)
- NVD source no longer requires credentials to function — API key is optional (no key = 7s inter-page delay; with key = 700ms)
- Admin enrichment source rows are now fully clickable to open the editor sheet

## Test Plan

- [ ] Run `dotnet test PatchHound.slnx -v minimal` — 603 tests passing
- [ ] Run `npm run typecheck` in `frontend/` — no errors
- [ ] Verify worker logs show NVD initial sync on startup
- [ ] Verify enrichment jobs resolve from cache (no outbound NVD calls per-CVE)
- [ ] Verify clicking an enrichment source row in admin opens the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)