### PR TITLE
Add stored credential support for integrations and ingestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (9463 symbols, 70322 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (14471 symbols, 79664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -101,44 +101,12 @@ This project is indexed by GitNexus as **PatchHound** (9463 symbols, 70322 relat
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
-## When Debugging
-
-1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
-2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/PatchHound/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
-- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
-- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
-
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
-| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
-| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
-| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
-| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
-| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -148,32 +116,6 @@ This project is indexed by GitNexus as **PatchHound** (9463 symbols, 70322 relat
 | `gitnexus://repo/PatchHound/clusters` | All functional areas |
 | `gitnexus://repo/PatchHound/processes` | All execution flows |
 | `gitnexus://repo/PatchHound/process/{name}` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. `gitnexus_impact` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. `gitnexus_detect_changes()` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-```bash
-npx gitnexus analyze
-```
-
-If the index previously included embeddings, preserve them by adding `--embeddings`:
-
-```bash
-npx gitnexus analyze --embeddings
-```
-
-To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (14471 symbols, 79664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (14544 symbols, 80307 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (9463 symbols, 70322 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (14471 symbols, 79664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -101,44 +101,12 @@ This project is indexed by GitNexus as **PatchHound** (9463 symbols, 70322 relat
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
-## When Debugging
-
-1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
-2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/PatchHound/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
-- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
-- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
-
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
-| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
-| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
-| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
-| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
-| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -148,32 +116,6 @@ This project is indexed by GitNexus as **PatchHound** (9463 symbols, 70322 relat
 | `gitnexus://repo/PatchHound/clusters` | All functional areas |
 | `gitnexus://repo/PatchHound/processes` | All execution flows |
 | `gitnexus://repo/PatchHound/process/{name}` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. `gitnexus_impact` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. `gitnexus_detect_changes()` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-```bash
-npx gitnexus analyze
-```
-
-If the index previously included embeddings, preserve them by adding `--embeddings`:
-
-```bash
-npx gitnexus analyze --embeddings
-```
-
-To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (14471 symbols, 79664 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (14544 symbols, 80307 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/frontend/src/api/integrations.schemas.ts
+++ b/frontend/src/api/integrations.schemas.ts
@@ -6,9 +6,8 @@ export const sentinelConnectorSchema = z.object({
   dceEndpoint: z.string(),
   dcrImmutableId: z.string(),
   streamName: z.string(),
-  tenantId: z.string(),
-  clientId: z.string(),
-  hasSecret: z.boolean(),
+  storedCredentialId: z.string().uuid().nullable(),
+  acceptedCredentialTypes: z.array(z.string()),
   updatedAt: isoDateTimeSchema.nullable(),
 })
 
@@ -19,9 +18,7 @@ export const updateSentinelConnectorSchema = z.object({
   dceEndpoint: z.string().max(512),
   dcrImmutableId: z.string().max(256),
   streamName: z.string().max(256),
-  tenantId: z.string().max(128),
-  clientId: z.string().max(128),
-  clientSecret: z.string().nullable().optional(),
+  storedCredentialId: z.string().uuid().nullable(),
 })
 
 export type UpdateSentinelConnectorInput = z.infer<typeof updateSentinelConnectorSchema>

--- a/frontend/src/api/settings.functions.ts
+++ b/frontend/src/api/settings.functions.ts
@@ -14,6 +14,7 @@ const updateTenantIngestionSourceSchema = z.object({
   enabled: z.boolean(),
   syncSchedule: z.string(),
   credentials: z.object({
+    storedCredentialId: z.string().uuid().nullable().optional(),
     clientId: z.string(),
     secret: z.string(),
     apiBaseUrl: z.string(),

--- a/frontend/src/api/settings.schemas.ts
+++ b/frontend/src/api/settings.schemas.ts
@@ -3,6 +3,8 @@ import { isoDateTimeSchema, nullableIsoDateTimeSchema } from './common.schemas'
 import { pagedResponseMetaSchema } from './pagination.schemas'
 
 export const tenantCredentialsSchema = z.object({
+  storedCredentialId: z.string().uuid().nullable().optional(),
+  acceptedCredentialTypes: z.array(z.string()).optional().default([]),
   clientId: z.string(),
   hasSecret: z.boolean(),
   apiBaseUrl: z.string(),

--- a/frontend/src/api/stored-credentials.functions.ts
+++ b/frontend/src/api/stored-credentials.functions.ts
@@ -1,0 +1,42 @@
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '@/server/middleware'
+import { apiDelete, apiGet, apiPost, apiPut } from '@/server/api'
+import { createStoredCredentialSchema, storedCredentialSchema, updateStoredCredentialSchema } from './stored-credentials.schemas'
+import { z } from 'zod'
+
+export const fetchStoredCredentials = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({
+    type: z.string().optional(),
+    tenantId: z.string().uuid().optional(),
+  }))
+  .handler(async ({ context, data }) => {
+    const params = new URLSearchParams()
+    if (data.type) params.set('type', data.type)
+    if (data.tenantId) params.set('tenantId', data.tenantId)
+    const qs = params.toString()
+    const response = await apiGet(`/stored-credentials${qs ? `?${qs}` : ''}`, context)
+    return z.array(storedCredentialSchema).parse(response)
+  })
+
+export const createStoredCredential = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(createStoredCredentialSchema)
+  .handler(async ({ context, data }) => {
+    const response = await apiPost('/stored-credentials', context, data)
+    return storedCredentialSchema.parse(response)
+  })
+
+export const updateStoredCredential = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(updateStoredCredentialSchema)
+  .handler(async ({ context, data: { id, ...payload } }) => {
+    await apiPut(`/stored-credentials/${id}`, context, payload)
+  })
+
+export const deleteStoredCredential = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, data: { id } }) => {
+    await apiDelete(`/stored-credentials/${id}`, context)
+  })

--- a/frontend/src/api/stored-credentials.schemas.ts
+++ b/frontend/src/api/stored-credentials.schemas.ts
@@ -17,8 +17,8 @@ export const createStoredCredentialSchema = z.object({
   name: z.string().min(1),
   type: z.string().min(1),
   isGlobal: z.boolean(),
-  credentialTenantId: z.string().min(1),
-  clientId: z.string().min(1),
+  credentialTenantId: z.string(),
+  clientId: z.string(),
   clientSecret: z.string().min(1),
   tenantIds: z.array(z.string().uuid()),
 })
@@ -27,8 +27,8 @@ export const updateStoredCredentialSchema = z.object({
   id: z.string().uuid(),
   name: z.string().min(1),
   isGlobal: z.boolean(),
-  credentialTenantId: z.string().min(1),
-  clientId: z.string().min(1),
+  credentialTenantId: z.string(),
+  clientId: z.string(),
   clientSecret: z.string().nullable().optional(),
   tenantIds: z.array(z.string().uuid()),
 })

--- a/frontend/src/api/stored-credentials.schemas.ts
+++ b/frontend/src/api/stored-credentials.schemas.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+export const storedCredentialSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  type: z.string(),
+  typeDisplayName: z.string(),
+  isGlobal: z.boolean(),
+  credentialTenantId: z.string(),
+  clientId: z.string(),
+  tenantIds: z.array(z.string().uuid()),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export const createStoredCredentialSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  isGlobal: z.boolean(),
+  credentialTenantId: z.string().min(1),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  tenantIds: z.array(z.string().uuid()),
+})
+
+export const updateStoredCredentialSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  isGlobal: z.boolean(),
+  credentialTenantId: z.string().min(1),
+  clientId: z.string().min(1),
+  clientSecret: z.string().nullable().optional(),
+  tenantIds: z.array(z.string().uuid()),
+})
+
+export type StoredCredential = z.infer<typeof storedCredentialSchema>
+export type CreateStoredCredentialInput = z.infer<typeof createStoredCredentialSchema>
+export type UpdateStoredCredentialInput = z.infer<typeof updateStoredCredentialSchema>

--- a/frontend/src/components/features/admin/GlobalEnrichmentSourceManagement.tsx
+++ b/frontend/src/components/features/admin/GlobalEnrichmentSourceManagement.tsx
@@ -690,11 +690,11 @@ function StoredCredentialSelector({
       >
         <SelectTrigger className="h-10 w-full rounded-lg border-border/70 bg-background px-3">
           <SelectValue placeholder="Select stored credential">
-            {selectedCredential?.name ?? 'Source-specific secret'}
+            {selectedCredential?.name ?? 'No stored credential'}
           </SelectValue>
         </SelectTrigger>
         <SelectContent className="rounded-xl border-border/70 bg-popover/95 backdrop-blur">
-          <SelectItem value="none">Source-specific secret</SelectItem>
+          <SelectItem value="none">No stored credential</SelectItem>
           {compatibleCredentials.map((credential) => (
             <SelectItem key={credential.id} value={credential.id}>
               {credential.name}
@@ -716,7 +716,9 @@ function StoredCredentialSelector({
         </div>
       ) : selectedCredential ? (
         <p className="text-[11px] text-muted-foreground">
-          Uses client {selectedCredential.clientId} from tenant {selectedCredential.credentialTenantId}.
+          {selectedCredential.type === 'api-key'
+            ? 'Uses a stored API key from OpenBao.'
+            : `Uses client ${selectedCredential.clientId} from tenant ${selectedCredential.credentialTenantId}.`}
         </p>
       ) : (
         <p className="text-[11px] text-muted-foreground">
@@ -785,7 +787,7 @@ function getProviderStatusTone(source: EnrichmentSource): 'neutral' | 'success' 
 function getProviderStatusDescription(source: EnrichmentSource) {
   if (source.key === 'nvd') {
     if (!source.enabled) return 'NVD enrichment is configured globally but currently inactive.'
-    if (!source.credentials.hasSecret) return 'NVD enrichment can run without an API key; add one to increase the allowed request rate for modified-feed sync.'
+    if (!source.credentials.hasSecret && !source.credentials.storedCredentialId) return 'NVD enrichment can run without an API key; add one to increase the allowed request rate for modified-feed sync.'
     if (source.runtime.lastError) return 'The worker is attempting NVD enrichment, but the latest run failed and should be reviewed.'
     return 'NVD is the global backfill source for missing vulnerability metadata when tenant ingestion does not provide it.'
   }

--- a/frontend/src/components/features/admin/GlobalEnrichmentSourceManagement.tsx
+++ b/frontend/src/components/features/admin/GlobalEnrichmentSourceManagement.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { Sparkles, X } from 'lucide-react'
+import { fetchStoredCredentials } from '@/api/stored-credentials.functions'
+import type { StoredCredential } from '@/api/stored-credentials.schemas'
 import {
   type EnrichmentSource,
   triggerEndOfLifeEnrichment,
@@ -13,6 +16,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { InsetPanel } from '@/components/ui/inset-panel'
 import { Separator } from '@/components/ui/separator'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   Sheet,
   SheetContent,
@@ -51,6 +61,12 @@ export function GlobalEnrichmentSourceManagement({
   const [historySource, setHistorySource] = useState<{ key: string; displayName: string } | null>(null)
   const { selectedTenantId } = useTenantScope()
 
+  const storedCredentialsQuery = useQuery({
+    queryKey: ['stored-credentials', 'enrichment'],
+    queryFn: () => fetchStoredCredentials({ data: {} }),
+    staleTime: 30_000,
+  })
+
   const eolTriggerMutation = useMutation({
     mutationFn: async () => {
       if (!selectedTenantId) throw new Error('No tenant selected')
@@ -73,6 +89,7 @@ export function GlobalEnrichmentSourceManagement({
           enabled: source.enabled,
           refreshTtlHours: source.refreshTtlHours,
           credentials: {
+            storedCredentialId: source.credentials.storedCredentialId ?? null,
             secret: source.credentials.secret,
             apiBaseUrl: source.credentials.apiBaseUrl,
           },
@@ -264,6 +281,7 @@ export function GlobalEnrichmentSourceManagement({
               isSaving={mutation.isPending}
               saveState={saveState}
               selectedTenantId={selectedTenantId}
+              storedCredentials={storedCredentialsQuery.data ?? []}
               isEolTriggering={eolTriggerMutation.isPending}
               onSave={() => mutation.mutate()}
               onClose={() => setEditingSourceKey(null)}
@@ -288,6 +306,7 @@ function EnrichmentSourceEditorSheetContent({
   isSaving,
   saveState,
   selectedTenantId,
+  storedCredentials,
   isEolTriggering,
   onSave,
   onClose,
@@ -299,6 +318,7 @@ function EnrichmentSourceEditorSheetContent({
   isSaving: boolean
   saveState: 'idle' | 'saved' | 'error'
   selectedTenantId: string | null | undefined
+  storedCredentials: StoredCredential[]
   isEolTriggering: boolean
   onSave: () => void
   onClose: () => void
@@ -457,7 +477,13 @@ function EnrichmentSourceEditorSheetContent({
           </FormSection>
 
           <FormSection title="Credentials">
-            {source.credentialMode === 'global-secret' || source.key === 'nvd' ? (
+            {source.credentials.acceptedCredentialTypes.length > 0 ? (
+              <StoredCredentialSelector
+                source={source}
+                storedCredentials={storedCredentials}
+                onUpdateSource={onUpdateSource}
+              />
+            ) : source.credentialMode === 'global-secret' || source.key === 'nvd' ? (
               <div className="grid content-start gap-2">
                 <span className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
                   API Key{source.key === 'nvd' ? ' (optional)' : ''}
@@ -624,6 +650,100 @@ function FormSection({ title, children }: { title: string; children: React.React
       <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">{title}</p>
       {children}
       <Separator className="opacity-50" />
+    </div>
+  )
+}
+
+function StoredCredentialSelector({
+  source,
+  storedCredentials,
+  onUpdateSource,
+}: {
+  source: EnrichmentSourceDraft
+  storedCredentials: StoredCredential[]
+  onUpdateSource: (key: string, mutate: (current: EnrichmentSourceDraft) => EnrichmentSourceDraft) => void
+}) {
+  const acceptedTypes = source.credentials.acceptedCredentialTypes
+  const compatibleCredentials = storedCredentials.filter(
+    (credential) => credential.isGlobal && acceptedTypes.includes(credential.type),
+  )
+  const selectedCredential = compatibleCredentials.find(
+    (credential) => credential.id === source.credentials.storedCredentialId,
+  )
+
+  return (
+    <div className="grid content-start gap-2">
+      <span className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        Stored Credential
+      </span>
+      <Select
+        value={source.credentials.storedCredentialId ?? 'none'}
+        onValueChange={(value) =>
+          onUpdateSource(source.key, (current) => ({
+            ...current,
+            credentials: {
+              ...current.credentials,
+              storedCredentialId: value === 'none' ? null : value,
+            },
+          }))
+        }
+      >
+        <SelectTrigger className="h-10 w-full rounded-lg border-border/70 bg-background px-3">
+          <SelectValue placeholder="Select stored credential">
+            {selectedCredential?.name ?? 'Source-specific secret'}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent className="rounded-xl border-border/70 bg-popover/95 backdrop-blur">
+          <SelectItem value="none">Source-specific secret</SelectItem>
+          {compatibleCredentials.map((credential) => (
+            <SelectItem key={credential.id} value={credential.id}>
+              {credential.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {compatibleCredentials.length === 0 ? (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground">
+            No global stored credentials are available for this provider type.
+          </p>
+          <Link
+            to="/admin/platform/credentials"
+            className="inline-flex w-fit text-[11px] font-medium text-primary underline-offset-4 hover:underline"
+          >
+            Manage stored credentials
+          </Link>
+        </div>
+      ) : selectedCredential ? (
+        <p className="text-[11px] text-muted-foreground">
+          Uses client {selectedCredential.clientId} from tenant {selectedCredential.credentialTenantId}.
+        </p>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">
+          Enter a provider-specific secret below, or select a reusable global credential.
+        </p>
+      )}
+      {source.credentialMode === 'global-secret' || source.key === 'nvd' ? (
+        <Input
+          type="password"
+          placeholder={
+            source.credentials.hasSecret
+              ? 'API key stored — enter a new key to replace it'
+              : source.key === 'nvd'
+                ? 'Enter NVD API key'
+                : 'Enter API key'
+          }
+          value={source.credentials.secret}
+          disabled={Boolean(source.credentials.storedCredentialId)}
+          onChange={(event) =>
+            onUpdateSource(source.key, (current) => ({
+              ...current,
+              credentials: { ...current.credentials, secret: event.target.value },
+            }))
+          }
+          className="h-10"
+        />
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/components/features/admin/SentinelConnectorCard.tsx
+++ b/frontend/src/components/features/admin/SentinelConnectorCard.tsx
@@ -1,12 +1,22 @@
 import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Satellite, Loader2, ExternalLinkIcon } from 'lucide-react'
+import { fetchStoredCredentials } from '@/api/stored-credentials.functions'
+import type { StoredCredential } from '@/api/stored-credentials.schemas'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   fetchSentinelConnector,
   updateSentinelConnector,
@@ -24,6 +34,11 @@ export function SentinelConnectorCard() {
     queryKey: ['sentinel-connector'],
     queryFn: () => fetchSentinelConnector(),
   })
+  const credentialsQuery = useQuery({
+    queryKey: ['stored-credentials', 'sentinel'],
+    queryFn: () => fetchStoredCredentials({ data: { type: 'entra-client-secret' } }),
+    staleTime: 30_000,
+  })
 
   const [editing, setEditing] = useState(false)
 
@@ -38,6 +53,8 @@ export function SentinelConnectorCard() {
   }
 
   const isConfigured = !!(config.dceEndpoint && config.dcrImmutableId && config.streamName)
+  const credentials = credentialsQuery.data ?? []
+  const selectedCredential = credentials.find((credential) => credential.id === config.storedCredentialId)
 
   if (!editing && !isConfigured) {
     return (
@@ -102,8 +119,8 @@ export function SentinelConnectorCard() {
               <p className="font-mono text-xs">{config.streamName}</p>
             </div>
             <div>
-              <span className="text-muted-foreground">Client Secret</span>
-              <p className="text-xs">{config.hasSecret ? '••••••••' : 'Not set'}</p>
+              <span className="text-muted-foreground">Stored Credential</span>
+              <p className="truncate text-xs">{selectedCredential?.name ?? 'Not set'}</p>
             </div>
           </div>
           <Button variant="outline" onClick={() => setEditing(true)}>
@@ -117,6 +134,7 @@ export function SentinelConnectorCard() {
   return (
     <SentinelConnectorForm
       config={config}
+      storedCredentials={credentials}
       onClose={() => setEditing(false)}
       onSaved={() => {
         void queryClient.invalidateQueries({ queryKey: ['sentinel-connector'] })
@@ -128,10 +146,19 @@ export function SentinelConnectorCard() {
 
 function SentinelConnectorForm({
   config,
+  storedCredentials,
   onClose,
   onSaved,
 }: {
-  config: { enabled: boolean; dceEndpoint: string; dcrImmutableId: string; streamName: string; tenantId: string; clientId: string; hasSecret: boolean }
+  config: {
+    enabled: boolean
+    dceEndpoint: string
+    dcrImmutableId: string
+    streamName: string
+    storedCredentialId: string | null
+    acceptedCredentialTypes: string[]
+  }
+  storedCredentials: StoredCredential[]
   onClose: () => void
   onSaved: () => void
 }) {
@@ -140,10 +167,16 @@ function SentinelConnectorForm({
     dceEndpoint: config.dceEndpoint,
     dcrImmutableId: config.dcrImmutableId,
     streamName: config.streamName || 'Custom-PatchHoundAuditLog',
-    tenantId: config.tenantId,
-    clientId: config.clientId,
-    clientSecret: null,
+    storedCredentialId: config.storedCredentialId,
   })
+  const compatibleCredentials = storedCredentials.filter(
+    (credential) =>
+      credential.isGlobal && config.acceptedCredentialTypes.includes(credential.type),
+  )
+  const selectedCredential = compatibleCredentials.find(
+    (credential) => credential.id === form.storedCredentialId,
+  )
+  const canSave = !form.enabled || Boolean(form.storedCredentialId)
 
   const mutation = useMutation({
     mutationFn: (data: UpdateSentinelConnectorInput) => updateSentinelConnector({ data }),
@@ -208,45 +241,44 @@ function SentinelConnectorForm({
               onChange={(e) => update('streamName', e.target.value)}
             />
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="entra-tenant">Entra Tenant ID</Label>
-            <Input
-              id="entra-tenant"
-              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-              value={form.tenantId}
-              onChange={(e) => update('tenantId', e.target.value)}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="client-id">Client ID</Label>
-            <Input
-              id="client-id"
-              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-              value={form.clientId}
-              onChange={(e) => update('clientId', e.target.value)}
-            />
-          </div>
           <div className="space-y-1.5 sm:col-span-2">
-            <Label htmlFor="client-secret">
-              Client Secret
-              {config.hasSecret && (
-                <span className="ml-2 text-xs text-muted-foreground">(leave blank to keep current)</span>
-              )}
-            </Label>
-            <Input
-              id="client-secret"
-              type="password"
-              placeholder={config.hasSecret ? '••••••••' : 'Enter client secret'}
-              value={form.clientSecret ?? ''}
-              onChange={(e) => update('clientSecret', e.target.value || null)}
-            />
+            <Label>Stored Credential</Label>
+            <Select
+              value={form.storedCredentialId ?? 'none'}
+              onValueChange={(value) =>
+                update('storedCredentialId', value === 'none' ? null : value)
+              }
+            >
+              <SelectTrigger className="h-10 w-full rounded-xl bg-background px-3">
+                <SelectValue placeholder="Select stored credential">
+                  {selectedCredential?.name ?? 'No credential selected'}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent className="rounded-2xl border-border/70 bg-popover/95 backdrop-blur">
+                <SelectItem value="none">No credential selected</SelectItem>
+                {compatibleCredentials.map((credential) => (
+                  <SelectItem key={credential.id} value={credential.id}>
+                    {credential.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Sentinel requires a global Entra ID stored credential with Monitoring Metrics Publisher access.
+            </p>
+            <Link
+              to="/admin/platform/credentials"
+              className="inline-flex w-fit text-xs font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Manage stored credentials
+            </Link>
           </div>
         </div>
 
         <div className="flex gap-2">
           <Button
             onClick={() => mutation.mutate(form)}
-            disabled={mutation.isPending}
+            disabled={mutation.isPending || !canSave}
           >
             {mutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
             Save
@@ -259,6 +291,11 @@ function SentinelConnectorForm({
         {mutation.isError && (
           <p className="text-sm text-destructive">
             {mutation.error instanceof Error ? mutation.error.message : 'Failed to save configuration'}
+          </p>
+        )}
+        {!canSave && (
+          <p className="text-sm text-destructive">
+            Select a global Entra ID stored credential before enabling Sentinel.
           </p>
         )}
       </CardContent>

--- a/frontend/src/components/features/admin/StoredCredentialsManagement.tsx
+++ b/frontend/src/components/features/admin/StoredCredentialsManagement.tsx
@@ -24,6 +24,13 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Table,
   TableBody,
   TableCell,
@@ -35,6 +42,7 @@ import { getApiErrorMessage } from '@/lib/api-errors'
 
 type CredentialFormState = {
   id?: string
+  type: string
   name: string
   credentialTenantId: string
   clientId: string
@@ -44,6 +52,7 @@ type CredentialFormState = {
 }
 
 const emptyForm: CredentialFormState = {
+  type: 'entra-client-secret',
   name: '',
   credentialTenantId: '',
   clientId: '',
@@ -117,6 +126,7 @@ export function StoredCredentialsManagement() {
   function openEdit(credential: StoredCredential) {
     setForm({
       id: credential.id,
+      type: credential.type,
       name: credential.name,
       credentialTenantId: credential.credentialTenantId,
       clientId: credential.clientId,
@@ -133,8 +143,8 @@ export function StoredCredentialsManagement() {
         id: form.id,
         name: form.name,
         isGlobal: form.isGlobal,
-        credentialTenantId: form.credentialTenantId,
-        clientId: form.clientId,
+        credentialTenantId: form.type === 'api-key' ? '' : form.credentialTenantId,
+        clientId: form.type === 'api-key' ? '' : form.clientId,
         clientSecret: form.clientSecret.trim() ? form.clientSecret : null,
         tenantIds: form.isGlobal ? [] : form.tenantIds,
       }
@@ -144,10 +154,10 @@ export function StoredCredentialsManagement() {
 
     const input: CreateStoredCredentialInput = {
       name: form.name,
-      type: 'entra-client-secret',
+      type: form.type,
       isGlobal: form.isGlobal,
-      credentialTenantId: form.credentialTenantId,
-      clientId: form.clientId,
+      credentialTenantId: form.type === 'api-key' ? '' : form.credentialTenantId,
+      clientId: form.type === 'api-key' ? '' : form.clientId,
       clientSecret: form.clientSecret,
       tenantIds: form.isGlobal ? [] : form.tenantIds,
     }
@@ -203,7 +213,9 @@ export function StoredCredentialsManagement() {
                     <TableCell>
                       <ScopeBadge credential={credential} tenants={tenants} />
                     </TableCell>
-                    <TableCell className="font-mono text-xs text-muted-foreground">{credential.clientId}</TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {credential.clientId || '-'}
+                    </TableCell>
                     <TableCell>{formatDate(credential.updatedAt)}</TableCell>
                     <TableCell className="pr-4">
                       <div className="flex justify-end gap-2">
@@ -266,12 +278,14 @@ function CredentialDialog({
   onChange: (form: CredentialFormState) => void
   onSubmit: () => void
 }) {
+  const isApiKey = form.type === 'api-key'
   const canSubmit = useMemo(() => {
-    if (!form.name.trim() || !form.credentialTenantId.trim() || !form.clientId.trim()) return false
+    if (!form.name.trim()) return false
+    if (!isApiKey && (!form.credentialTenantId.trim() || !form.clientId.trim())) return false
     if (!isEditing && !form.clientSecret.trim()) return false
     if (!form.isGlobal && form.tenantIds.length === 0) return false
     return true
-  }, [form, isEditing])
+  }, [form, isApiKey, isEditing])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -279,7 +293,7 @@ function CredentialDialog({
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit credential' : 'New credential'}</DialogTitle>
           <DialogDescription>
-            Entra ID identity credentials are stored in OpenBao and attached by reference.
+            Stored secrets are kept in OpenBao and attached by reference.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4">
@@ -287,22 +301,55 @@ function CredentialDialog({
             <Input value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
           </Field>
           <Field label="Credential type">
-            <Input value="Entra ID identity" disabled />
+            {isEditing ? (
+              <Input value={getCredentialTypeDisplayName(form.type)} disabled />
+            ) : (
+              <Select
+                value={form.type}
+                onValueChange={(value) => {
+                  const nextType = value ?? 'entra-client-secret'
+                  onChange({
+                    ...form,
+                    type: nextType,
+                    credentialTenantId: nextType === 'api-key' ? '' : form.credentialTenantId,
+                    clientId: nextType === 'api-key' ? '' : form.clientId,
+                  })
+                }}
+              >
+                <SelectTrigger className="h-10 w-full rounded-lg border-border/70 bg-background px-3">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="rounded-xl border-border/70 bg-popover/95 backdrop-blur">
+                  <SelectItem value="entra-client-secret">Entra ID identity</SelectItem>
+                  <SelectItem value="api-key">API key</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
           </Field>
-          <Field label="Entra Tenant ID">
-            <Input
-              value={form.credentialTenantId}
-              onChange={(event) => onChange({ ...form, credentialTenantId: event.target.value })}
-            />
-          </Field>
-          <Field label="Client ID">
-            <Input value={form.clientId} onChange={(event) => onChange({ ...form, clientId: event.target.value })} />
-          </Field>
-          <Field label={isEditing ? 'Rotate client secret' : 'Client secret'}>
+          {!isApiKey ? (
+            <>
+              <Field label="Entra Tenant ID">
+                <Input
+                  value={form.credentialTenantId}
+                  onChange={(event) => onChange({ ...form, credentialTenantId: event.target.value })}
+                />
+              </Field>
+              <Field label="Client ID">
+                <Input value={form.clientId} onChange={(event) => onChange({ ...form, clientId: event.target.value })} />
+              </Field>
+            </>
+          ) : null}
+          <Field label={isEditing ? `Rotate ${isApiKey ? 'API key' : 'client secret'}` : isApiKey ? 'API key' : 'Client secret'}>
             <Input
               type="password"
               value={form.clientSecret}
-              placeholder={isEditing ? 'Leave blank to keep existing secret' : 'Enter client secret'}
+              placeholder={
+                isEditing
+                  ? 'Leave blank to keep existing secret'
+                  : isApiKey
+                    ? 'Enter API key'
+                    : 'Enter client secret'
+              }
               onChange={(event) => onChange({ ...form, clientSecret: event.target.value })}
             />
           </Field>
@@ -424,4 +471,10 @@ function formatDate(value: string) {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+}
+
+function getCredentialTypeDisplayName(type: string) {
+  if (type === 'api-key') return 'API key'
+  if (type === 'entra-client-secret') return 'Entra ID identity'
+  return type
 }

--- a/frontend/src/components/features/admin/StoredCredentialsManagement.tsx
+++ b/frontend/src/components/features/admin/StoredCredentialsManagement.tsx
@@ -1,0 +1,427 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { KeyRound, Pencil, Plus, Trash2 } from 'lucide-react'
+import {
+  createStoredCredential,
+  deleteStoredCredential,
+  fetchStoredCredentials,
+  updateStoredCredential,
+} from '@/api/stored-credentials.functions'
+import { fetchTenants } from '@/api/settings.functions'
+import type { CreateStoredCredentialInput, StoredCredential, UpdateStoredCredentialInput } from '@/api/stored-credentials.schemas'
+import type { TenantListItem } from '@/api/settings.schemas'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { getApiErrorMessage } from '@/lib/api-errors'
+
+type CredentialFormState = {
+  id?: string
+  name: string
+  credentialTenantId: string
+  clientId: string
+  clientSecret: string
+  isGlobal: boolean
+  tenantIds: string[]
+}
+
+const emptyForm: CredentialFormState = {
+  name: '',
+  credentialTenantId: '',
+  clientId: '',
+  clientSecret: '',
+  isGlobal: false,
+  tenantIds: [],
+}
+
+export function StoredCredentialsManagement() {
+  const [formOpen, setFormOpen] = useState(false)
+  const [form, setForm] = useState<CredentialFormState>(emptyForm)
+  const [deleteTarget, setDeleteTarget] = useState<StoredCredential | null>(null)
+
+  const credentialsQuery = useQuery({
+    queryKey: ['stored-credentials'],
+    queryFn: () => fetchStoredCredentials({ data: {} }),
+    staleTime: 30_000,
+  })
+
+  const tenantsQuery = useQuery({
+    queryKey: ['tenants', 'credential-scope'],
+    queryFn: () => fetchTenants({ data: { page: 1, pageSize: 200 } }),
+    staleTime: 60_000,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createStoredCredential,
+    onSuccess: async () => {
+      toast.success('Credential created')
+      closeForm()
+      await credentialsQuery.refetch()
+    },
+    onError: (error) => toast.error(getApiErrorMessage(error, 'Failed to create credential')),
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: updateStoredCredential,
+    onSuccess: async () => {
+      toast.success('Credential updated')
+      closeForm()
+      await credentialsQuery.refetch()
+    },
+    onError: (error) => toast.error(getApiErrorMessage(error, 'Failed to update credential')),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteStoredCredential,
+    onSuccess: async () => {
+      toast.success('Credential deleted')
+      setDeleteTarget(null)
+      await credentialsQuery.refetch()
+    },
+    onError: (error) => toast.error(getApiErrorMessage(error, 'Failed to delete credential')),
+  })
+
+  const credentials = credentialsQuery.data ?? []
+  const tenants = tenantsQuery.data?.items ?? []
+  const isEditing = Boolean(form.id)
+  const isSubmitting = createMutation.isPending || updateMutation.isPending
+
+  function closeForm() {
+    setFormOpen(false)
+    setForm(emptyForm)
+  }
+
+  function openCreate() {
+    setForm(emptyForm)
+    setFormOpen(true)
+  }
+
+  function openEdit(credential: StoredCredential) {
+    setForm({
+      id: credential.id,
+      name: credential.name,
+      credentialTenantId: credential.credentialTenantId,
+      clientId: credential.clientId,
+      clientSecret: '',
+      isGlobal: credential.isGlobal,
+      tenantIds: credential.tenantIds,
+    })
+    setFormOpen(true)
+  }
+
+  function submitForm() {
+    if (isEditing && form.id) {
+      const input: UpdateStoredCredentialInput = {
+        id: form.id,
+        name: form.name,
+        isGlobal: form.isGlobal,
+        credentialTenantId: form.credentialTenantId,
+        clientId: form.clientId,
+        clientSecret: form.clientSecret.trim() ? form.clientSecret : null,
+        tenantIds: form.isGlobal ? [] : form.tenantIds,
+      }
+      updateMutation.mutate({ data: input })
+      return
+    }
+
+    const input: CreateStoredCredentialInput = {
+      name: form.name,
+      type: 'entra-client-secret',
+      isGlobal: form.isGlobal,
+      credentialTenantId: form.credentialTenantId,
+      clientId: form.clientId,
+      clientSecret: form.clientSecret,
+      tenantIds: form.isGlobal ? [] : form.tenantIds,
+    }
+    createMutation.mutate({ data: input })
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Stored credentials</h2>
+          <p className="text-sm text-muted-foreground">
+            Reusable identities for sources and integrations.
+          </p>
+        </div>
+        <Button type="button" onClick={openCreate}>
+          <Plus className="size-4" />
+          New credential
+        </Button>
+      </div>
+
+      <Card className="overflow-hidden rounded-2xl border-border/70">
+        <CardHeader className="border-b border-border/60 px-4 py-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <KeyRound className="size-4 text-primary" />
+            Credential inventory
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="pl-4">Name</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead>Client ID</TableHead>
+                <TableHead>Updated</TableHead>
+                <TableHead className="pr-4 text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {credentials.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    No stored credentials.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                credentials.map((credential) => (
+                  <TableRow key={credential.id}>
+                    <TableCell className="pl-4 font-medium">{credential.name}</TableCell>
+                    <TableCell>{credential.typeDisplayName}</TableCell>
+                    <TableCell>
+                      <ScopeBadge credential={credential} tenants={tenants} />
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">{credential.clientId}</TableCell>
+                    <TableCell>{formatDate(credential.updatedAt)}</TableCell>
+                    <TableCell className="pr-4">
+                      <div className="flex justify-end gap-2">
+                        <Button type="button" variant="ghost" size="icon-sm" onClick={() => openEdit(credential)}>
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button type="button" variant="ghost" size="icon-sm" onClick={() => setDeleteTarget(credential)}>
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <CredentialDialog
+        open={formOpen}
+        form={form}
+        tenants={tenants}
+        isEditing={isEditing}
+        isSubmitting={isSubmitting}
+        onOpenChange={(open) => {
+          if (!open) closeForm()
+          else setFormOpen(true)
+        }}
+        onChange={setForm}
+        onSubmit={submitForm}
+      />
+
+      <DeleteCredentialDialog
+        credential={deleteTarget}
+        isDeleting={deleteMutation.isPending}
+        onCancel={() => setDeleteTarget(null)}
+        onDelete={(credential) => deleteMutation.mutate({ data: { id: credential.id } })}
+      />
+    </section>
+  )
+}
+
+function CredentialDialog({
+  open,
+  form,
+  tenants,
+  isEditing,
+  isSubmitting,
+  onOpenChange,
+  onChange,
+  onSubmit,
+}: {
+  open: boolean
+  form: CredentialFormState
+  tenants: TenantListItem[]
+  isEditing: boolean
+  isSubmitting: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (form: CredentialFormState) => void
+  onSubmit: () => void
+}) {
+  const canSubmit = useMemo(() => {
+    if (!form.name.trim() || !form.credentialTenantId.trim() || !form.clientId.trim()) return false
+    if (!isEditing && !form.clientSecret.trim()) return false
+    if (!form.isGlobal && form.tenantIds.length === 0) return false
+    return true
+  }, [form, isEditing])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Edit credential' : 'New credential'}</DialogTitle>
+          <DialogDescription>
+            Entra ID identity credentials are stored in OpenBao and attached by reference.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <Field label="Name">
+            <Input value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} />
+          </Field>
+          <Field label="Credential type">
+            <Input value="Entra ID identity" disabled />
+          </Field>
+          <Field label="Entra Tenant ID">
+            <Input
+              value={form.credentialTenantId}
+              onChange={(event) => onChange({ ...form, credentialTenantId: event.target.value })}
+            />
+          </Field>
+          <Field label="Client ID">
+            <Input value={form.clientId} onChange={(event) => onChange({ ...form, clientId: event.target.value })} />
+          </Field>
+          <Field label={isEditing ? 'Rotate client secret' : 'Client secret'}>
+            <Input
+              type="password"
+              value={form.clientSecret}
+              placeholder={isEditing ? 'Leave blank to keep existing secret' : 'Enter client secret'}
+              onChange={(event) => onChange({ ...form, clientSecret: event.target.value })}
+            />
+          </Field>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.isGlobal}
+              onChange={(event) => onChange({ ...form, isGlobal: event.target.checked })}
+              className="size-4 rounded border-border"
+            />
+            Available globally
+          </label>
+          {!form.isGlobal ? (
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Available tenants</p>
+              <div className="max-h-44 overflow-auto rounded-xl border border-border/70 p-2">
+                {tenants.map((tenant) => {
+                  const checked = form.tenantIds.includes(tenant.id)
+                  return (
+                    <label key={tenant.id} className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-accent/30">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(event) => {
+                          onChange({
+                            ...form,
+                            tenantIds: event.target.checked
+                              ? [...form.tenantIds, tenant.id]
+                              : form.tenantIds.filter((id) => id !== tenant.id),
+                          })
+                        }}
+                        className="size-4 rounded border-border"
+                      />
+                      <span>{tenant.name}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            </div>
+          ) : null}
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" disabled={!canSubmit || isSubmitting} onClick={onSubmit}>
+            {isSubmitting ? 'Saving…' : isEditing ? 'Save credential' : 'Create credential'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteCredentialDialog({
+  credential,
+  isDeleting,
+  onCancel,
+  onDelete,
+}: {
+  credential: StoredCredential | null
+  isDeleting: boolean
+  onCancel: () => void
+  onDelete: (credential: StoredCredential) => void
+}) {
+  return (
+    <Dialog open={credential !== null} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete credential?</DialogTitle>
+          <DialogDescription>
+            Attached credentials cannot be deleted until they are detached from sources.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={!credential || isDeleting}
+            onClick={() => credential && onDelete(credential)}
+          >
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ScopeBadge({ credential, tenants }: { credential: StoredCredential; tenants: TenantListItem[] }) {
+  if (credential.isGlobal) {
+    return <Badge className="rounded-full">Global</Badge>
+  }
+
+  const names = credential.tenantIds
+    .map((id) => tenants.find((tenant) => tenant.id === id)?.name)
+    .filter(Boolean)
+
+  return (
+    <Badge variant="outline" className="rounded-full">
+      {names.length === 1 ? names[0] : `${credential.tenantIds.length} tenants`}
+    </Badge>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="grid gap-2">
+      <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+}

--- a/frontend/src/components/features/admin/TenantSourceManagement.tsx
+++ b/frontend/src/components/features/admin/TenantSourceManagement.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react'
-import { useRouter } from "@tanstack/react-router";
-import { useMutation } from '@tanstack/react-query'
+import { Link, useRouter } from "@tanstack/react-router";
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { ArrowLeft, CircleHelp, Clock, PenSquare, RotateCw, Square, X } from 'lucide-react'
 import { abortTenantIngestionRun, triggerTenantIngestionSync, updateTenant } from '@/api/settings.functions'
+import { createStoredCredential, fetchStoredCredentials } from '@/api/stored-credentials.functions'
 import type { TenantDetail, TenantIngestionSource } from '@/api/settings.schemas'
+import type { CreateStoredCredentialInput, StoredCredential } from '@/api/stored-credentials.schemas'
 import { SourceRunHistoryView } from '@/components/features/admin/SourceRunHistorySheet'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -20,6 +22,21 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   Table,
   TableBody,
@@ -62,6 +79,7 @@ export function TenantSourceManagement({
   const [saveState, setSaveState] = useState<'idle' | 'saved' | 'error'>('idle')
   const [syncingSourceKey, setSyncingSourceKey] = useState<string | null>(null)
   const [abortingRunId, setAbortingRunId] = useState<string | null>(null)
+  const [credentialDialogSourceKey, setCredentialDialogSourceKey] = useState<string | null>(null)
 
   const editingSource = useMemo(
     () => sources.find((source) => source.key === editingSourceKey) ?? null,
@@ -85,10 +103,12 @@ export function TenantSourceManagement({
             enabled: source.enabled,
             syncSchedule: source.syncSchedule,
             credentials: {
+              storedCredentialId: source.credentials.storedCredentialId ?? null,
               clientId: source.credentials.clientId,
               secret: source.credentials.secret,
               apiBaseUrl: source.credentials.apiBaseUrl,
               tokenScope: source.credentials.tokenScope,
+              linkedSourceKey: source.credentials.linkedSourceKey ?? null,
             },
           })),
         },
@@ -102,6 +122,36 @@ export function TenantSourceManagement({
     onError: (error) => {
       setSaveState('error')
       toast.error(getApiErrorMessage(error, 'Failed to save source configuration'))
+    },
+  })
+
+  const credentialQuery = useQuery({
+    queryKey: ['stored-credentials', tenant.id, 'entra-client-secret'],
+    queryFn: () => fetchStoredCredentials({ data: { tenantId: tenant.id, type: 'entra-client-secret' } }),
+    staleTime: 30_000,
+  })
+
+  const createCredentialMutation = useMutation({
+    mutationFn: createStoredCredential,
+    onSuccess: async (credential) => {
+      toast.success('Credential created')
+      if (credentialDialogSourceKey) {
+        updateSource(credentialDialogSourceKey, (current) => ({
+          ...current,
+          credentials: {
+            ...current.credentials,
+            storedCredentialId: credential.id,
+            clientId: '',
+            secret: '',
+            hasSecret: true,
+          },
+        }))
+      }
+      setCredentialDialogSourceKey(null)
+      await credentialQuery.refetch()
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, 'Failed to create credential'))
     },
   })
 
@@ -351,11 +401,14 @@ export function TenantSourceManagement({
             {editingSource ? (
               <TenantSourceEditorSheetContent
                 source={editingSource}
+                tenantId={tenant.id}
+                credentials={credentialQuery.data ?? []}
                 isSaving={mutation.isPending}
                 saveState={saveState}
                 onSave={() => mutation.mutate()}
                 onClose={onCloseEditor}
                 onUpdateSource={updateSource}
+                onCreateCredential={(sourceKey) => setCredentialDialogSourceKey(sourceKey)}
                 onViewHistory={() => {
                   onCloseEditor();
                   onOpenHistory(editingSource.key);
@@ -364,6 +417,15 @@ export function TenantSourceManagement({
             ) : null}
           </SheetContent>
         </Sheet>
+        <InlineCredentialDialog
+          open={credentialDialogSourceKey !== null}
+          tenantId={tenant.id}
+          isSubmitting={createCredentialMutation.isPending}
+          onOpenChange={(open) => {
+            if (!open) setCredentialDialogSourceKey(null)
+          }}
+          onSubmit={(input) => createCredentialMutation.mutate({ data: input })}
+        />
       </section>
     </TooltipProvider>
   );
@@ -373,14 +435,19 @@ export function TenantSourceManagement({
 
 function TenantSourceEditorSheetContent({
   source,
+  tenantId,
+  credentials,
   isSaving,
   saveState,
   onSave,
   onClose,
   onUpdateSource,
+  onCreateCredential,
   onViewHistory,
 }: {
   source: TenantIngestionSourceDraft;
+  tenantId: string;
+  credentials: StoredCredential[];
   isSaving: boolean;
   saveState: "idle" | "saved" | "error";
   onSave: () => void;
@@ -389,8 +456,17 @@ function TenantSourceEditorSheetContent({
     key: string,
     mutate: (current: TenantIngestionSourceDraft) => TenantIngestionSourceDraft,
   ) => void;
+  onCreateCredential: (sourceKey: string) => void;
   onViewHistory: () => void;
 }) {
+  const compatibleCredentials = credentials.filter((credential) =>
+    source.credentials.acceptedCredentialTypes?.includes(credential.type)
+    && (credential.isGlobal || credential.tenantIds.includes(tenantId))
+  )
+  const selectedCredential = compatibleCredentials.find(
+    (credential) => credential.id === source.credentials.storedCredentialId,
+  )
+
   return (
     <>
       <SheetHeader className="shrink-0 border-b border-border/60 p-5">
@@ -520,56 +596,54 @@ function TenantSourceEditorSheetContent({
 
           <FormSection title="Credentials">
             <div className="space-y-4">
-              <div className="grid gap-4 sm:grid-cols-2">
+              {source.credentials.acceptedCredentialTypes?.length ? (
                 <FieldBlock
-                  label="Client ID"
-                  tooltip="Application client identifier used to authenticate against the source."
+                  label="Stored credential"
+                  tooltip="Reusable credential filtered by source type and tenant availability."
                   className="col-span-2"
                   control={
-                    <Input
-                      value={source.credentials.clientId}
-                      onChange={(event) => {
-                        onUpdateSource(source.key, (current) => ({
-                          ...current,
-                          credentials: {
-                            ...current.credentials,
-                            clientId: event.target.value,
-                          },
-                        }));
-                      }}
-                      className="h-10"
-                    />
+                    <div className="flex gap-2">
+                      <Select
+                        value={source.credentials.storedCredentialId ?? 'none'}
+                        onValueChange={(value) => {
+                          onUpdateSource(source.key, (current) => ({
+                            ...current,
+                            credentials: {
+                              ...current.credentials,
+                              storedCredentialId: value === 'none' ? null : value,
+                            },
+                          }))
+                        }}
+                      >
+                        <SelectTrigger className="h-10 flex-1">
+                          <SelectValue placeholder="Select credential">
+                            {selectedCredential?.name ?? 'No credential selected'}
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">No credential selected</SelectItem>
+                          {compatibleCredentials.map((credential) => (
+                            <SelectItem key={credential.id} value={credential.id}>
+                              {credential.name}
+                              {credential.isGlobal ? ' · global' : ''}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button type="button" variant="outline" onClick={() => onCreateCredential(source.key)}>
+                        New
+                      </Button>
+                      <Link
+                        to="/admin/platform/credentials"
+                        className="inline-flex h-10 items-center rounded-lg border border-border bg-background px-3 text-sm font-medium transition-colors hover:bg-muted"
+                      >
+                        Manage
+                      </Link>
+                    </div>
                   }
                 />
-                <FieldBlock
-                  label="Client Secret"
-                  tooltip="Stored securely after save. Enter a new value only when rotating credentials."
-                  className="sm:col-span-2"
-                  control={
-                    <Input
-                      type="password"
-                      value={source.credentials.secret}
-                      placeholder={
-                        source.credentials.hasSecret
-                          ? "Stored in OpenBao — enter a new value to rotate"
-                          : "Not configured"
-                      }
-                      onChange={(event) => {
-                        onUpdateSource(source.key, (current) => ({
-                          ...current,
-                          credentials: {
-                            ...current.credentials,
-                            secret: event.target.value,
-                            hasSecret:
-                              current.credentials.hasSecret ||
-                              event.target.value.trim().length > 0,
-                          },
-                        }));
-                      }}
-                      className="h-10"
-                    />
-                  }
-                />
+              ) : null}
+              <div className="grid gap-4 sm:grid-cols-2">
                 <FieldBlock
                   label="API Base URL"
                   tooltip="Base endpoint used for provider API requests."
@@ -640,6 +714,107 @@ function TenantSourceEditorSheetContent({
       </SheetFooter>
     </>
   );
+}
+
+function InlineCredentialDialog({
+  open,
+  tenantId,
+  isSubmitting,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean
+  tenantId: string
+  isSubmitting: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (input: CreateStoredCredentialInput) => void
+}) {
+  const [name, setName] = useState('')
+  const [credentialTenantId, setCredentialTenantId] = useState('')
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
+  const [isGlobal, setIsGlobal] = useState(false)
+
+  function reset() {
+    setName('')
+    setCredentialTenantId('')
+    setClientId('')
+    setClientSecret('')
+    setIsGlobal(false)
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        onOpenChange(nextOpen)
+        if (!nextOpen) reset()
+      }}
+    >
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>New stored credential</DialogTitle>
+          <DialogDescription>
+            Create a reusable Entra ID identity for compatible integrations.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <FieldBlock
+            label="Name"
+            tooltip="Operator-facing name shown in credential selectors."
+            control={<Input value={name} onChange={(event) => setName(event.target.value)} />}
+          />
+          <FieldBlock
+            label="Entra Tenant ID"
+            tooltip="Directory tenant used when requesting tokens."
+            control={<Input value={credentialTenantId} onChange={(event) => setCredentialTenantId(event.target.value)} />}
+          />
+          <FieldBlock
+            label="Client ID"
+            tooltip="Application client identifier."
+            control={<Input value={clientId} onChange={(event) => setClientId(event.target.value)} />}
+          />
+          <FieldBlock
+            label="Client Secret"
+            tooltip="Stored server-side in OpenBao."
+            control={<Input type="password" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} />}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={isGlobal}
+              onChange={(event) => setIsGlobal(event.target.checked)}
+              className="size-4 rounded border-border"
+            />
+            Available globally
+          </label>
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={isSubmitting || !name.trim() || !credentialTenantId.trim() || !clientId.trim() || !clientSecret.trim()}
+            onClick={() => {
+              onSubmit({
+                name,
+                type: 'entra-client-secret',
+                isGlobal,
+                credentialTenantId,
+                clientId,
+                clientSecret,
+                tenantIds: isGlobal ? [] : [tenantId],
+              })
+              reset()
+            }}
+          >
+            {isSubmitting ? 'Creating…' : 'Create credential'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
 }
 
 // ─── History full-page view ─────────────────────────────────────────────────

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -63,6 +63,7 @@ import { Route as AuthedAdminPlatformNotificationsRouteImport } from './routes/_
 import { Route as AuthedAdminPlatformIntegrationsRouteImport } from './routes/_authed/admin/platform/integrations'
 import { Route as AuthedAdminPlatformFeatureFlagsRouteImport } from './routes/_authed/admin/platform/feature-flags'
 import { Route as AuthedAdminPlatformEnrichmentRouteImport } from './routes/_authed/admin/platform/enrichment'
+import { Route as AuthedAdminPlatformCredentialsRouteImport } from './routes/_authed/admin/platform/credentials'
 import { Route as AuthedAdminPlatformAiRouteImport } from './routes/_authed/admin/platform/ai'
 import { Route as AuthedAdminPlatformAdvancedToolsRouteImport } from './routes/_authed/admin/platform/advanced-tools'
 import { Route as AuthedAdminPlatformAccessRouteImport } from './routes/_authed/admin/platform/access'
@@ -359,6 +360,12 @@ const AuthedAdminPlatformEnrichmentRoute =
     path: '/admin/platform/enrichment',
     getParentRoute: () => AuthedRoute,
   } as any)
+const AuthedAdminPlatformCredentialsRoute =
+  AuthedAdminPlatformCredentialsRouteImport.update({
+    id: '/admin/platform/credentials',
+    path: '/admin/platform/credentials',
+    getParentRoute: () => AuthedRoute,
+  } as any)
 const AuthedAdminPlatformAiRoute = AuthedAdminPlatformAiRouteImport.update({
   id: '/admin/platform/ai',
   path: '/admin/platform/ai',
@@ -429,6 +436,7 @@ export interface FileRoutesByFullPath {
   '/admin/platform/access': typeof AuthedAdminPlatformAccessRoute
   '/admin/platform/advanced-tools': typeof AuthedAdminPlatformAdvancedToolsRoute
   '/admin/platform/ai': typeof AuthedAdminPlatformAiRoute
+  '/admin/platform/credentials': typeof AuthedAdminPlatformCredentialsRoute
   '/admin/platform/enrichment': typeof AuthedAdminPlatformEnrichmentRoute
   '/admin/platform/feature-flags': typeof AuthedAdminPlatformFeatureFlagsRoute
   '/admin/platform/integrations': typeof AuthedAdminPlatformIntegrationsRoute
@@ -489,6 +497,7 @@ export interface FileRoutesByTo {
   '/admin/platform/access': typeof AuthedAdminPlatformAccessRoute
   '/admin/platform/advanced-tools': typeof AuthedAdminPlatformAdvancedToolsRoute
   '/admin/platform/ai': typeof AuthedAdminPlatformAiRoute
+  '/admin/platform/credentials': typeof AuthedAdminPlatformCredentialsRoute
   '/admin/platform/enrichment': typeof AuthedAdminPlatformEnrichmentRoute
   '/admin/platform/feature-flags': typeof AuthedAdminPlatformFeatureFlagsRoute
   '/admin/platform/integrations': typeof AuthedAdminPlatformIntegrationsRoute
@@ -551,6 +560,7 @@ export interface FileRoutesById {
   '/_authed/admin/platform/access': typeof AuthedAdminPlatformAccessRoute
   '/_authed/admin/platform/advanced-tools': typeof AuthedAdminPlatformAdvancedToolsRoute
   '/_authed/admin/platform/ai': typeof AuthedAdminPlatformAiRoute
+  '/_authed/admin/platform/credentials': typeof AuthedAdminPlatformCredentialsRoute
   '/_authed/admin/platform/enrichment': typeof AuthedAdminPlatformEnrichmentRoute
   '/_authed/admin/platform/feature-flags': typeof AuthedAdminPlatformFeatureFlagsRoute
   '/_authed/admin/platform/integrations': typeof AuthedAdminPlatformIntegrationsRoute
@@ -613,6 +623,7 @@ export interface FileRouteTypes {
     | '/admin/platform/access'
     | '/admin/platform/advanced-tools'
     | '/admin/platform/ai'
+    | '/admin/platform/credentials'
     | '/admin/platform/enrichment'
     | '/admin/platform/feature-flags'
     | '/admin/platform/integrations'
@@ -673,6 +684,7 @@ export interface FileRouteTypes {
     | '/admin/platform/access'
     | '/admin/platform/advanced-tools'
     | '/admin/platform/ai'
+    | '/admin/platform/credentials'
     | '/admin/platform/enrichment'
     | '/admin/platform/feature-flags'
     | '/admin/platform/integrations'
@@ -734,6 +746,7 @@ export interface FileRouteTypes {
     | '/_authed/admin/platform/access'
     | '/_authed/admin/platform/advanced-tools'
     | '/_authed/admin/platform/ai'
+    | '/_authed/admin/platform/credentials'
     | '/_authed/admin/platform/enrichment'
     | '/_authed/admin/platform/feature-flags'
     | '/_authed/admin/platform/integrations'
@@ -1147,6 +1160,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminPlatformEnrichmentRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/admin/platform/credentials': {
+      id: '/_authed/admin/platform/credentials'
+      path: '/admin/platform/credentials'
+      fullPath: '/admin/platform/credentials'
+      preLoaderRoute: typeof AuthedAdminPlatformCredentialsRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/admin/platform/ai': {
       id: '/_authed/admin/platform/ai'
       path: '/admin/platform/ai'
@@ -1232,6 +1252,7 @@ interface AuthedRouteChildren {
   AuthedAdminPlatformAccessRoute: typeof AuthedAdminPlatformAccessRoute
   AuthedAdminPlatformAdvancedToolsRoute: typeof AuthedAdminPlatformAdvancedToolsRoute
   AuthedAdminPlatformAiRoute: typeof AuthedAdminPlatformAiRoute
+  AuthedAdminPlatformCredentialsRoute: typeof AuthedAdminPlatformCredentialsRoute
   AuthedAdminPlatformEnrichmentRoute: typeof AuthedAdminPlatformEnrichmentRoute
   AuthedAdminPlatformFeatureFlagsRoute: typeof AuthedAdminPlatformFeatureFlagsRoute
   AuthedAdminPlatformIntegrationsRoute: typeof AuthedAdminPlatformIntegrationsRoute
@@ -1284,6 +1305,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAdminPlatformAccessRoute: AuthedAdminPlatformAccessRoute,
   AuthedAdminPlatformAdvancedToolsRoute: AuthedAdminPlatformAdvancedToolsRoute,
   AuthedAdminPlatformAiRoute: AuthedAdminPlatformAiRoute,
+  AuthedAdminPlatformCredentialsRoute: AuthedAdminPlatformCredentialsRoute,
   AuthedAdminPlatformEnrichmentRoute: AuthedAdminPlatformEnrichmentRoute,
   AuthedAdminPlatformFeatureFlagsRoute: AuthedAdminPlatformFeatureFlagsRoute,
   AuthedAdminPlatformIntegrationsRoute: AuthedAdminPlatformIntegrationsRoute,

--- a/frontend/src/routes/_authed/admin/index.tsx
+++ b/frontend/src/routes/_authed/admin/index.tsx
@@ -1,5 +1,5 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
-import { Bell, Bot, Braces, Building2, ChevronRight, Flag, GitBranchPlus, Globe, Plug, ScanSearch, ShieldCheck, ShieldEllipsis, Tags, Users, Workflow, Wrench } from 'lucide-react'
+import { Bell, Bot, Braces, Building2, ChevronRight, Flag, GitBranchPlus, Globe, KeyRound, Plug, ScanSearch, ShieldCheck, ShieldEllipsis, Tags, Users, Workflow, Wrench } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export const Route = createFileRoute('/_authed/admin/')({
@@ -37,6 +37,7 @@ type AdminArea = {
     | '/admin/platform/access'
     | '/admin/platform/security-profiles'
     | '/admin/platform/enrichment'
+    | '/admin/platform/credentials'
   roles: AdminRole[]
   icon: typeof Users
   featureFlag?: string
@@ -135,6 +136,13 @@ const adminSections: AdminSection[] = [
         to: '/admin/platform/enrichment',
         roles: ['GlobalAdmin'],
         icon: Globe,
+      },
+      {
+        title: 'Stored credentials',
+        description: 'Manage reusable credential references for tenant sources and shared platform integrations.',
+        to: '/admin/platform/credentials',
+        roles: ['GlobalAdmin'],
+        icon: KeyRound,
       },
       {
         title: 'Integrations',

--- a/frontend/src/routes/_authed/admin/platform/credentials.tsx
+++ b/frontend/src/routes/_authed/admin/platform/credentials.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { StoredCredentialsManagement } from '@/components/features/admin/StoredCredentialsManagement'
+
+export const Route = createFileRoute('/_authed/admin/platform/credentials')({
+  beforeLoad: ({ context }) => {
+    const activeRoles = context.user?.activeRoles ?? []
+    if (!activeRoles.includes('GlobalAdmin')) {
+      throw redirect({ to: '/admin' })
+    }
+  },
+  component: StoredCredentialsPage,
+})
+
+function StoredCredentialsPage() {
+  return (
+    <section className="space-y-6 pb-4">
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          Platform configuration
+        </p>
+        <h1 className="text-3xl font-semibold tracking-[-0.04em]">
+          Stored Credentials
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Create, scope, rotate, and remove reusable credential references for
+          ingestion sources and platform integrations.
+        </p>
+      </div>
+
+      <StoredCredentialsManagement />
+    </section>
+  )
+}

--- a/frontend/src/server/system.functions.ts
+++ b/frontend/src/server/system.functions.ts
@@ -43,6 +43,8 @@ const enrichmentSourceSchema = z.object({
   credentialMode: z.enum(['global-secret', 'tenant-source', 'no-credential']),
   refreshTtlHours: z.number().int().nullable(),
   credentials: z.object({
+    storedCredentialId: z.string().uuid().nullable().optional(),
+    acceptedCredentialTypes: z.array(z.string()).optional().default([]),
     hasSecret: z.boolean(),
     apiBaseUrl: z.string(),
   }),
@@ -155,6 +157,7 @@ export const updateEnrichmentSources = createServerFn({ method: 'POST' })
     enabled: z.boolean(),
     refreshTtlHours: z.number().int().nullable(),
     credentials: z.object({
+      storedCredentialId: z.string().uuid().nullable().optional(),
       secret: z.string(),
       apiBaseUrl: z.string(),
     }),

--- a/src/PatchHound.Api/Controllers/IntegrationsController.cs
+++ b/src/PatchHound.Api/Controllers/IntegrationsController.cs
@@ -4,8 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Auth;
 using PatchHound.Api.Models.Integrations;
 using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Data;
-using PatchHound.Infrastructure.Secrets;
 
 namespace PatchHound.Api.Controllers;
 
@@ -14,15 +14,10 @@ namespace PatchHound.Api.Controllers;
 [Authorize]
 public class IntegrationsController : ControllerBase
 {
-    private const string SentinelSecretPath = "system/sentinel-connector";
-    private const string SentinelSecretKey = "clientSecret";
-
-    private readonly ISecretStore _secretStore;
     private readonly PatchHoundDbContext _dbContext;
 
-    public IntegrationsController(ISecretStore secretStore, PatchHoundDbContext dbContext)
+    public IntegrationsController(PatchHoundDbContext dbContext)
     {
-        _secretStore = secretStore;
         _dbContext = dbContext;
     }
 
@@ -42,9 +37,8 @@ public class IntegrationsController : ControllerBase
                     DceEndpoint: string.Empty,
                     DcrImmutableId: string.Empty,
                     StreamName: string.Empty,
-                    TenantId: string.Empty,
-                    ClientId: string.Empty,
-                    HasSecret: false,
+                    StoredCredentialId: null,
+                    AcceptedCredentialTypes: [StoredCredentialTypes.EntraClientSecret],
                     UpdatedAt: null
                 )
             );
@@ -56,9 +50,8 @@ public class IntegrationsController : ControllerBase
                 DceEndpoint: config.DceEndpoint,
                 DcrImmutableId: config.DcrImmutableId,
                 StreamName: config.StreamName,
-                TenantId: config.TenantId,
-                ClientId: config.ClientId,
-                HasSecret: !string.IsNullOrWhiteSpace(config.SecretRef),
+                StoredCredentialId: config.StoredCredentialId,
+                AcceptedCredentialTypes: [StoredCredentialTypes.EntraClientSecret],
                 UpdatedAt: config.UpdatedAt
             )
         );
@@ -72,13 +65,25 @@ public class IntegrationsController : ControllerBase
     )
     {
         var config = await _dbContext.SentinelConnectorConfigurations.FirstOrDefaultAsync(ct);
-
-        var hasNewSecret = !string.IsNullOrWhiteSpace(request.ClientSecret);
-        var secretRef = config?.SecretRef ?? string.Empty;
-
-        if (hasNewSecret)
+        if (request.Enabled && !request.StoredCredentialId.HasValue)
         {
-            secretRef = SentinelSecretPath;
+            return ValidationProblem(
+                "Sentinel requires a global Entra ID stored credential before it can be enabled."
+            );
+        }
+
+        if (request.StoredCredentialId.HasValue)
+        {
+            var exists = await _dbContext.StoredCredentials.AsNoTracking().AnyAsync(
+                credential =>
+                    credential.Id == request.StoredCredentialId.Value
+                    && credential.Type == StoredCredentialTypes.EntraClientSecret
+                    && credential.IsGlobal,
+                ct
+            );
+
+            if (!exists)
+                return ValidationProblem("Sentinel requires a global Entra ID stored credential.");
         }
 
         if (config is null)
@@ -88,9 +93,7 @@ public class IntegrationsController : ControllerBase
                 dceEndpoint: request.DceEndpoint.Trim(),
                 dcrImmutableId: request.DcrImmutableId.Trim(),
                 streamName: request.StreamName.Trim(),
-                tenantId: request.TenantId.Trim(),
-                clientId: request.ClientId.Trim(),
-                secretRef: secretRef
+                storedCredentialId: request.StoredCredentialId
             );
             await _dbContext.SentinelConnectorConfigurations.AddAsync(config, ct);
         }
@@ -101,23 +104,11 @@ public class IntegrationsController : ControllerBase
                 dceEndpoint: request.DceEndpoint.Trim(),
                 dcrImmutableId: request.DcrImmutableId.Trim(),
                 streamName: request.StreamName.Trim(),
-                tenantId: request.TenantId.Trim(),
-                clientId: request.ClientId.Trim(),
-                secretRef: secretRef
+                storedCredentialId: request.StoredCredentialId
             );
         }
 
         await _dbContext.SaveChangesAsync(ct);
-
-        // Write secret to vault after DB commit succeeds
-        if (hasNewSecret)
-        {
-            await _secretStore.PutSecretAsync(
-                SentinelSecretPath,
-                new Dictionary<string, string> { [SentinelSecretKey] = request.ClientSecret!.Trim() },
-                ct
-            );
-        }
 
         return NoContent();
     }

--- a/src/PatchHound.Api/Controllers/SetupController.cs
+++ b/src/PatchHound.Api/Controllers/SetupController.cs
@@ -6,6 +6,8 @@ using PatchHound.Api.Models.Setup;
 using PatchHound.Core.Common;
 using PatchHound.Core.Interfaces;
 using PatchHound.Core.Models;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Tenants;
@@ -114,20 +116,31 @@ public class SetupController : ControllerBase
                 );
             }
 
-            var secretRef =
-                string.IsNullOrWhiteSpace(source.SecretRef)
-                    ? $"tenants/{tenant.Id}/sources/{TenantSourceCatalog.DefenderSourceKey}"
-                    : source.SecretRef;
+            var credentialId = Guid.NewGuid();
+            var secretRef = $"stored-credentials/{credentialId}";
+            var credential = StoredCredential.Create(
+                "Microsoft Defender setup credential",
+                StoredCredentialTypes.EntraClientSecret,
+                isGlobal: false,
+                tenant.EntraTenantId,
+                clientId,
+                secretRef,
+                DateTimeOffset.UtcNow,
+                credentialId
+            );
+            credential.TenantScopes.Add(StoredCredentialTenant.Create(credential.Id, tenant.Id));
+            await _dbContext.StoredCredentials.AddAsync(credential, ct);
 
             source.UpdateConfiguration(
                 source.DisplayName,
                 true,
                 TenantSourceCatalog.DefaultDefenderSchedule,
-                tenant.EntraTenantId,
-                clientId,
-                secretRef,
-                TenantSourceCatalog.DefaultDefenderApiBaseUrl,
-                TenantSourceCatalog.DefaultDefenderTokenScope
+                credentialTenantId: string.Empty,
+                clientId: string.Empty,
+                secretRef: string.Empty,
+                apiBaseUrl: TenantSourceCatalog.DefaultDefenderApiBaseUrl,
+                tokenScope: TenantSourceCatalog.DefaultDefenderTokenScope,
+                storedCredentialId: credential.Id
             );
 
             await _dbContext.SaveChangesAsync(ct);
@@ -136,8 +149,7 @@ public class SetupController : ControllerBase
                 secretRef,
                 new Dictionary<string, string>
                 {
-                    [TenantSourceCatalog.GetSecretKeyName(TenantSourceCatalog.DefenderSourceKey)] =
-                        clientSecret,
+                    [StoredCredentialSecretKeys.ClientSecret] = clientSecret,
                 },
                 ct
             );

--- a/src/PatchHound.Api/Controllers/StoredCredentialsController.cs
+++ b/src/PatchHound.Api/Controllers/StoredCredentialsController.cs
@@ -95,7 +95,7 @@ public class StoredCredentialsController(
             secretRef,
             new Dictionary<string, string>
             {
-                [StoredCredentialSecretKeys.ClientSecret] = request.ClientSecret.Trim(),
+                [GetSecretKeyName(request.Type)] = request.ClientSecret.Trim(),
             },
             ct
         );
@@ -179,7 +179,7 @@ public class StoredCredentialsController(
                 credential.SecretRef,
                 new Dictionary<string, string>
                 {
-                    [StoredCredentialSecretKeys.ClientSecret] = request.ClientSecret.Trim(),
+                    [GetSecretKeyName(credential.Type)] = request.ClientSecret.Trim(),
                 },
                 ct
             );
@@ -256,23 +256,42 @@ public class StoredCredentialsController(
         bool requireSecret = true
     )
     {
-        if (!string.Equals(type, StoredCredentialTypes.EntraClientSecret, StringComparison.OrdinalIgnoreCase))
+        if (!IsSupportedCredentialType(type))
             return new BadRequestObjectResult(new ProblemDetails { Title = "Unsupported credential type." });
 
         if (string.IsNullOrWhiteSpace(name))
             return new BadRequestObjectResult(new ProblemDetails { Title = "Credential name is required." });
 
-        if (string.IsNullOrWhiteSpace(credentialTenantId) || string.IsNullOrWhiteSpace(clientId))
+        if (
+            string.Equals(type, StoredCredentialTypes.EntraClientSecret, StringComparison.OrdinalIgnoreCase)
+            && (string.IsNullOrWhiteSpace(credentialTenantId) || string.IsNullOrWhiteSpace(clientId))
+        )
+        {
             return new BadRequestObjectResult(new ProblemDetails { Title = "Tenant ID and client ID are required." });
+        }
 
         if (requireSecret && string.IsNullOrWhiteSpace(clientSecret))
-            return new BadRequestObjectResult(new ProblemDetails { Title = "Client secret is required." });
+        {
+            var title = string.Equals(type, StoredCredentialTypes.ApiKey, StringComparison.OrdinalIgnoreCase)
+                ? "API key is required."
+                : "Client secret is required.";
+            return new BadRequestObjectResult(new ProblemDetails { Title = title });
+        }
 
         if (!isGlobal && tenantIds.Count == 0)
             return new BadRequestObjectResult(new ProblemDetails { Title = "Select at least one tenant or mark the credential global." });
 
         return null;
     }
+
+    private static bool IsSupportedCredentialType(string type) =>
+        string.Equals(type, StoredCredentialTypes.EntraClientSecret, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(type, StoredCredentialTypes.ApiKey, StringComparison.OrdinalIgnoreCase);
+
+    private static string GetSecretKeyName(string type) =>
+        string.Equals(type, StoredCredentialTypes.ApiKey, StringComparison.OrdinalIgnoreCase)
+            ? StoredCredentialSecretKeys.ApiKey
+            : StoredCredentialSecretKeys.ClientSecret;
 
     private static IReadOnlyList<Guid> NormalizeTenantIds(bool isGlobal, IReadOnlyList<Guid> tenantIds) =>
         isGlobal ? [] : tenantIds.Where(id => id != Guid.Empty).Distinct().ToList();

--- a/src/PatchHound.Api/Controllers/StoredCredentialsController.cs
+++ b/src/PatchHound.Api/Controllers/StoredCredentialsController.cs
@@ -1,0 +1,293 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Auth;
+using PatchHound.Api.Models.Credentials;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Credentials;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Secrets;
+using PatchHound.Infrastructure.Services;
+
+namespace PatchHound.Api.Controllers;
+
+[ApiController]
+[Route("api/stored-credentials")]
+[Authorize(Policy = Policies.ConfigureTenant)]
+public class StoredCredentialsController(
+    PatchHoundDbContext dbContext,
+    ISecretStore secretStore,
+    ITenantContext tenantContext,
+    AuditLogWriter auditLogWriter
+) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<StoredCredentialDto>>> List(
+        [FromQuery] string? type,
+        [FromQuery] Guid? tenantId,
+        CancellationToken ct
+    )
+    {
+        if (tenantId.HasValue && !tenantContext.HasAccessToTenant(tenantId.Value))
+            return Forbid();
+
+        var query = dbContext.StoredCredentials.AsNoTracking()
+            .Include(credential => credential.TenantScopes)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(type))
+            query = query.Where(credential => credential.Type == type);
+
+        if (tenantId.HasValue)
+        {
+            query = query.Where(credential =>
+                credential.IsGlobal
+                || credential.TenantScopes.Any(scope => scope.TenantId == tenantId.Value));
+        }
+
+        var credentials = await query
+            .OrderBy(credential => credential.Name)
+            .ToListAsync(ct);
+
+        return credentials.Select(MapDto).ToList();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<StoredCredentialDto>> Create(
+        [FromBody] CreateStoredCredentialRequest request,
+        CancellationToken ct
+    )
+    {
+        var validation = ValidateCredentialInput(
+            request.Type,
+            request.Name,
+            request.CredentialTenantId,
+            request.ClientId,
+            request.ClientSecret,
+            request.IsGlobal,
+            request.TenantIds
+        );
+        if (validation is not null) return validation;
+
+        if (!request.IsGlobal && request.TenantIds.Any(id => !tenantContext.HasAccessToTenant(id)))
+            return Forbid();
+
+        var now = DateTimeOffset.UtcNow;
+        var credentialId = Guid.NewGuid();
+        var secretRef = $"stored-credentials/{credentialId}";
+        var credential = StoredCredential.Create(
+            request.Name,
+            request.Type,
+            request.IsGlobal,
+            request.CredentialTenantId,
+            request.ClientId,
+            secretRef,
+            now,
+            credentialId
+        );
+
+        foreach (var tenantId in NormalizeTenantIds(request.IsGlobal, request.TenantIds))
+            credential.TenantScopes.Add(StoredCredentialTenant.Create(credential.Id, tenantId));
+
+        await secretStore.PutSecretAsync(
+            secretRef,
+            new Dictionary<string, string>
+            {
+                [StoredCredentialSecretKeys.ClientSecret] = request.ClientSecret.Trim(),
+            },
+            ct
+        );
+
+        await dbContext.StoredCredentials.AddAsync(credential, ct);
+        await dbContext.SaveChangesAsync(ct);
+
+        await auditLogWriter.WriteAsync(
+            Guid.Empty,
+            nameof(StoredCredential),
+            credential.Id,
+            AuditAction.Created,
+            null,
+            new
+            {
+                credential.Name,
+                credential.Type,
+                credential.IsGlobal,
+                TenantIds = credential.TenantScopes.Select(scope => scope.TenantId).ToList(),
+            },
+            ct
+        );
+        await dbContext.SaveChangesAsync(ct);
+
+        return CreatedAtAction(nameof(List), new { id = credential.Id }, MapDto(credential));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateStoredCredentialRequest request,
+        CancellationToken ct
+    )
+    {
+        var credential = await dbContext.StoredCredentials
+            .Include(item => item.TenantScopes)
+            .FirstOrDefaultAsync(item => item.Id == id, ct);
+        if (credential is null) return NotFound();
+
+        var validation = ValidateCredentialInput(
+            credential.Type,
+            request.Name,
+            request.CredentialTenantId,
+            request.ClientId,
+            request.ClientSecret,
+            request.IsGlobal,
+            request.TenantIds,
+            requireSecret: false
+        );
+        if (validation is not null) return validation;
+
+        if (!request.IsGlobal && request.TenantIds.Any(tenantId => !tenantContext.HasAccessToTenant(tenantId)))
+            return Forbid();
+
+        var oldValues = new
+        {
+            credential.Name,
+            credential.Type,
+            credential.IsGlobal,
+            credential.CredentialTenantId,
+            credential.ClientId,
+            TenantIds = credential.TenantScopes.Select(scope => scope.TenantId).ToList(),
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        credential.Update(
+            request.Name,
+            request.IsGlobal,
+            request.CredentialTenantId,
+            request.ClientId,
+            now
+        );
+
+        dbContext.StoredCredentialTenants.RemoveRange(credential.TenantScopes);
+        foreach (var tenantId in NormalizeTenantIds(request.IsGlobal, request.TenantIds))
+            credential.TenantScopes.Add(StoredCredentialTenant.Create(credential.Id, tenantId));
+
+        if (!string.IsNullOrWhiteSpace(request.ClientSecret))
+        {
+            await secretStore.PutSecretAsync(
+                credential.SecretRef,
+                new Dictionary<string, string>
+                {
+                    [StoredCredentialSecretKeys.ClientSecret] = request.ClientSecret.Trim(),
+                },
+                ct
+            );
+        }
+
+        await auditLogWriter.WriteAsync(
+            Guid.Empty,
+            nameof(StoredCredential),
+            credential.Id,
+            AuditAction.Updated,
+            oldValues,
+            new
+            {
+                credential.Name,
+                credential.Type,
+                credential.IsGlobal,
+                credential.CredentialTenantId,
+                credential.ClientId,
+                TenantIds = credential.TenantScopes.Select(scope => scope.TenantId).ToList(),
+            },
+            ct
+        );
+        await dbContext.SaveChangesAsync(ct);
+
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var inUse = await dbContext.TenantSourceConfigurations.AsNoTracking()
+                .AnyAsync(source => source.StoredCredentialId == id, ct)
+            || await dbContext.EnrichmentSourceConfigurations.AsNoTracking()
+                .AnyAsync(source => source.StoredCredentialId == id, ct)
+            || await dbContext.SentinelConnectorConfigurations.AsNoTracking()
+                .AnyAsync(source => source.StoredCredentialId == id, ct);
+        if (inUse)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Credential is still in use.",
+                Detail = "Detach this credential from all source configurations before deleting it.",
+            });
+        }
+
+        var credential = await dbContext.StoredCredentials
+            .FirstOrDefaultAsync(item => item.Id == id, ct);
+        if (credential is null) return NotFound();
+
+        dbContext.StoredCredentials.Remove(credential);
+        await auditLogWriter.WriteAsync(
+            Guid.Empty,
+            nameof(StoredCredential),
+            credential.Id,
+            AuditAction.Deleted,
+            new { credential.Name, credential.Type, credential.IsGlobal },
+            null,
+            ct
+        );
+        await dbContext.SaveChangesAsync(ct);
+        await secretStore.DeleteSecretPathAsync(credential.SecretRef, ct);
+
+        return NoContent();
+    }
+
+    private static ActionResult? ValidateCredentialInput(
+        string type,
+        string name,
+        string credentialTenantId,
+        string clientId,
+        string? clientSecret,
+        bool isGlobal,
+        IReadOnlyList<Guid> tenantIds,
+        bool requireSecret = true
+    )
+    {
+        if (!string.Equals(type, StoredCredentialTypes.EntraClientSecret, StringComparison.OrdinalIgnoreCase))
+            return new BadRequestObjectResult(new ProblemDetails { Title = "Unsupported credential type." });
+
+        if (string.IsNullOrWhiteSpace(name))
+            return new BadRequestObjectResult(new ProblemDetails { Title = "Credential name is required." });
+
+        if (string.IsNullOrWhiteSpace(credentialTenantId) || string.IsNullOrWhiteSpace(clientId))
+            return new BadRequestObjectResult(new ProblemDetails { Title = "Tenant ID and client ID are required." });
+
+        if (requireSecret && string.IsNullOrWhiteSpace(clientSecret))
+            return new BadRequestObjectResult(new ProblemDetails { Title = "Client secret is required." });
+
+        if (!isGlobal && tenantIds.Count == 0)
+            return new BadRequestObjectResult(new ProblemDetails { Title = "Select at least one tenant or mark the credential global." });
+
+        return null;
+    }
+
+    private static IReadOnlyList<Guid> NormalizeTenantIds(bool isGlobal, IReadOnlyList<Guid> tenantIds) =>
+        isGlobal ? [] : tenantIds.Where(id => id != Guid.Empty).Distinct().ToList();
+
+    private static StoredCredentialDto MapDto(StoredCredential credential) =>
+        new(
+            credential.Id,
+            credential.Name,
+            credential.Type,
+            StoredCredentialTypes.GetDisplayName(credential.Type),
+            credential.IsGlobal,
+            credential.CredentialTenantId,
+            credential.ClientId,
+            credential.TenantScopes.Select(scope => scope.TenantId).OrderBy(id => id).ToList(),
+            credential.CreatedAt,
+            credential.UpdatedAt
+        );
+}

--- a/src/PatchHound.Api/Controllers/SystemController.cs
+++ b/src/PatchHound.Api/Controllers/SystemController.cs
@@ -429,6 +429,29 @@ public class SystemController : ControllerBase
             var secretRef = existingSource?.SecretRef ?? string.Empty;
             var secretValue = source.Credentials.Secret.Trim();
             var oldSecretRef = existingSource?.SecretRef;
+            var storedCredentialId = source.Credentials.StoredCredentialId;
+
+            if (storedCredentialId.HasValue)
+            {
+                var acceptedTypes = EnrichmentSourceCatalog.GetAcceptedCredentialTypes(source.Key);
+                var credentialAvailable = acceptedTypes.Count > 0
+                    && await _dbContext.StoredCredentials.AsNoTracking()
+                        .AnyAsync(
+                            credential =>
+                                credential.Id == storedCredentialId.Value
+                                && acceptedTypes.Contains(credential.Type)
+                                && credential.IsGlobal,
+                            ct
+                        );
+
+                if (!credentialAvailable)
+                {
+                    return BadRequest(new ProblemDetails
+                    {
+                        Title = "Selected credential is not compatible with this global enrichment source.",
+                    });
+                }
+            }
 
             if (!string.IsNullOrWhiteSpace(secretValue))
             {
@@ -450,6 +473,7 @@ public class SystemController : ControllerBase
                     source.Enabled,
                     secretRef,
                     source.Credentials.ApiBaseUrl,
+                    storedCredentialId,
                     source.RefreshTtlHours
                 );
                 await _dbContext.EnrichmentSourceConfigurations.AddAsync(existingSource, ct);
@@ -466,6 +490,7 @@ public class SystemController : ControllerBase
                 source.Enabled,
                 secretRef,
                 source.Credentials.ApiBaseUrl,
+                storedCredentialId,
                 source.RefreshTtlHours
             );
 
@@ -522,6 +547,8 @@ public class SystemController : ControllerBase
             source.DisplayName,
             source.Enabled,
             new EnrichmentSourceCredentialsDto(
+                source.StoredCredentialId,
+                EnrichmentSourceCatalog.GetAcceptedCredentialTypes(source.SourceKey),
                 !string.IsNullOrWhiteSpace(source.SecretRef),
                 source.ApiBaseUrl
             ),

--- a/src/PatchHound.Api/Controllers/TenantsController.cs
+++ b/src/PatchHound.Api/Controllers/TenantsController.cs
@@ -240,13 +240,10 @@ public class TenantsController : ControllerBase
             .TenantSourceConfigurations.Where(source => source.TenantId == tenant.Id)
             .ToDictionaryAsync(source => source.SourceKey, StringComparer.OrdinalIgnoreCase, ct);
 
-        // Collect pending secret writes — vault writes happen after DB commit
-        var pendingSecretWrites = new List<(string Path, string Key, string Value)>();
-        var pendingSecretAudits = new List<(Guid EntityId, string? OldSecretRef, string NewSecretRef)>();
-
         foreach (var source in request.IngestionSources)
         {
             existingSources.TryGetValue(source.Key, out var existingSource);
+            var storedCredentialId = source.Credentials.StoredCredentialId;
             var linkedSourceKey = string.IsNullOrWhiteSpace(source.Credentials.LinkedSourceKey)
                 ? null
                 : source.Credentials.LinkedSourceKey.Trim();
@@ -278,37 +275,34 @@ public class TenantsController : ControllerBase
                         credentialTenantId: string.Empty,
                         clientId: string.Empty,
                         secretRef: string.Empty,
-                        source.Credentials.ApiBaseUrl,
-                        source.Credentials.TokenScope,
+                        apiBaseUrl: source.Credentials.ApiBaseUrl,
+                        tokenScope: source.Credentials.TokenScope,
                         linkedSourceKey: linkedSourceKey
                     );
                 }
                 continue;
             }
 
-            var secretRef = existingSource?.SecretRef ?? string.Empty;
-            var secretValue = source.Credentials.Secret.Trim();
-
-            if (string.IsNullOrWhiteSpace(secretValue))
+            if (storedCredentialId.HasValue)
             {
-                secretValue = string.Empty;
+                var credentialAvailable = await _dbContext.StoredCredentials.AsNoTracking()
+                    .AnyAsync(credential =>
+                        credential.Id == storedCredentialId.Value
+                        && TenantSourceCatalog.GetAcceptedCredentialTypes(source.Key).Contains(credential.Type)
+                        && (
+                            credential.IsGlobal
+                            || credential.TenantScopes.Any(scope => scope.TenantId == tenant.Id)
+                        ),
+                        ct
+                    );
+                if (!credentialAvailable)
+                {
+                    return BadRequest(new ProblemDetails
+                    {
+                        Title = "Selected credential is not compatible with this source or tenant.",
+                    });
+                }
             }
-
-            if (!string.IsNullOrWhiteSpace(secretValue))
-            {
-                secretRef = $"tenants/{tenant.Id}/sources/{source.Key}";
-
-                // Defer the actual vault write
-                pendingSecretWrites.Add(
-                    (
-                        secretRef,
-                        TenantSourceCatalog.GetSecretKeyName(source.Key),
-                        secretValue
-                    )
-                );
-            }
-
-            var oldSecretRef = existingSource?.SecretRef;
 
             if (existingSource is null)
             {
@@ -318,18 +312,12 @@ public class TenantsController : ControllerBase
                     source.DisplayName,
                     source.Enabled,
                     source.SyncSchedule,
-                    tenant.EntraTenantId,
-                    source.Credentials.ClientId,
-                    secretRef,
-                    source.Credentials.ApiBaseUrl,
-                    source.Credentials.TokenScope
+                    apiBaseUrl: source.Credentials.ApiBaseUrl,
+                    tokenScope: source.Credentials.TokenScope,
+                    storedCredentialId: storedCredentialId
                 );
                 await _dbContext.TenantSourceConfigurations.AddAsync(created, ct);
                 existingSources[source.Key] = created;
-                if (!string.IsNullOrWhiteSpace(secretValue))
-                {
-                    pendingSecretAudits.Add((created.Id, oldSecretRef, secretRef));
-                }
                 continue;
             }
 
@@ -337,51 +325,16 @@ public class TenantsController : ControllerBase
                 source.DisplayName,
                 source.Enabled,
                 source.SyncSchedule,
-                tenant.EntraTenantId,
-                source.Credentials.ClientId,
-                secretRef,
-                source.Credentials.ApiBaseUrl,
-                source.Credentials.TokenScope
+                credentialTenantId: string.Empty,
+                clientId: string.Empty,
+                secretRef: string.Empty,
+                apiBaseUrl: source.Credentials.ApiBaseUrl,
+                tokenScope: source.Credentials.TokenScope,
+                storedCredentialId: storedCredentialId
             );
-
-            if (
-                !string.IsNullOrWhiteSpace(secretValue)
-                && !string.Equals(oldSecretRef, secretRef, StringComparison.Ordinal)
-            )
-            {
-                pendingSecretAudits.Add((existingSource.Id, oldSecretRef, secretRef));
-            }
         }
 
         await _dbContext.SaveChangesAsync(ct);
-
-        // Write secrets to vault after DB commit succeeds
-        foreach (var (path, key, value) in pendingSecretWrites)
-        {
-            await _secretStore.PutSecretAsync(
-                path,
-                new Dictionary<string, string> { [key] = value },
-                ct
-            );
-        }
-
-        foreach (var (entityId, oldSecretRef, newSecretRef) in pendingSecretAudits)
-        {
-            await _auditLogWriter.WriteAsync(
-                tenant.Id,
-                "TenantSourceSecret",
-                entityId,
-                AuditAction.Updated,
-                string.IsNullOrWhiteSpace(oldSecretRef) ? null : new { SecretRef = oldSecretRef },
-                new { SecretRef = newSecretRef },
-                ct
-            );
-        }
-
-        if (pendingSecretAudits.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync(ct);
-        }
 
         return NoContent();
     }
@@ -767,6 +720,8 @@ public class TenantsController : ControllerBase
             TenantSourceCatalog.SupportsScheduling(source),
             TenantSourceCatalog.SupportsManualSync(source),
             new TenantSourceCredentialsDto(
+                source.StoredCredentialId,
+                TenantSourceCatalog.GetAcceptedCredentialTypes(source.SourceKey),
                 source.ClientId,
                 !string.IsNullOrWhiteSpace(source.SecretRef),
                 source.ApiBaseUrl,

--- a/src/PatchHound.Api/Models/Admin/TenantDto.cs
+++ b/src/PatchHound.Api/Models/Admin/TenantDto.cs
@@ -45,6 +45,8 @@ public record TenantIngestionSourceDto(
 );
 
 public record TenantSourceCredentialsDto(
+    Guid? StoredCredentialId,
+    IReadOnlyList<string> AcceptedCredentialTypes,
     string ClientId,
     bool HasSecret,
     string ApiBaseUrl,
@@ -121,6 +123,7 @@ public record UpdateTenantIngestionSourceRequest(
 );
 
 public record UpdateTenantSourceCredentialsRequest(
+    Guid? StoredCredentialId,
     string ClientId,
     string Secret,
     string ApiBaseUrl,

--- a/src/PatchHound.Api/Models/Credentials/StoredCredentialDtos.cs
+++ b/src/PatchHound.Api/Models/Credentials/StoredCredentialDtos.cs
@@ -1,0 +1,35 @@
+namespace PatchHound.Api.Models.Credentials;
+
+public record StoredCredentialDto(
+    Guid Id,
+    string Name,
+    string Type,
+    string TypeDisplayName,
+    bool IsGlobal,
+    string CredentialTenantId,
+    string ClientId,
+    IReadOnlyList<Guid> TenantIds,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);
+
+public record CreateStoredCredentialRequest(
+    string Name,
+    string Type,
+    bool IsGlobal,
+    string CredentialTenantId,
+    string ClientId,
+    string ClientSecret,
+    IReadOnlyList<Guid> TenantIds
+);
+
+public record UpdateStoredCredentialRequest(
+    string Name,
+    bool IsGlobal,
+    string CredentialTenantId,
+    string ClientId,
+    string? ClientSecret,
+    IReadOnlyList<Guid> TenantIds
+);
+
+public record AcceptedCredentialTypeDto(string Type, string DisplayName);

--- a/src/PatchHound.Api/Models/Integrations/SentinelConnectorDto.cs
+++ b/src/PatchHound.Api/Models/Integrations/SentinelConnectorDto.cs
@@ -5,8 +5,7 @@ public record SentinelConnectorDto(
     string DceEndpoint,
     string DcrImmutableId,
     string StreamName,
-    string TenantId,
-    string ClientId,
-    bool HasSecret,
+    Guid? StoredCredentialId,
+    string[] AcceptedCredentialTypes,
     DateTimeOffset? UpdatedAt
 );

--- a/src/PatchHound.Api/Models/Integrations/UpdateSentinelConnectorRequest.cs
+++ b/src/PatchHound.Api/Models/Integrations/UpdateSentinelConnectorRequest.cs
@@ -7,7 +7,5 @@ public record UpdateSentinelConnectorRequest(
     [MaxLength(512)] string DceEndpoint,
     [MaxLength(256)] string DcrImmutableId,
     [MaxLength(256)] string StreamName,
-    [MaxLength(128)] string TenantId,
-    [MaxLength(128)] string ClientId,
-    string? ClientSecret
+    Guid? StoredCredentialId
 );

--- a/src/PatchHound.Api/Models/System/EnrichmentSourceDtos.cs
+++ b/src/PatchHound.Api/Models/System/EnrichmentSourceDtos.cs
@@ -12,7 +12,12 @@ public record EnrichmentSourceDto(
     IReadOnlyList<EnrichmentRunDto> RecentRuns
 );
 
-public record EnrichmentSourceCredentialsDto(bool HasSecret, string ApiBaseUrl);
+public record EnrichmentSourceCredentialsDto(
+    Guid? StoredCredentialId,
+    IReadOnlyList<string> AcceptedCredentialTypes,
+    bool HasSecret,
+    string ApiBaseUrl
+);
 
 public record EnrichmentSourceRuntimeDto(
     DateTimeOffset? LastStartedAt,
@@ -51,4 +56,8 @@ public record UpdateEnrichmentSourceRequest(
     UpdateEnrichmentSourceCredentialsRequest Credentials
 );
 
-public record UpdateEnrichmentSourceCredentialsRequest(string Secret, string ApiBaseUrl);
+public record UpdateEnrichmentSourceCredentialsRequest(
+    Guid? StoredCredentialId,
+    string Secret,
+    string ApiBaseUrl
+);

--- a/src/PatchHound.Core/Entities/EnrichmentSourceConfiguration.cs
+++ b/src/PatchHound.Core/Entities/EnrichmentSourceConfiguration.cs
@@ -8,6 +8,7 @@ public class EnrichmentSourceConfiguration
     public bool Enabled { get; private set; }
     public string SecretRef { get; private set; } = string.Empty;
     public string ApiBaseUrl { get; private set; } = string.Empty;
+    public Guid? StoredCredentialId { get; private set; }
     public int? RefreshTtlHours { get; private set; }
     public Guid? ActiveEnrichmentRunId { get; private set; }
     public DateTimeOffset? LeaseAcquiredAt { get; private set; }
@@ -26,6 +27,7 @@ public class EnrichmentSourceConfiguration
         bool enabled,
         string secretRef = "",
         string apiBaseUrl = "",
+        Guid? storedCredentialId = null,
         int? refreshTtlHours = null
     )
     {
@@ -37,6 +39,7 @@ public class EnrichmentSourceConfiguration
             Enabled = enabled,
             SecretRef = secretRef,
             ApiBaseUrl = apiBaseUrl,
+            StoredCredentialId = storedCredentialId,
             RefreshTtlHours = refreshTtlHours,
         };
     }
@@ -46,6 +49,7 @@ public class EnrichmentSourceConfiguration
         bool enabled,
         string secretRef,
         string apiBaseUrl,
+        Guid? storedCredentialId,
         int? refreshTtlHours
     )
     {
@@ -53,6 +57,7 @@ public class EnrichmentSourceConfiguration
         Enabled = enabled;
         SecretRef = secretRef;
         ApiBaseUrl = apiBaseUrl;
+        StoredCredentialId = storedCredentialId;
         RefreshTtlHours = refreshTtlHours;
     }
 

--- a/src/PatchHound.Core/Entities/SentinelConnectorConfiguration.cs
+++ b/src/PatchHound.Core/Entities/SentinelConnectorConfiguration.cs
@@ -7,9 +7,8 @@ public class SentinelConnectorConfiguration
     public string DceEndpoint { get; private set; } = string.Empty;
     public string DcrImmutableId { get; private set; } = string.Empty;
     public string StreamName { get; private set; } = string.Empty;
-    public string TenantId { get; private set; } = string.Empty;
-    public string ClientId { get; private set; } = string.Empty;
-    public string SecretRef { get; private set; } = string.Empty;
+    public Guid? StoredCredentialId { get; private set; }
+    public StoredCredential? StoredCredential { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
     private SentinelConnectorConfiguration() { }
@@ -19,9 +18,7 @@ public class SentinelConnectorConfiguration
         string dceEndpoint,
         string dcrImmutableId,
         string streamName,
-        string tenantId,
-        string clientId,
-        string secretRef
+        Guid? storedCredentialId
     )
     {
         return new SentinelConnectorConfiguration
@@ -31,9 +28,7 @@ public class SentinelConnectorConfiguration
             DceEndpoint = dceEndpoint,
             DcrImmutableId = dcrImmutableId,
             StreamName = streamName,
-            TenantId = tenantId,
-            ClientId = clientId,
-            SecretRef = secretRef,
+            StoredCredentialId = storedCredentialId,
             UpdatedAt = DateTimeOffset.UtcNow,
         };
     }
@@ -43,18 +38,14 @@ public class SentinelConnectorConfiguration
         string dceEndpoint,
         string dcrImmutableId,
         string streamName,
-        string tenantId,
-        string clientId,
-        string secretRef
+        Guid? storedCredentialId
     )
     {
         Enabled = enabled;
         DceEndpoint = dceEndpoint;
         DcrImmutableId = dcrImmutableId;
         StreamName = streamName;
-        TenantId = tenantId;
-        ClientId = clientId;
-        SecretRef = secretRef;
+        StoredCredentialId = storedCredentialId;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/src/PatchHound.Core/Entities/StoredCredential.cs
+++ b/src/PatchHound.Core/Entities/StoredCredential.cs
@@ -1,0 +1,73 @@
+namespace PatchHound.Core.Entities;
+
+public class StoredCredential
+{
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Type { get; private set; } = string.Empty;
+    public bool IsGlobal { get; private set; }
+    public string CredentialTenantId { get; private set; } = string.Empty;
+    public string ClientId { get; private set; } = string.Empty;
+    public string SecretRef { get; private set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public ICollection<StoredCredentialTenant> TenantScopes { get; private set; } =
+        new List<StoredCredentialTenant>();
+
+    private StoredCredential() { }
+
+    public static StoredCredential Create(
+        string name,
+        string type,
+        bool isGlobal,
+        string credentialTenantId,
+        string clientId,
+        string secretRef,
+        DateTimeOffset now,
+        Guid? id = null
+    )
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException(nameof(name));
+        if (string.IsNullOrWhiteSpace(type)) throw new ArgumentException(nameof(type));
+        if (string.IsNullOrWhiteSpace(secretRef)) throw new ArgumentException(nameof(secretRef));
+
+        return new StoredCredential
+        {
+            Id = id ?? Guid.NewGuid(),
+            Name = name.Trim(),
+            Type = type.Trim(),
+            IsGlobal = isGlobal,
+            CredentialTenantId = credentialTenantId.Trim(),
+            ClientId = clientId.Trim(),
+            SecretRef = secretRef.Trim(),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Update(
+        string name,
+        bool isGlobal,
+        string credentialTenantId,
+        string clientId,
+        DateTimeOffset now
+    )
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException(nameof(name));
+
+        Name = name.Trim();
+        IsGlobal = isGlobal;
+        CredentialTenantId = credentialTenantId.Trim();
+        ClientId = clientId.Trim();
+        UpdatedAt = now;
+    }
+
+    public void ReplaceSecretRef(string secretRef, DateTimeOffset now)
+    {
+        if (string.IsNullOrWhiteSpace(secretRef)) throw new ArgumentException(nameof(secretRef));
+
+        SecretRef = secretRef.Trim();
+        UpdatedAt = now;
+    }
+}

--- a/src/PatchHound.Core/Entities/StoredCredentialTenant.cs
+++ b/src/PatchHound.Core/Entities/StoredCredentialTenant.cs
@@ -1,0 +1,24 @@
+namespace PatchHound.Core.Entities;
+
+public class StoredCredentialTenant
+{
+    public Guid StoredCredentialId { get; private set; }
+    public Guid TenantId { get; private set; }
+
+    public StoredCredential StoredCredential { get; private set; } = null!;
+    public Tenant Tenant { get; private set; } = null!;
+
+    private StoredCredentialTenant() { }
+
+    public static StoredCredentialTenant Create(Guid storedCredentialId, Guid tenantId)
+    {
+        if (storedCredentialId == Guid.Empty) throw new ArgumentException(nameof(storedCredentialId));
+        if (tenantId == Guid.Empty) throw new ArgumentException(nameof(tenantId));
+
+        return new StoredCredentialTenant
+        {
+            StoredCredentialId = storedCredentialId,
+            TenantId = tenantId,
+        };
+    }
+}

--- a/src/PatchHound.Core/Entities/TenantSourceConfiguration.cs
+++ b/src/PatchHound.Core/Entities/TenantSourceConfiguration.cs
@@ -14,6 +14,7 @@ public class TenantSourceConfiguration
     public string ApiBaseUrl { get; private set; } = string.Empty;
     public string TokenScope { get; private set; } = string.Empty;
     public string? LinkedSourceKey { get; private set; }
+    public Guid? StoredCredentialId { get; private set; }
     public DateTimeOffset? ManualRequestedAt { get; private set; }
     public DateTimeOffset? LastStartedAt { get; private set; }
     public DateTimeOffset? LastCompletedAt { get; private set; }
@@ -39,7 +40,8 @@ public class TenantSourceConfiguration
         string secretRef = "",
         string apiBaseUrl = "",
         string tokenScope = "",
-        string? linkedSourceKey = null
+        string? linkedSourceKey = null,
+        Guid? storedCredentialId = null
     )
     {
         return new TenantSourceConfiguration
@@ -56,6 +58,7 @@ public class TenantSourceConfiguration
             ApiBaseUrl = apiBaseUrl,
             TokenScope = tokenScope,
             LinkedSourceKey = linkedSourceKey,
+            StoredCredentialId = storedCredentialId,
         };
     }
 
@@ -68,7 +71,8 @@ public class TenantSourceConfiguration
         string secretRef,
         string apiBaseUrl,
         string tokenScope,
-        string? linkedSourceKey = null
+        string? linkedSourceKey = null,
+        Guid? storedCredentialId = null
     )
     {
         DisplayName = displayName;
@@ -80,6 +84,7 @@ public class TenantSourceConfiguration
         ApiBaseUrl = apiBaseUrl;
         TokenScope = tokenScope;
         LinkedSourceKey = string.IsNullOrWhiteSpace(linkedSourceKey) ? null : linkedSourceKey;
+        StoredCredentialId = storedCredentialId;
     }
 
     public void UpdateRuntime(

--- a/src/PatchHound.Infrastructure/CredentialSources/EntraApplicationsConfigurationProvider.cs
+++ b/src/PatchHound.Infrastructure/CredentialSources/EntraApplicationsConfigurationProvider.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Data;
-using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Infrastructure.Tenants;
 
@@ -8,7 +8,7 @@ namespace PatchHound.Infrastructure.CredentialSources;
 
 public class EntraApplicationsConfigurationProvider(
     PatchHoundDbContext dbContext,
-    ISecretStore secretStore
+    StoredCredentialResolver credentialResolver
 )
 {
     public virtual async Task<EntraClientConfiguration?> GetConfigurationAsync(
@@ -30,38 +30,27 @@ public class EntraApplicationsConfigurationProvider(
         if (!string.IsNullOrWhiteSpace(source.LinkedSourceKey))
             return await ResolveFromLinkedSourceAsync(tenantId, source.LinkedSourceKey, source.ApiBaseUrl, source.TokenScope, ct);
 
-        if (!TenantSourceCatalog.HasConfiguredCredentials(source))
+        if (!source.StoredCredentialId.HasValue)
         {
-            var hasAnyCredentialInput =
-                !string.IsNullOrWhiteSpace(source.CredentialTenantId)
-                || !string.IsNullOrWhiteSpace(source.ClientId)
-                || !string.IsNullOrWhiteSpace(source.SecretRef);
-
-            if (hasAnyCredentialInput)
-                throw new IngestionTerminalException(
-                    "Entra Applications source is enabled but credentials are incomplete."
-                );
-
             return null;
         }
 
-        var clientSecret = string.Empty;
-        if (!string.IsNullOrWhiteSpace(source.SecretRef))
-            clientSecret = await secretStore.GetSecretAsync(source.SecretRef, "clientSecret", ct) ?? string.Empty;
-
-        if (string.IsNullOrWhiteSpace(source.CredentialTenantId)
-            || string.IsNullOrWhiteSpace(source.ClientId)
-            || string.IsNullOrWhiteSpace(clientSecret))
+        var credential = await credentialResolver.ResolveEntraClientSecretAsync(
+            source.StoredCredentialId.Value,
+            tenantId,
+            ct
+        );
+        if (credential is null)
         {
             throw new IngestionTerminalException(
-                "Entra Applications source credentials could not be resolved."
+                "Entra Applications source credential could not be resolved or is not available to this tenant."
             );
         }
 
         return new EntraClientConfiguration(
-            source.CredentialTenantId,
-            source.ClientId,
-            clientSecret,
+            credential.TenantId,
+            credential.ClientId,
+            credential.ClientSecret,
             source.ApiBaseUrl,
             source.TokenScope
         );
@@ -78,18 +67,17 @@ public class EntraApplicationsConfigurationProvider(
         var linked = await dbContext.TenantSourceConfigurations.AsNoTracking()
             .FirstOrDefaultAsync(s => s.TenantId == tenantId && s.SourceKey == linkedSourceKey, ct);
 
-        if (linked is null || !TenantSourceCatalog.HasConfiguredCredentials(linked))
+        if (linked is null || !linked.StoredCredentialId.HasValue)
             throw new IngestionTerminalException(
                 $"Entra Applications source is linked to '{linkedSourceKey}' but that source has no configured credentials."
             );
 
-        var clientSecret = string.Empty;
-        if (!string.IsNullOrWhiteSpace(linked.SecretRef))
-            clientSecret = await secretStore.GetSecretAsync(linked.SecretRef, "clientSecret", ct) ?? string.Empty;
-
-        if (string.IsNullOrWhiteSpace(linked.CredentialTenantId)
-            || string.IsNullOrWhiteSpace(linked.ClientId)
-            || string.IsNullOrWhiteSpace(clientSecret))
+        var credential = await credentialResolver.ResolveEntraClientSecretAsync(
+            linked.StoredCredentialId.Value,
+            tenantId,
+            ct
+        );
+        if (credential is null)
         {
             throw new IngestionTerminalException(
                 $"Entra Applications source could not resolve credentials from linked source '{linkedSourceKey}'."
@@ -97,9 +85,9 @@ public class EntraApplicationsConfigurationProvider(
         }
 
         return new EntraClientConfiguration(
-            linked.CredentialTenantId,
-            linked.ClientId,
-            clientSecret,
+            credential.TenantId,
+            credential.ClientId,
+            credential.ClientSecret,
             string.IsNullOrWhiteSpace(apiBaseUrl) ? TenantSourceCatalog.DefaultEntraApplicationsApiBaseUrl : apiBaseUrl,
             string.IsNullOrWhiteSpace(tokenScope) ? TenantSourceCatalog.DefaultEntraApplicationsTokenScope : tokenScope
         );

--- a/src/PatchHound.Infrastructure/Credentials/StoredCredentialResolver.cs
+++ b/src/PatchHound.Infrastructure/Credentials/StoredCredentialResolver.cs
@@ -84,6 +84,29 @@ public class StoredCredentialResolver(
             clientSecret
         );
     }
+
+    public async Task<string?> ResolveGlobalApiKeyAsync(Guid credentialId, CancellationToken ct)
+    {
+        var credential = await dbContext.StoredCredentials.AsNoTracking()
+            .FirstOrDefaultAsync(
+                item =>
+                    item.Id == credentialId
+                    && item.Type == StoredCredentialTypes.ApiKey
+                    && item.IsGlobal,
+                ct
+            );
+
+        if (credential is null)
+            return null;
+
+        var apiKey = await secretStore.GetSecretAsync(
+            credential.SecretRef,
+            StoredCredentialSecretKeys.ApiKey,
+            ct
+        ) ?? string.Empty;
+
+        return string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
+    }
 }
 
 public sealed record EntraStoredCredential(
@@ -94,5 +117,6 @@ public sealed record EntraStoredCredential(
 
 public static class StoredCredentialSecretKeys
 {
+    public const string ApiKey = "apiKey";
     public const string ClientSecret = "clientSecret";
 }

--- a/src/PatchHound.Infrastructure/Credentials/StoredCredentialResolver.cs
+++ b/src/PatchHound.Infrastructure/Credentials/StoredCredentialResolver.cs
@@ -1,0 +1,98 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Secrets;
+
+namespace PatchHound.Infrastructure.Credentials;
+
+public class StoredCredentialResolver(
+    PatchHoundDbContext dbContext,
+    ISecretStore secretStore
+)
+{
+    public async Task<EntraStoredCredential?> ResolveEntraClientSecretAsync(
+        Guid credentialId,
+        Guid tenantId,
+        CancellationToken ct
+    )
+    {
+        var credential = await dbContext.StoredCredentials.AsNoTracking()
+            .Include(item => item.TenantScopes)
+            .FirstOrDefaultAsync(
+                item =>
+                    item.Id == credentialId
+                    && item.Type == StoredCredentialTypes.EntraClientSecret
+                    && (item.IsGlobal || item.TenantScopes.Any(scope => scope.TenantId == tenantId)),
+                ct
+            );
+
+        if (credential is null)
+            return null;
+
+        var clientSecret = await secretStore.GetSecretAsync(
+            credential.SecretRef,
+            StoredCredentialSecretKeys.ClientSecret,
+            ct
+        ) ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(credential.CredentialTenantId)
+            || string.IsNullOrWhiteSpace(credential.ClientId)
+            || string.IsNullOrWhiteSpace(clientSecret))
+        {
+            return null;
+        }
+
+        return new EntraStoredCredential(
+            credential.CredentialTenantId,
+            credential.ClientId,
+            clientSecret
+        );
+    }
+
+    public async Task<EntraStoredCredential?> ResolveGlobalEntraClientSecretAsync(
+        Guid credentialId,
+        CancellationToken ct
+    )
+    {
+        var credential = await dbContext.StoredCredentials.AsNoTracking()
+            .FirstOrDefaultAsync(
+                item =>
+                    item.Id == credentialId
+                    && item.Type == StoredCredentialTypes.EntraClientSecret
+                    && item.IsGlobal,
+                ct
+            );
+
+        if (credential is null)
+            return null;
+
+        var clientSecret = await secretStore.GetSecretAsync(
+            credential.SecretRef,
+            StoredCredentialSecretKeys.ClientSecret,
+            ct
+        ) ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(credential.CredentialTenantId)
+            || string.IsNullOrWhiteSpace(credential.ClientId)
+            || string.IsNullOrWhiteSpace(clientSecret))
+        {
+            return null;
+        }
+
+        return new EntraStoredCredential(
+            credential.CredentialTenantId,
+            credential.ClientId,
+            clientSecret
+        );
+    }
+}
+
+public sealed record EntraStoredCredential(
+    string TenantId,
+    string ClientId,
+    string ClientSecret
+);
+
+public static class StoredCredentialSecretKeys
+{
+    public const string ClientSecret = "clientSecret";
+}

--- a/src/PatchHound.Infrastructure/Credentials/StoredCredentialTypes.cs
+++ b/src/PatchHound.Infrastructure/Credentials/StoredCredentialTypes.cs
@@ -3,9 +3,12 @@ namespace PatchHound.Infrastructure.Credentials;
 public static class StoredCredentialTypes
 {
     public const string EntraClientSecret = "entra-client-secret";
+    public const string ApiKey = "api-key";
 
     public static string GetDisplayName(string type) =>
         string.Equals(type, EntraClientSecret, StringComparison.OrdinalIgnoreCase)
             ? "Entra ID identity"
+            : string.Equals(type, ApiKey, StringComparison.OrdinalIgnoreCase)
+                ? "API key"
             : type;
 }

--- a/src/PatchHound.Infrastructure/Credentials/StoredCredentialTypes.cs
+++ b/src/PatchHound.Infrastructure/Credentials/StoredCredentialTypes.cs
@@ -1,0 +1,11 @@
+namespace PatchHound.Infrastructure.Credentials;
+
+public static class StoredCredentialTypes
+{
+    public const string EntraClientSecret = "entra-client-secret";
+
+    public static string GetDisplayName(string type) =>
+        string.Equals(type, EntraClientSecret, StringComparison.OrdinalIgnoreCase)
+            ? "Entra ID identity"
+            : type;
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/EnrichmentSourceConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/EnrichmentSourceConfiguration.cs
@@ -17,8 +17,15 @@ public class EnrichmentSourceConfigurationConfiguration
         builder.Property(source => source.DisplayName).HasMaxLength(256).IsRequired();
         builder.Property(source => source.SecretRef).HasMaxLength(512).IsRequired();
         builder.Property(source => source.ApiBaseUrl).HasMaxLength(512).IsRequired();
+        builder.Property(source => source.StoredCredentialId);
         builder.HasIndex(source => source.ActiveEnrichmentRunId);
+        builder.HasIndex(source => source.StoredCredentialId);
         builder.Property(source => source.LastStatus).HasMaxLength(64).IsRequired();
         builder.Property(source => source.LastError).HasMaxLength(512).IsRequired();
+
+        builder.HasOne<StoredCredential>()
+            .WithMany()
+            .HasForeignKey(source => source.StoredCredentialId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/PatchHound.Infrastructure/Data/Configurations/SentinelConnectorConfigurationConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/SentinelConnectorConfigurationConfiguration.cs
@@ -14,8 +14,10 @@ public class SentinelConnectorConfigurationConfiguration
         builder.Property(c => c.DceEndpoint).HasMaxLength(512);
         builder.Property(c => c.DcrImmutableId).HasMaxLength(256);
         builder.Property(c => c.StreamName).HasMaxLength(256);
-        builder.Property(c => c.TenantId).HasMaxLength(128);
-        builder.Property(c => c.ClientId).HasMaxLength(128);
-        builder.Property(c => c.SecretRef).HasMaxLength(256);
+
+        builder.HasOne(c => c.StoredCredential)
+            .WithMany()
+            .HasForeignKey(c => c.StoredCredentialId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/PatchHound.Infrastructure/Data/Configurations/StoredCredentialConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/StoredCredentialConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class StoredCredentialConfiguration : IEntityTypeConfiguration<StoredCredential>
+{
+    public void Configure(EntityTypeBuilder<StoredCredential> builder)
+    {
+        builder.HasKey(credential => credential.Id);
+
+        builder.Property(credential => credential.Name).HasMaxLength(160).IsRequired();
+        builder.Property(credential => credential.Type).HasMaxLength(80).IsRequired();
+        builder.Property(credential => credential.CredentialTenantId).HasMaxLength(256);
+        builder.Property(credential => credential.ClientId).HasMaxLength(256);
+        builder.Property(credential => credential.SecretRef).HasMaxLength(512).IsRequired();
+
+        builder.HasIndex(credential => credential.Type);
+        builder.HasIndex(credential => credential.IsGlobal);
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/StoredCredentialTenantConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/StoredCredentialTenantConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class StoredCredentialTenantConfiguration : IEntityTypeConfiguration<StoredCredentialTenant>
+{
+    public void Configure(EntityTypeBuilder<StoredCredentialTenant> builder)
+    {
+        builder.HasKey(scope => new { scope.StoredCredentialId, scope.TenantId });
+
+        builder.HasOne(scope => scope.StoredCredential)
+            .WithMany(credential => credential.TenantScopes)
+            .HasForeignKey(scope => scope.StoredCredentialId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(scope => scope.Tenant)
+            .WithMany()
+            .HasForeignKey(scope => scope.TenantId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(scope => scope.TenantId);
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/TenantSourceConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/TenantSourceConfiguration.cs
@@ -24,6 +24,7 @@ public class TenantSourceConfigurationConfiguration
         builder.Property(source => source.ActiveIngestionRunId);
         builder.Property(source => source.ActiveSnapshotId);
         builder.Property(source => source.BuildingSnapshotId);
+        builder.Property(source => source.StoredCredentialId);
         builder.Property(source => source.LeaseAcquiredAt);
         builder.Property(source => source.LeaseExpiresAt);
         builder.Property(source => source.LinkedSourceKey).HasMaxLength(128);
@@ -32,5 +33,11 @@ public class TenantSourceConfigurationConfiguration
 
         builder.HasIndex(source => source.ActiveSnapshotId);
         builder.HasIndex(source => source.BuildingSnapshotId);
+        builder.HasIndex(source => source.StoredCredentialId);
+
+        builder.HasOne<StoredCredential>()
+            .WithMany()
+            .HasForeignKey(source => source.StoredCredentialId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+++ b/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
@@ -36,6 +36,8 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
     public DbSet<SecurityProfile> SecurityProfiles => Set<SecurityProfile>();
     public DbSet<TenantSourceConfiguration> TenantSourceConfigurations =>
         Set<TenantSourceConfiguration>();
+    public DbSet<StoredCredential> StoredCredentials => Set<StoredCredential>();
+    public DbSet<StoredCredentialTenant> StoredCredentialTenants => Set<StoredCredentialTenant>();
     public DbSet<IngestionRun> IngestionRuns => Set<IngestionRun>();
     public DbSet<IngestionSnapshot> IngestionSnapshots => Set<IngestionSnapshot>();
     public DbSet<IngestionCheckpoint> IngestionCheckpoints => Set<IngestionCheckpoint>();
@@ -284,6 +286,16 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<TenantSourceConfiguration>()
+            .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+        modelBuilder
+            .Entity<StoredCredential>()
+            .HasQueryFilter(e =>
+                IsSystemContext
+                || e.IsGlobal
+                || e.TenantScopes.Any(scope => AccessibleTenantIds.Contains(scope.TenantId))
+            );
+        modelBuilder
+            .Entity<StoredCredentialTenant>()
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<IngestionRun>()

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -177,6 +177,7 @@ public static class DependencyInjection
             .AddHttpClient<ISecretStore, OpenBaoSecretStore>()
             .AddExternalHttpPolicies(maxConnectionsPerServer: 4);
         services.AddScoped<DefenderTenantConfigurationProvider>();
+        services.AddScoped<PatchHound.Infrastructure.Credentials.StoredCredentialResolver>();
         services.AddScoped<EntraApplicationsConfigurationProvider>();
         services
             .AddHttpClient<EntraGraphApiClient>()

--- a/src/PatchHound.Infrastructure/Migrations/20260425203243_AddStoredCredentials.Designer.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260425203243_AddStoredCredentials.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425203243_AddStoredCredentials")]
+    partial class AddStoredCredentials
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Migrations/20260425203243_AddStoredCredentials.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260425203243_AddStoredCredentials.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoredCredentials : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClientId",
+                table: "SentinelConnectorConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "SecretRef",
+                table: "SentinelConnectorConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                table: "SentinelConnectorConfigurations");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "StoredCredentialId",
+                table: "TenantSourceConfigurations",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "StoredCredentialId",
+                table: "SentinelConnectorConfigurations",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "StoredCredentialId",
+                table: "EnrichmentSourceConfigurations",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "StoredCredentials",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: false),
+                    Type = table.Column<string>(type: "character varying(80)", maxLength: 80, nullable: false),
+                    IsGlobal = table.Column<bool>(type: "boolean", nullable: false),
+                    CredentialTenantId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ClientId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    SecretRef = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StoredCredentials", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StoredCredentialTenants",
+                columns: table => new
+                {
+                    StoredCredentialId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StoredCredentialTenants", x => new { x.StoredCredentialId, x.TenantId });
+                    table.ForeignKey(
+                        name: "FK_StoredCredentialTenants_StoredCredentials_StoredCredentialId",
+                        column: x => x.StoredCredentialId,
+                        principalTable: "StoredCredentials",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_StoredCredentialTenants_Tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "Tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantSourceConfigurations_StoredCredentialId",
+                table: "TenantSourceConfigurations",
+                column: "StoredCredentialId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SentinelConnectorConfigurations_StoredCredentialId",
+                table: "SentinelConnectorConfigurations",
+                column: "StoredCredentialId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EnrichmentSourceConfigurations_StoredCredentialId",
+                table: "EnrichmentSourceConfigurations",
+                column: "StoredCredentialId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredCredentials_IsGlobal",
+                table: "StoredCredentials",
+                column: "IsGlobal");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredCredentials_Type",
+                table: "StoredCredentials",
+                column: "Type");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredCredentialTenants_TenantId",
+                table: "StoredCredentialTenants",
+                column: "TenantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EnrichmentSourceConfigurations_StoredCredentials_StoredCred~",
+                table: "EnrichmentSourceConfigurations",
+                column: "StoredCredentialId",
+                principalTable: "StoredCredentials",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SentinelConnectorConfigurations_StoredCredentials_StoredCre~",
+                table: "SentinelConnectorConfigurations",
+                column: "StoredCredentialId",
+                principalTable: "StoredCredentials",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TenantSourceConfigurations_StoredCredentials_StoredCredenti~",
+                table: "TenantSourceConfigurations",
+                column: "StoredCredentialId",
+                principalTable: "StoredCredentials",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_EnrichmentSourceConfigurations_StoredCredentials_StoredCred~",
+                table: "EnrichmentSourceConfigurations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SentinelConnectorConfigurations_StoredCredentials_StoredCre~",
+                table: "SentinelConnectorConfigurations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TenantSourceConfigurations_StoredCredentials_StoredCredenti~",
+                table: "TenantSourceConfigurations");
+
+            migrationBuilder.DropTable(
+                name: "StoredCredentialTenants");
+
+            migrationBuilder.DropTable(
+                name: "StoredCredentials");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TenantSourceConfigurations_StoredCredentialId",
+                table: "TenantSourceConfigurations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SentinelConnectorConfigurations_StoredCredentialId",
+                table: "SentinelConnectorConfigurations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_EnrichmentSourceConfigurations_StoredCredentialId",
+                table: "EnrichmentSourceConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "StoredCredentialId",
+                table: "TenantSourceConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "StoredCredentialId",
+                table: "SentinelConnectorConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "StoredCredentialId",
+                table: "EnrichmentSourceConfigurations");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ClientId",
+                table: "SentinelConnectorConfigurations",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SecretRef",
+                table: "SentinelConnectorConfigurations",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TenantId",
+                table: "SentinelConnectorConfigurations",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/NvdFeedSyncService.cs
+++ b/src/PatchHound.Infrastructure/Services/NvdFeedSyncService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Tenants;
@@ -13,6 +14,7 @@ public class NvdFeedSyncService(
     HttpClient httpClient,
     PatchHoundDbContext db,
     ISecretStore secretStore,
+    StoredCredentialResolver credentialResolver,
     ILogger<NvdFeedSyncService> logger)
 {
     private const string FeedBaseUrl = "https://nvd.nist.gov/feeds/json/cve/2.0";
@@ -218,13 +220,36 @@ public class NvdFeedSyncService(
             var source = await db.EnrichmentSourceConfigurations
                 .FirstOrDefaultAsync(s => s.SourceKey == EnrichmentSourceCatalog.NvdSourceKey, ct);
 
-            if (source is null || string.IsNullOrWhiteSpace(source.SecretRef))
+            if (source is null)
+            {
+                logger.LogDebug("NVD source is not configured; proceeding without API key.");
+                return null;
+            }
+
+            if (source.StoredCredentialId.HasValue)
+            {
+                var apiKey = await credentialResolver.ResolveGlobalApiKeyAsync(
+                    source.StoredCredentialId.Value,
+                    ct
+                );
+
+                if (!string.IsNullOrWhiteSpace(apiKey))
+                    return apiKey;
+
+                logger.LogWarning(
+                    "NVD source references stored credential {CredentialId}, but no API key could be resolved; proceeding without key.",
+                    source.StoredCredentialId.Value
+                );
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(source.SecretRef))
             {
                 logger.LogDebug("NVD source has no SecretRef configured; proceeding without API key.");
                 return null;
             }
 
-            return await secretStore.GetSecretAsync(source.SecretRef, "apiKey", ct);
+            return await secretStore.GetSecretAsync(source.SecretRef, StoredCredentialSecretKeys.ApiKey, ct);
         }
         catch (Exception ex)
         {

--- a/src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
@@ -15,6 +15,14 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
         CancellationToken ct
     )
     {
+        var localExisting = dbContext.RemediationWorkflows.Local
+            .FirstOrDefault(workflow =>
+                workflow.TenantId == tenantId
+                && workflow.RemediationCaseId == remediationCaseId
+                && workflow.Status == RemediationWorkflowStatus.Active);
+        if (localExisting is not null)
+            return localExisting;
+
         var existing = await dbContext.RemediationWorkflows
             .FirstOrDefaultAsync(workflow =>
                 workflow.TenantId == tenantId

--- a/src/PatchHound.Infrastructure/Services/SentinelConnectorWorker.cs
+++ b/src/PatchHound.Infrastructure/Services/SentinelConnectorWorker.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Data;
-using PatchHound.Infrastructure.Secrets;
 
 namespace PatchHound.Infrastructure.Services;
 
@@ -33,6 +33,7 @@ public sealed class SentinelConnectorWorker : BackgroundService
     private IConfidentialClientApplication? _msalApp;
     private string _cachedClientId = string.Empty;
     private string _cachedTenantId = string.Empty;
+    private Guid? _cachedStoredCredentialId;
 
     public SentinelConnectorWorker(
         SentinelAuditQueue queue,
@@ -56,6 +57,13 @@ public sealed class SentinelConnectorWorker : BackgroundService
             var config = await LoadConfigAsync(stoppingToken);
 
             if (config is null || !config.Enabled)
+            {
+                await DrainAsync(stoppingToken);
+                await DelayOrDrain(ConfigPollInterval, stoppingToken);
+                continue;
+            }
+
+            if (!config.StoredCredentialId.HasValue)
             {
                 await DrainAsync(stoppingToken);
                 await DelayOrDrain(ConfigPollInterval, stoppingToken);
@@ -163,37 +171,41 @@ public sealed class SentinelConnectorWorker : BackgroundService
         CancellationToken ct
     )
     {
+        var credential = await LoadCredentialAsync(config, ct);
         if (
             _msalApp is null
-            || _cachedClientId != config.ClientId
-            || _cachedTenantId != config.TenantId
+            || _cachedStoredCredentialId != config.StoredCredentialId
+            || _cachedClientId != credential.ClientId
+            || _cachedTenantId != credential.TenantId
         )
         {
-            var secret = await LoadClientSecretAsync(config, ct);
             _msalApp = ConfidentialClientApplicationBuilder
-                .Create(config.ClientId)
-                .WithClientSecret(secret)
-                .WithAuthority($"https://login.microsoftonline.com/{config.TenantId}")
+                .Create(credential.ClientId)
+                .WithClientSecret(credential.ClientSecret)
+                .WithAuthority($"https://login.microsoftonline.com/{credential.TenantId}")
                 .Build();
-            _cachedClientId = config.ClientId;
-            _cachedTenantId = config.TenantId;
+            _cachedStoredCredentialId = config.StoredCredentialId;
+            _cachedClientId = credential.ClientId;
+            _cachedTenantId = credential.TenantId;
         }
 
         var result = await _msalApp.AcquireTokenForClient(MonitorScope).ExecuteAsync(ct);
         return result.AccessToken;
     }
 
-    private async Task<string> LoadClientSecretAsync(
+    private async Task<EntraStoredCredential> LoadCredentialAsync(
         SentinelConnectorConfiguration config,
         CancellationToken ct
     )
     {
+        if (!config.StoredCredentialId.HasValue)
+            throw new InvalidOperationException("Sentinel connector requires a stored credential.");
+
         using var scope = _scopeFactory.CreateScope();
-        var secretStore = scope.ServiceProvider.GetRequiredService<ISecretStore>();
-        var value = await secretStore.GetSecretAsync(config.SecretRef, "clientSecret", ct);
-        return value
+        var resolver = scope.ServiceProvider.GetRequiredService<StoredCredentialResolver>();
+        return await resolver.ResolveGlobalEntraClientSecretAsync(config.StoredCredentialId.Value, ct)
             ?? throw new InvalidOperationException(
-                $"Client secret not found at vault path '{config.SecretRef}'"
+                $"Stored credential '{config.StoredCredentialId}' could not be resolved for Sentinel."
             );
     }
 

--- a/src/PatchHound.Infrastructure/Tenants/EnrichmentSourceCatalog.cs
+++ b/src/PatchHound.Infrastructure/Tenants/EnrichmentSourceCatalog.cs
@@ -93,8 +93,12 @@ public static class EnrichmentSourceCatalog
 
     public static IReadOnlyList<string> GetAcceptedCredentialTypes(string sourceKey)
     {
-        return string.Equals(sourceKey, DefenderSourceKey, StringComparison.OrdinalIgnoreCase)
-            ? [StoredCredentialTypes.EntraClientSecret]
-            : [];
+        if (string.Equals(sourceKey, DefenderSourceKey, StringComparison.OrdinalIgnoreCase))
+            return [StoredCredentialTypes.EntraClientSecret];
+
+        if (string.Equals(sourceKey, NvdSourceKey, StringComparison.OrdinalIgnoreCase))
+            return [StoredCredentialTypes.ApiKey];
+
+        return [];
     }
 }

--- a/src/PatchHound.Infrastructure/Tenants/EnrichmentSourceCatalog.cs
+++ b/src/PatchHound.Infrastructure/Tenants/EnrichmentSourceCatalog.cs
@@ -1,4 +1,5 @@
 using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Credentials;
 
 namespace PatchHound.Infrastructure.Tenants;
 
@@ -88,5 +89,12 @@ public static class EnrichmentSourceCatalog
         return string.Equals(sourceKey, NvdSourceKey, StringComparison.OrdinalIgnoreCase)
             ? "apiKey"
             : "secret";
+    }
+
+    public static IReadOnlyList<string> GetAcceptedCredentialTypes(string sourceKey)
+    {
+        return string.Equals(sourceKey, DefenderSourceKey, StringComparison.OrdinalIgnoreCase)
+            ? [StoredCredentialTypes.EntraClientSecret]
+            : [];
     }
 }

--- a/src/PatchHound.Infrastructure/Tenants/TenantSourceCatalog.cs
+++ b/src/PatchHound.Infrastructure/Tenants/TenantSourceCatalog.cs
@@ -1,4 +1,5 @@
 using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Credentials;
 
 namespace PatchHound.Infrastructure.Tenants;
 
@@ -52,9 +53,20 @@ public static class TenantSourceCatalog
         if (!string.IsNullOrWhiteSpace(source.LinkedSourceKey))
             return true;
 
+        if (source.StoredCredentialId.HasValue)
+            return true;
+
         return !string.IsNullOrWhiteSpace(source.CredentialTenantId)
             && !string.IsNullOrWhiteSpace(source.ClientId)
             && !string.IsNullOrWhiteSpace(source.SecretRef);
+    }
+
+    public static IReadOnlyList<string> GetAcceptedCredentialTypes(string sourceKey)
+    {
+        return string.Equals(sourceKey, DefenderSourceKey, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(sourceKey, EntraApplicationsSourceKey, StringComparison.OrdinalIgnoreCase)
+                ? [StoredCredentialTypes.EntraClientSecret]
+                : [];
     }
 
     public static bool SupportsScheduling(TenantSourceConfiguration source) =>

--- a/src/PatchHound.Infrastructure/VulnerabilitySources/DefenderTenantConfigurationProvider.cs
+++ b/src/PatchHound.Infrastructure/VulnerabilitySources/DefenderTenantConfigurationProvider.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Infrastructure.Tenants;
@@ -9,15 +10,15 @@ namespace PatchHound.Infrastructure.VulnerabilitySources;
 public class DefenderTenantConfigurationProvider
 {
     private readonly PatchHoundDbContext _dbContext;
-    private readonly ISecretStore _secretStore;
+    private readonly StoredCredentialResolver _credentialResolver;
 
     public DefenderTenantConfigurationProvider(
         PatchHoundDbContext dbContext,
-        ISecretStore secretStore
+        StoredCredentialResolver credentialResolver
     )
     {
         _dbContext = dbContext;
-        _secretStore = secretStore;
+        _credentialResolver = credentialResolver;
     }
 
     public virtual async Task<DefenderClientConfiguration?> GetConfigurationAsync(
@@ -35,46 +36,27 @@ public class DefenderTenantConfigurationProvider
         if (source is null || !source.Enabled)
             return null;
 
-        if (!TenantSourceCatalog.HasConfiguredCredentials(source))
+        if (!source.StoredCredentialId.HasValue)
         {
-            var hasAnyCredentialInput =
-                !string.IsNullOrWhiteSpace(source.CredentialTenantId)
-                || !string.IsNullOrWhiteSpace(source.ClientId)
-                || !string.IsNullOrWhiteSpace(source.SecretRef);
-
-            if (hasAnyCredentialInput)
-            {
-                throw new IngestionTerminalException(
-                    "Microsoft Defender source is enabled but credentials are incomplete."
-                );
-            }
-
             return null;
         }
 
-        var clientSecret = string.Empty;
-        if (!string.IsNullOrWhiteSpace(source.SecretRef))
-        {
-            clientSecret =
-                await _secretStore.GetSecretAsync(source.SecretRef, "clientSecret", ct)
-                ?? string.Empty;
-        }
-
-        if (
-            string.IsNullOrWhiteSpace(source.CredentialTenantId)
-            || string.IsNullOrWhiteSpace(source.ClientId)
-            || string.IsNullOrWhiteSpace(clientSecret)
-        )
+        var credential = await _credentialResolver.ResolveEntraClientSecretAsync(
+            source.StoredCredentialId.Value,
+            tenantId,
+            ct
+        );
+        if (credential is null)
         {
             throw new IngestionTerminalException(
-                "Microsoft Defender source credentials could not be resolved."
+                "Microsoft Defender source credential could not be resolved or is not available to this tenant."
             );
         }
 
         return new DefenderClientConfiguration(
-            source.CredentialTenantId,
-            source.ClientId,
-            clientSecret,
+            credential.TenantId,
+            credential.ClientId,
+            credential.ClientSecret,
             source.ApiBaseUrl,
             source.TokenScope
         );

--- a/src/PatchHound.Worker/IngestionWorker.cs
+++ b/src/PatchHound.Worker/IngestionWorker.cs
@@ -144,6 +144,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
                 source.ApiBaseUrl,
                 source.TokenScope,
                 source.SyncSchedule,
+                source.StoredCredentialId,
                 source.ManualRequestedAt,
                 source.LastStartedAt,
                 source.LinkedSourceKey
@@ -209,9 +210,12 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
             );
     }
 
-    private static bool HasConfiguredCredentials(ScheduledSource source)
+    internal static bool HasConfiguredCredentials(ScheduledSource source)
     {
         if (!string.IsNullOrWhiteSpace(source.LinkedSourceKey))
+            return true;
+
+        if (source.StoredCredentialId.HasValue)
             return true;
 
         return !string.IsNullOrWhiteSpace(source.CredentialTenantId)
@@ -254,7 +258,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
         return nextOccurrence.HasValue && nextOccurrence.Value <= nowUtc.UtcDateTime;
     }
 
-    private sealed record ScheduledSource(
+    internal sealed record ScheduledSource(
         Guid Id,
         Guid TenantId,
         string TenantName,
@@ -266,6 +270,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
         string ApiBaseUrl,
         string TokenScope,
         string SyncSchedule,
+        Guid? StoredCredentialId,
         DateTimeOffset? ManualRequestedAt,
         DateTimeOffset? LastStartedAt,
         string? LinkedSourceKey = null

--- a/src/PatchHound.Worker/PatchHound.Worker.csproj
+++ b/src/PatchHound.Worker/PatchHound.Worker.csproj
@@ -3,6 +3,9 @@
     <UserSecretsId>dotnet-PatchHound.Worker-e581a381-1285-4971-b5b5-e747fa87d883</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="PatchHound.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Cronos" Version="0.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />

--- a/tests/PatchHound.Tests/Api/IntegrationsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/IntegrationsControllerTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Api.Models.Integrations;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Credentials;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class IntegrationsControllerTests : IDisposable
+{
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly IntegrationsController _controller;
+
+    public IntegrationsControllerTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+        _controller = new IntegrationsController(_dbContext);
+    }
+
+    [Fact]
+    public async Task UpdateSentinelConnector_WhenEnabledWithoutCredential_ReturnsValidationProblem()
+    {
+        var result = await _controller.UpdateSentinelConnector(
+            new UpdateSentinelConnectorRequest(
+                Enabled: true,
+                DceEndpoint: "https://example.ingest.monitor.azure.com",
+                DcrImmutableId: "dcr-123",
+                StreamName: "Custom-PatchHoundAuditLog",
+                StoredCredentialId: null
+            ),
+            CancellationToken.None
+        );
+
+        result.Should().BeOfType<ObjectResult>();
+        (await _dbContext.SentinelConnectorConfigurations.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task UpdateSentinelConnector_WhenCredentialIsNotGlobal_ReturnsValidationProblem()
+    {
+        var credential = StoredCredential.Create(
+            "Tenant credential",
+            StoredCredentialTypes.EntraClientSecret,
+            isGlobal: false,
+            credentialTenantId: "tenant",
+            clientId: "client",
+            secretRef: "secret/ref",
+            now: DateTimeOffset.UtcNow
+        );
+        await _dbContext.StoredCredentials.AddAsync(credential);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpdateSentinelConnector(
+            new UpdateSentinelConnectorRequest(
+                Enabled: true,
+                DceEndpoint: "https://example.ingest.monitor.azure.com",
+                DcrImmutableId: "dcr-123",
+                StreamName: "Custom-PatchHoundAuditLog",
+                StoredCredentialId: credential.Id
+            ),
+            CancellationToken.None
+        );
+
+        result.Should().BeOfType<ObjectResult>();
+        (await _dbContext.SentinelConnectorConfigurations.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task UpdateSentinelConnector_WhenGlobalCredentialProvided_SavesReference()
+    {
+        var credential = StoredCredential.Create(
+            "Global credential",
+            StoredCredentialTypes.EntraClientSecret,
+            isGlobal: true,
+            credentialTenantId: "tenant",
+            clientId: "client",
+            secretRef: "secret/ref",
+            now: DateTimeOffset.UtcNow
+        );
+        await _dbContext.StoredCredentials.AddAsync(credential);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpdateSentinelConnector(
+            new UpdateSentinelConnectorRequest(
+                Enabled: true,
+                DceEndpoint: " https://example.ingest.monitor.azure.com ",
+                DcrImmutableId: " dcr-123 ",
+                StreamName: " Custom-PatchHoundAuditLog ",
+                StoredCredentialId: credential.Id
+            ),
+            CancellationToken.None
+        );
+
+        result.Should().BeOfType<NoContentResult>();
+
+        var saved = await _dbContext.SentinelConnectorConfigurations.SingleAsync();
+        saved.Enabled.Should().BeTrue();
+        saved.StoredCredentialId.Should().Be(credential.Id);
+        saved.DceEndpoint.Should().Be("https://example.ingest.monitor.azure.com");
+        saved.DcrImmutableId.Should().Be("dcr-123");
+        saved.StreamName.Should().Be("Custom-PatchHoundAuditLog");
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/tests/PatchHound.Tests/Api/SettingsAuditControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/SettingsAuditControllerTests.cs
@@ -5,13 +5,16 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using PatchHound.Api.Controllers;
 using PatchHound.Api.Models.Admin;
+using PatchHound.Api.Models.Credentials;
 using PatchHound.Api.Models.System;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
+using PatchHound.Infrastructure.Tenants;
 using PatchHound.Tests.TestData;
 
 namespace PatchHound.Tests.Api;
@@ -55,69 +58,49 @@ public class SettingsAuditControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task UpdateTenant_WritesAuditEntry_ForTenantSourceSecretChange()
+    public async Task CreateStoredCredential_WritesAuditEntry_ForCredentialLifecycle()
     {
         var tenant = Tenant.Create("Tenant One", "entra-1");
         _tenantContext.CurrentTenantId.Returns(tenant.Id);
         _tenantContext.AccessibleTenantIds.Returns(new List<Guid> { tenant.Id });
         _tenantContext.HasAccessToTenant(tenant.Id).Returns(true);
-        var source = TenantSourceConfiguration.Create(
-            tenant.Id,
-            "microsoft-defender",
-            "Microsoft Defender",
-            true,
-            "0 */6 * * *",
-            "tenant",
-            "client",
-            "tenants/old/source",
-            "https://api.security.microsoft.com",
-            "scope"
-        );
 
-        await _dbContext.AddRangeAsync(tenant, source);
+        await _dbContext.AddAsync(tenant);
         await _dbContext.SaveChangesAsync();
 
-        var controller = new TenantsController(
+        var controller = new StoredCredentialsController(
             _dbContext,
             _secretStore,
             _tenantContext,
             new AuditLogWriter(_dbContext, _tenantContext)
         );
 
-        var action = await controller.Update(
-            tenant.Id,
-            new UpdateTenantRequest(
-                "Tenant One Updated",
-                new UpdateTenantSlaConfigurationRequest(5, 10, 20, 30),
-                [
-                    new UpdateTenantIngestionSourceRequest(
-                        "microsoft-defender",
-                        "Microsoft Defender",
-                        true,
-                        "0 */12 * * *",
-                        new UpdateTenantSourceCredentialsRequest(
-                            "client",
-                            "new-secret",
-                            "https://api.security.microsoft.com",
-                            "scope"
-                        )
-                    ),
-                ]
+        var action = await controller.Create(
+            new CreateStoredCredentialRequest(
+                "Defender credential",
+                "entra-client-secret",
+                false,
+                "entra-1",
+                "client",
+                "new-secret",
+                [tenant.Id]
             ),
             CancellationToken.None
         );
 
-        action.Should().BeOfType<NoContentResult>();
+        action.Result.Should().BeOfType<CreatedAtActionResult>();
 
-        var secretAudit = await _dbContext
+        var secretAudit = (await _dbContext
             .AuditLogEntries.IgnoreQueryFilters()
-            .SingleAsync(entry => entry.EntityType == "TenantSourceSecret");
+            .Where(entry => entry.EntityType == nameof(StoredCredential))
+            .ToListAsync())
+            .First(entry => entry.NewValues?.Contains("entra-client-secret") == true);
 
-        secretAudit.TenantId.Should().Be(tenant.Id);
-        secretAudit.Action.Should().Be(AuditAction.Updated);
+        secretAudit.TenantId.Should().Be(Guid.Empty);
+        secretAudit.Action.Should().Be(AuditAction.Created);
         secretAudit.UserId.Should().Be(_userId);
-        secretAudit.OldValues.Should().Contain("tenants/old/source");
-        secretAudit.NewValues.Should().Contain($"tenants/{tenant.Id}/sources/microsoft-defender");
+        secretAudit.NewValues.Should().Contain("Defender credential");
+        secretAudit.NewValues.Should().Contain("entra-client-secret");
     }
 
     [Fact]
@@ -154,6 +137,7 @@ public class SettingsAuditControllerTests : IDisposable
                     true,
                     null,
                     new UpdateEnrichmentSourceCredentialsRequest(
+                        null,
                         "replacement-secret",
                         "https://services.nvd.nist.gov/rest/json/cves/2.0"
                     )
@@ -177,6 +161,55 @@ public class SettingsAuditControllerTests : IDisposable
         secretAudit.UserId.Should().Be(_userId);
         secretAudit.OldValues.Should().Contain("system/enrichment-sources/nvd-old");
         secretAudit.NewValues.Should().Contain("system/enrichment-sources/nvd");
+    }
+
+    [Fact]
+    public async Task UpdateEnrichmentSources_RejectsTenantScopedStoredCredential_ForGlobalSource()
+    {
+        var credential = StoredCredential.Create(
+            "Tenant scoped",
+            StoredCredentialTypes.EntraClientSecret,
+            isGlobal: false,
+            credentialTenantId: "entra-tenant",
+            clientId: "client-id",
+            secretRef: "stored-credentials/test",
+            now: DateTimeOffset.UtcNow
+        );
+        credential.TenantScopes.Add(StoredCredentialTenant.Create(credential.Id, _tenantId));
+        await _dbContext.StoredCredentials.AddAsync(credential);
+        await _dbContext.SaveChangesAsync();
+
+        var controller = new SystemController(
+            _secretStore,
+            _dbContext,
+            new AuditLogWriter(_dbContext, _tenantContext),
+            new NotificationEmailConfigurationResolver(
+                _secretStore,
+                Options.Create(new PatchHound.Infrastructure.Options.SmtpOptions())
+            ),
+            new MailgunEmailSender(new HttpClient()),
+            _tenantContext
+        );
+
+        var action = await controller.UpdateEnrichmentSources(
+            [
+                new UpdateEnrichmentSourceRequest(
+                    EnrichmentSourceCatalog.DefenderSourceKey,
+                    "Microsoft Defender",
+                    true,
+                    24,
+                    new UpdateEnrichmentSourceCredentialsRequest(
+                        credential.Id,
+                        string.Empty,
+                        "https://api.security.microsoft.com"
+                    )
+                ),
+            ],
+            CancellationToken.None
+        );
+
+        action.Should().BeOfType<BadRequestObjectResult>();
+        (await _dbContext.EnrichmentSourceConfigurations.CountAsync()).Should().Be(0);
     }
 
     [Fact]

--- a/tests/PatchHound.Tests/Api/SettingsAuditControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/SettingsAuditControllerTests.cs
@@ -213,6 +213,55 @@ public class SettingsAuditControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task UpdateEnrichmentSources_AcceptsGlobalApiKeyStoredCredential_ForNvdSource()
+    {
+        var credential = StoredCredential.Create(
+            "NVD API",
+            StoredCredentialTypes.ApiKey,
+            isGlobal: true,
+            credentialTenantId: string.Empty,
+            clientId: string.Empty,
+            secretRef: "stored-credentials/nvd",
+            now: DateTimeOffset.UtcNow
+        );
+        await _dbContext.StoredCredentials.AddAsync(credential);
+        await _dbContext.SaveChangesAsync();
+
+        var controller = new SystemController(
+            _secretStore,
+            _dbContext,
+            new AuditLogWriter(_dbContext, _tenantContext),
+            new NotificationEmailConfigurationResolver(
+                _secretStore,
+                Options.Create(new PatchHound.Infrastructure.Options.SmtpOptions())
+            ),
+            new MailgunEmailSender(new HttpClient()),
+            _tenantContext
+        );
+
+        var action = await controller.UpdateEnrichmentSources(
+            [
+                new UpdateEnrichmentSourceRequest(
+                    EnrichmentSourceCatalog.NvdSourceKey,
+                    "NVD API",
+                    true,
+                    null,
+                    new UpdateEnrichmentSourceCredentialsRequest(
+                        credential.Id,
+                        string.Empty,
+                        EnrichmentSourceCatalog.DefaultNvdApiBaseUrl
+                    )
+                ),
+            ],
+            CancellationToken.None
+        );
+
+        action.Should().BeOfType<NoContentResult>();
+        var source = await _dbContext.EnrichmentSourceConfigurations.SingleAsync();
+        source.StoredCredentialId.Should().Be(credential.Id);
+    }
+
+    [Fact]
     public async Task GetEnrichmentSources_ReturnsQueueSummaryAndRecentRuns()
     {
         var source = EnrichmentSourceConfiguration.Create(

--- a/tests/PatchHound.Tests/Api/SetupControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/SetupControllerTests.cs
@@ -11,6 +11,7 @@ using PatchHound.Core.Entities;
 using PatchHound.Core.Interfaces;
 using PatchHound.Core.Models;
 using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Tenants;
 using PatchHound.Tests.TestData;
@@ -100,19 +101,25 @@ public class SetupControllerTests : IDisposable
             .SingleAsync(item => item.Id == defaultSource.Id);
 
         updatedSource.Enabled.Should().BeTrue();
-        updatedSource.CredentialTenantId.Should().Be("entra-tenant");
-        updatedSource.ClientId.Should().Be("client-id");
-        updatedSource.SecretRef.Should().Be(
-            $"tenants/{tenant.Id}/sources/{TenantSourceCatalog.DefenderSourceKey}"
-        );
+        updatedSource.CredentialTenantId.Should().BeEmpty();
+        updatedSource.ClientId.Should().BeEmpty();
+        updatedSource.SecretRef.Should().BeEmpty();
+        updatedSource.StoredCredentialId.Should().NotBeNull();
+
+        var credential = await _dbContext.StoredCredentials
+            .IgnoreQueryFilters()
+            .Include(item => item.TenantScopes)
+            .SingleAsync(item => item.Id == updatedSource.StoredCredentialId);
+        credential.CredentialTenantId.Should().Be("entra-tenant");
+        credential.ClientId.Should().Be("client-id");
+        credential.TenantScopes.Should().ContainSingle(scope => scope.TenantId == tenant.Id);
 
         await _secretStore
             .Received(1)
             .PutSecretAsync(
-                updatedSource.SecretRef,
+                credential.SecretRef,
                 Arg.Is<IReadOnlyDictionary<string, string>>(values =>
-                    values[TenantSourceCatalog.GetSecretKeyName(TenantSourceCatalog.DefenderSourceKey)]
-                    == "client-secret"
+                    values[StoredCredentialSecretKeys.ClientSecret] == "client-secret"
                 ),
                 Arg.Any<CancellationToken>()
             );

--- a/tests/PatchHound.Tests/Api/StoredCredentialsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/StoredCredentialsControllerTests.cs
@@ -95,6 +95,38 @@ public class StoredCredentialsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Create_WhenApiKey_PersistsApiKeySecretWithoutEntraFields()
+    {
+        var result = await _controller.Create(
+            new CreateStoredCredentialRequest(
+                "NVD",
+                StoredCredentialTypes.ApiKey,
+                IsGlobal: true,
+                CredentialTenantId: string.Empty,
+                ClientId: string.Empty,
+                ClientSecret: " nvd-api-key ",
+                TenantIds: []
+            ),
+            CancellationToken.None
+        );
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        var dto = created.Value.Should().BeOfType<StoredCredentialDto>().Subject;
+        dto.Type.Should().Be(StoredCredentialTypes.ApiKey);
+        dto.TypeDisplayName.Should().Be("API key");
+        dto.CredentialTenantId.Should().BeEmpty();
+        dto.ClientId.Should().BeEmpty();
+
+        var saved = await _dbContext.StoredCredentials.SingleAsync();
+        await _secretStore.Received(1).PutSecretAsync(
+            saved.SecretRef,
+            Arg.Is<IReadOnlyDictionary<string, string>>(values =>
+                values[StoredCredentialSecretKeys.ApiKey] == "nvd-api-key"),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
     public async Task List_WhenTenantFilterProvided_ReturnsGlobalAndScopedCredentials()
     {
         var otherTenantId = Guid.NewGuid();

--- a/tests/PatchHound.Tests/Api/StoredCredentialsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/StoredCredentialsControllerTests.cs
@@ -1,0 +1,207 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Api.Models.Credentials;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Credentials;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Secrets;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class StoredCredentialsControllerTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly ISecretStore _secretStore;
+    private readonly StoredCredentialsController _controller;
+
+    public StoredCredentialsControllerTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId);
+        _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+        _tenantContext.HasAccessToTenant(_tenantId).Returns(true);
+        _tenantContext.HasAccessToTenant(Arg.Is<Guid>(id => id != _tenantId)).Returns(false);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+
+        _secretStore = Substitute.For<ISecretStore>();
+        _secretStore
+            .PutSecretAsync(
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.CompletedTask);
+        _secretStore
+            .DeleteSecretPathAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        _controller = new StoredCredentialsController(
+            _dbContext,
+            _secretStore,
+            _tenantContext,
+            new AuditLogWriter(_dbContext, _tenantContext)
+        );
+    }
+
+    [Fact]
+    public async Task Create_WhenTenantScoped_PersistsCredentialScopeAndSecret()
+    {
+        var result = await _controller.Create(
+            new CreateStoredCredentialRequest(
+                "Defender",
+                StoredCredentialTypes.EntraClientSecret,
+                IsGlobal: false,
+                CredentialTenantId: "entra-tenant",
+                ClientId: "client-id",
+                ClientSecret: " client-secret ",
+                TenantIds: [_tenantId]
+            ),
+            CancellationToken.None
+        );
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        var dto = created.Value.Should().BeOfType<StoredCredentialDto>().Subject;
+        dto.Name.Should().Be("Defender");
+        dto.IsGlobal.Should().BeFalse();
+        dto.TenantIds.Should().ContainSingle().Which.Should().Be(_tenantId);
+
+        var saved = await _dbContext.StoredCredentials
+            .Include(credential => credential.TenantScopes)
+            .SingleAsync();
+        saved.SecretRef.Should().Be($"stored-credentials/{saved.Id}");
+        saved.TenantScopes.Should().ContainSingle(scope => scope.TenantId == _tenantId);
+        await _secretStore.Received(1).PutSecretAsync(
+            saved.SecretRef,
+            Arg.Is<IReadOnlyDictionary<string, string>>(values =>
+                values[StoredCredentialSecretKeys.ClientSecret] == "client-secret"),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task List_WhenTenantFilterProvided_ReturnsGlobalAndScopedCredentials()
+    {
+        var otherTenantId = Guid.NewGuid();
+        var global = StoredCredential.Create(
+            "Global",
+            StoredCredentialTypes.EntraClientSecret,
+            true,
+            "entra",
+            "client",
+            "secret/global",
+            DateTimeOffset.UtcNow
+        );
+        var scoped = StoredCredential.Create(
+            "Scoped",
+            StoredCredentialTypes.EntraClientSecret,
+            false,
+            "entra",
+            "client",
+            "secret/scoped",
+            DateTimeOffset.UtcNow
+        );
+        scoped.TenantScopes.Add(StoredCredentialTenant.Create(scoped.Id, _tenantId));
+        var inaccessible = StoredCredential.Create(
+            "Other",
+            StoredCredentialTypes.EntraClientSecret,
+            false,
+            "entra",
+            "client",
+            "secret/other",
+            DateTimeOffset.UtcNow
+        );
+        inaccessible.TenantScopes.Add(StoredCredentialTenant.Create(inaccessible.Id, otherTenantId));
+
+        await _dbContext.StoredCredentials.AddRangeAsync(global, scoped, inaccessible);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.List(
+            StoredCredentialTypes.EntraClientSecret,
+            _tenantId,
+            CancellationToken.None
+        );
+
+        var credentials = result.Value.Should().NotBeNull().And.Subject;
+        credentials.Select(credential => credential.Name).Should().BeEquivalentTo(["Global", "Scoped"]);
+    }
+
+    [Fact]
+    public async Task Create_WhenSecretWriteFails_DoesNotPersistCredential()
+    {
+        _secretStore
+            .PutSecretAsync(
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => throw new InvalidOperationException("secret store unavailable"));
+
+        var act = () => _controller.Create(
+            new CreateStoredCredentialRequest(
+                "Defender",
+                StoredCredentialTypes.EntraClientSecret,
+                IsGlobal: false,
+                CredentialTenantId: "entra-tenant",
+                ClientId: "client-id",
+                ClientSecret: "client-secret",
+                TenantIds: [_tenantId]
+            ),
+            CancellationToken.None
+        );
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await _dbContext.StoredCredentials.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_WhenCredentialUsedBySentinel_ReturnsConflict()
+    {
+        var credential = StoredCredential.Create(
+            "Sentinel",
+            StoredCredentialTypes.EntraClientSecret,
+            true,
+            "entra",
+            "client",
+            "secret/sentinel",
+            DateTimeOffset.UtcNow
+        );
+        var sentinel = SentinelConnectorConfiguration.Create(
+            enabled: true,
+            dceEndpoint: "https://example.ingest.monitor.azure.com",
+            dcrImmutableId: "dcr-123",
+            streamName: "Custom-PatchHoundAuditLog",
+            storedCredentialId: credential.Id
+        );
+
+        await _dbContext.StoredCredentials.AddAsync(credential);
+        await _dbContext.SentinelConnectorConfigurations.AddAsync(sentinel);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Delete(credential.Id, CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+        await _secretStore.DidNotReceiveWithAnyArgs().DeleteSecretPathAsync(default!, default);
+        (await _dbContext.StoredCredentials.CountAsync()).Should().Be(1);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/DefenderVulnerabilitySourceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/DefenderVulnerabilitySourceTests.cs
@@ -12,6 +12,7 @@ using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Infrastructure.Tenants;
 using PatchHound.Infrastructure.VulnerabilitySources;
+using PatchHound.Infrastructure.Credentials;
 
 namespace PatchHound.Tests.Infrastructure;
 
@@ -263,18 +264,16 @@ public class DefenderVulnerabilitySourceTests
                 "Microsoft Defender",
                 true,
                 "0 * * * *",
-                credentialTenantId: "tenant",
-                clientId: string.Empty,
-                secretRef: "secret/ref",
                 apiBaseUrl: TenantSourceCatalog.DefaultDefenderApiBaseUrl,
-                tokenScope: TenantSourceCatalog.DefaultDefenderTokenScope
+                tokenScope: TenantSourceCatalog.DefaultDefenderTokenScope,
+                storedCredentialId: Guid.NewGuid()
             )
         );
         await dbContext.SaveChangesAsync();
 
         var provider = new DefenderTenantConfigurationProvider(
             dbContext,
-            new TestSecretStore("secret")
+            new StoredCredentialResolver(dbContext, new TestSecretStore("secret"))
         );
         var apiClient = Substitute.For<DefenderApiClient>(new HttpClient());
         var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<DefenderVulnerabilitySource>>();
@@ -1254,6 +1253,22 @@ public class DefenderVulnerabilitySourceTests
             options,
             new ServiceCollection().AddSingleton(tenantContext).BuildServiceProvider()
         );
+        var credentialId = Guid.NewGuid();
+        await dbContext.StoredCredentials.AddAsync(
+            StoredCredential.Create(
+                "Defender",
+                StoredCredentialTypes.EntraClientSecret,
+                isGlobal: false,
+                configuration.TenantId,
+                configuration.ClientId,
+                "secret/ref",
+                DateTimeOffset.UtcNow,
+                credentialId
+            )
+        );
+        await dbContext.StoredCredentialTenants.AddAsync(
+            StoredCredentialTenant.Create(credentialId, tenantId)
+        );
         await dbContext.TenantSourceConfigurations.AddAsync(
             TenantSourceConfiguration.Create(
                 tenantId,
@@ -1261,18 +1276,16 @@ public class DefenderVulnerabilitySourceTests
                 "Microsoft Defender",
                 true,
                 "0 * * * *",
-                configuration.TenantId,
-                configuration.ClientId,
-                "secret/ref",
-                configuration.ApiBaseUrl,
-                configuration.TokenScope
+                apiBaseUrl: configuration.ApiBaseUrl,
+                tokenScope: configuration.TokenScope,
+                storedCredentialId: credentialId
             )
         );
         await dbContext.SaveChangesAsync();
 
         return new DefenderTenantConfigurationProvider(
             dbContext,
-            new TestSecretStore(configuration.ClientSecret)
+            new StoredCredentialResolver(dbContext, new TestSecretStore(configuration.ClientSecret))
         );
     }
 

--- a/tests/PatchHound.Tests/Infrastructure/NvdFeedSyncServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/NvdFeedSyncServiceTests.cs
@@ -7,8 +7,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
+using PatchHound.Infrastructure.Tenants;
 
 namespace PatchHound.Tests.Infrastructure;
 
@@ -20,6 +22,22 @@ public class NvdFeedSyncServiceTests
         store.GetSecretAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
         return store;
+    }
+
+    private static NvdFeedSyncService CreateService(
+        HttpClient httpClient,
+        PatchHound.Infrastructure.Data.PatchHoundDbContext db,
+        ISecretStore? secretStore = null
+    )
+    {
+        var store = secretStore ?? NullSecrets();
+        return new NvdFeedSyncService(
+            httpClient,
+            db,
+            store,
+            new StoredCredentialResolver(db, store),
+            NullLogger<NvdFeedSyncService>.Instance
+        );
     }
 
     [Fact]
@@ -34,8 +52,7 @@ public class NvdFeedSyncServiceTests
 
         var handler = new GzipArchiveHandler(feedJson);
         var httpClient = new HttpClient(handler);
-        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
-            NullLogger<NvdFeedSyncService>.Instance);
+        var service = CreateService(httpClient, db);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
 
@@ -74,8 +91,7 @@ public class NvdFeedSyncServiceTests
 
         var handler = new FakeApiHandler(feedJson);
         var httpClient = new HttpClient(handler);
-        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
-            NullLogger<NvdFeedSyncService>.Instance);
+        var service = CreateService(httpClient, db);
 
         await service.SyncModifiedFeedAsync(CancellationToken.None);
 
@@ -93,8 +109,7 @@ public class NvdFeedSyncServiceTests
 
         var handler = new GzipArchiveHandler("{}");
         var httpClient = new HttpClient(handler);
-        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
-            NullLogger<NvdFeedSyncService>.Instance);
+        var service = CreateService(httpClient, db);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
 
@@ -127,8 +142,7 @@ public class NvdFeedSyncServiceTests
 
         var handler = new GzipArchiveHandler(feedJson);
         var httpClient = new HttpClient(handler);
-        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
-            NullLogger<NvdFeedSyncService>.Instance);
+        var service = CreateService(httpClient, db);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
 
@@ -145,8 +159,7 @@ public class NvdFeedSyncServiceTests
             "2024-01-01T00:00:00.000", "2024-01-10T00:00:00.000",
             referenceUrl: null, criteria: "cpe:2.3:a:acme:widget:1.0:*:*:*:*:*:*:*"));
         var httpClient = new HttpClient(handler);
-        var service = new NvdFeedSyncService(httpClient, db, NullSecrets(),
-            NullLogger<NvdFeedSyncService>.Instance);
+        var service = CreateService(httpClient, db);
 
         await service.SyncYearFeedAsync(2024, CancellationToken.None);
 
@@ -159,6 +172,53 @@ public class NvdFeedSyncServiceTests
             .Select(c => c.CveId)
             .ToListAsync();
         cachedIds.Should().Equal("CVE-2024-1234");
+    }
+
+    [Fact]
+    public async Task SyncModifiedFeedAsync_uses_global_api_key_stored_credential()
+    {
+        await using var db = await TestDbContextFactory.CreateAsync();
+        var credential = StoredCredential.Create(
+            "NVD API",
+            StoredCredentialTypes.ApiKey,
+            isGlobal: true,
+            credentialTenantId: string.Empty,
+            clientId: string.Empty,
+            secretRef: "stored-credentials/nvd",
+            now: DateTimeOffset.UtcNow
+        );
+        await db.StoredCredentials.AddAsync(credential);
+        await db.EnrichmentSourceConfigurations.AddAsync(
+            EnrichmentSourceConfiguration.Create(
+                EnrichmentSourceCatalog.NvdSourceKey,
+                "NVD API",
+                true,
+                secretRef: string.Empty,
+                apiBaseUrl: EnrichmentSourceCatalog.DefaultNvdApiBaseUrl,
+                storedCredentialId: credential.Id
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var store = NullSecrets();
+        store.GetSecretAsync(
+                credential.SecretRef,
+                StoredCredentialSecretKeys.ApiKey,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns("nvd-api-key");
+
+        var handler = new FakeApiHandler(BuildSinglePageResponse("CVE-2024-1234", "Window 1", 7.5m,
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "2024-01-01T00:00:00.000", "2024-01-10T00:00:00.000",
+            referenceUrl: null, criteria: "cpe:2.3:a:acme:widget:1.0:*:*:*:*:*:*:*"));
+        var httpClient = new HttpClient(handler);
+        var service = CreateService(httpClient, db, store);
+
+        await service.SyncModifiedFeedAsync(CancellationToken.None);
+
+        handler.RequestCount.Should().Be(1);
+        handler.ApiKeys.Should().ContainSingle().Which.Should().Be("nvd-api-key");
     }
 
     private static string BuildSinglePageResponse(
@@ -230,6 +290,7 @@ public class NvdFeedSyncServiceTests
     {
         private readonly string _responseJson;
         public int RequestCount { get; private set; }
+        public List<string?> ApiKeys { get; } = [];
 
         public FakeApiHandler(string responseJson) => _responseJson = responseJson;
 
@@ -237,6 +298,11 @@ public class NvdFeedSyncServiceTests
             HttpRequestMessage request, CancellationToken ct)
         {
             RequestCount++;
+            ApiKeys.Add(
+                request.Headers.TryGetValues("apiKey", out var values)
+                    ? values.SingleOrDefault()
+                    : null
+            );
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(_responseJson, Encoding.UTF8, "application/json"),

--- a/tests/PatchHound.Tests/Infrastructure/Services/DefenderVulnerabilityEnrichmentRunnerTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/DefenderVulnerabilityEnrichmentRunnerTests.cs
@@ -8,6 +8,7 @@ using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Secrets;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Infrastructure.VulnerabilitySources;
+using PatchHound.Infrastructure.Credentials;
 using PatchHound.Tests.Infrastructure;
 
 namespace PatchHound.Tests.Infrastructure.Services;
@@ -248,7 +249,7 @@ public class DefenderVulnerabilityEnrichmentRunnerTests
         public StubDefenderConfigurationProvider(
             PatchHoundDbContext db,
             DefenderClientConfiguration? configuration
-        ) : base(db, new NullSecretStore())
+        ) : base(db, new StoredCredentialResolver(db, new NullSecretStore()))
         {
             _configuration = configuration;
         }

--- a/tests/PatchHound.Tests/Infrastructure/Services/RemediationOwnershipRoutingTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/RemediationOwnershipRoutingTests.cs
@@ -65,6 +65,43 @@ public class RemediationOwnershipRoutingTests : IDisposable
     }
 
     [Fact]
+    public async Task AddRecommendationForCaseAsync_ReusesUnsavedWorkflowCreatedEarlierInRequest()
+    {
+        var ownerTeam = Team.Create(_tenantId, "Software Owners");
+        var product = SoftwareProduct.Create("Contoso", "Browser", null);
+        var remediationCase = RemediationCase.Create(_tenantId, product.Id);
+        var tenantSoftware = SoftwareTenantRecord.Create(
+            _tenantId,
+            null,
+            product.Id,
+            DateTimeOffset.UtcNow.AddDays(-10),
+            DateTimeOffset.UtcNow
+        );
+        tenantSoftware.AssignOwnerTeam(ownerTeam.Id);
+
+        await _dbContext.AddRangeAsync(ownerTeam, product, remediationCase, tenantSoftware);
+        await _dbContext.SaveChangesAsync();
+
+        var workflowService = new RemediationWorkflowService(_dbContext);
+        var sut = new AnalystRecommendationService(_dbContext, workflowService);
+
+        var result = await sut.AddRecommendationForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.ApprovedForPatching,
+            "Patch the affected product.",
+            Guid.NewGuid(),
+            ct: CancellationToken.None
+        );
+
+        result.IsSuccess.Should().BeTrue();
+        (await _dbContext.RemediationWorkflows.CountAsync()).Should().Be(1);
+        result.Value.RemediationWorkflowId.Should().Be(
+            await _dbContext.RemediationWorkflows.Select(workflow => workflow.Id).SingleAsync()
+        );
+    }
+
+    [Fact]
     public async Task EnsurePatchingTasksAsync_UsesWorkflowSoftwareOwnerTeam()
     {
         var ownerTeam = Team.Create(_tenantId, "Software Owners");

--- a/tests/PatchHound.Tests/PatchHound.Tests.csproj
+++ b/tests/PatchHound.Tests/PatchHound.Tests.csproj
@@ -31,5 +31,6 @@
     <ProjectReference Include="..\..\src\PatchHound.Infrastructure\PatchHound.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\PatchHound.Api\PatchHound.Api.csproj" />
     <ProjectReference Include="..\..\src\PatchHound.Puppy\PatchHound.Puppy.csproj" />
+    <ProjectReference Include="..\..\src\PatchHound.Worker\PatchHound.Worker.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/PatchHound.Tests/Worker/IngestionWorkerTests.cs
+++ b/tests/PatchHound.Tests/Worker/IngestionWorkerTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using PatchHound.Worker;
+
+namespace PatchHound.Tests.Worker;
+
+public class IngestionWorkerTests
+{
+    [Fact]
+    public void HasConfiguredCredentials_ReturnsTrue_WhenStoredCredentialIsSelected()
+    {
+        var source = new IngestionWorker.ScheduledSource(
+            Id: Guid.NewGuid(),
+            TenantId: Guid.NewGuid(),
+            TenantName: "Tenant",
+            SourceKey: "microsoft-defender",
+            Enabled: true,
+            CredentialTenantId: string.Empty,
+            ClientId: string.Empty,
+            SecretRef: string.Empty,
+            ApiBaseUrl: "https://api.securitycenter.microsoft.com",
+            TokenScope: "https://api.securitycenter.microsoft.com/.default",
+            SyncSchedule: "0 * * * *",
+            StoredCredentialId: Guid.NewGuid(),
+            ManualRequestedAt: DateTimeOffset.UtcNow,
+            LastStartedAt: null
+        );
+
+        IngestionWorker.HasConfiguredCredentials(source).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
closes #43 
This pull request introduces support for stored credentials in the frontend, refactoring how credentials are managed for integrations and enrichment sources. It adds new schemas and API functions for CRUD operations on stored credentials, updates relevant forms and components to use the new model, and cleans up the documentation to reduce redundancy and improve clarity.

The most important changes are:

**Stored Credential Model and API:**
* Added `stored-credentials.schemas.ts` defining the `StoredCredential` type and validation schemas, and implemented CRUD server functions in `stored-credentials.functions.ts` to manage stored credentials via the API. [[1]](diffhunk://#diff-9b2f93893e06931290d135e0adfca921bd313e82054727c6135587477cf8c55fR1-R38) [[2]](diffhunk://#diff-9d122af227f6cd33cd6429ac5342d383f6740e1dd4dcc4f797b624c1dd44d861R1-R42)
* Updated integration and enrichment source schemas to reference `storedCredentialId` instead of direct credential fields (`tenantId`, `clientId`, etc.), and added `acceptedCredentialTypes` for compatibility checks. [[1]](diffhunk://#diff-f5bf2f9cd9cf6bb80b104153f71dc15ae5bef8aacf1d27d10329ff596c7b1b8bL9-R10) [[2]](diffhunk://#diff-f5bf2f9cd9cf6bb80b104153f71dc15ae5bef8aacf1d27d10329ff596c7b1b8bL22-R21) [[3]](diffhunk://#diff-021781d1e9d2490f8a4f7e23287bb95aa534a6f7fef3e0713beb0dba40dbf48aR6-R7) [[4]](diffhunk://#diff-e746ae9f5af5d34f8e0a1d94bac47232c9894acb367a3ccec827854b282f117cR17)

**UI Integration for Stored Credentials:**
* Modified `GlobalEnrichmentSourceManagement.tsx` to query available stored credentials and pass them to the editor sheet, and updated the credentials form to use a selector for stored credentials when supported. [[1]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472L2-R7) [[2]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472R19-R25) [[3]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472R64-R69) [[4]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472R92) [[5]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472R284) [[6]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472R309) [[7]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472R321) [[8]](diffhunk://#diff-87f0b8ef259893e9442b625a2ff726344c891e1df96b5dd3d20f7d7bca7ac472L460-R486)

**Documentation Cleanup:**
* Cleaned up and condensed the `AGENTS.md` and `CLAUDE.md` documentation by removing redundant tool usage guides and self-check sections, focusing on essential information and resource links. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L92-R92) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L104-L142) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L152-L177)

These changes modernize credential management, improve security and maintainability, and streamline the user experience for managing integration credentials.
