### PR TITLE
Implement dashboard heatmap endpoint

### DIFF
--- a/frontend/src/components/features/admin/UserTable.tsx
+++ b/frontend/src/components/features/admin/UserTable.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { SearchIcon } from 'lucide-react'
 import type { UserListItem } from '@/api/users.schemas'
-import type { TeamItem } from '@/api/teams.schemas'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'

--- a/frontend/src/components/features/devices/DeviceExposuresSection.test.tsx
+++ b/frontend/src/components/features/devices/DeviceExposuresSection.test.tsx
@@ -112,6 +112,6 @@ describe('Device exposures section', () => {
     )
 
     fireEvent.click(screen.getByRole('tab', { name: 'Exposures' }))
-    expect(screen.getByText('No exposures observed for this device.')).toBeInTheDocument()
+    expect(screen.getByText('No open exposures on this device.')).toBeInTheDocument()
   })
 })

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -1024,9 +1024,41 @@ public class DashboardController : ControllerBase
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
         }
 
-        // Heatmap not yet implemented — returns empty list.
-        _ = tenantId;
-        return Ok(new List<HeatmapRowDto>());
+        var normalizedGroupBy = NormalizeHeatmapGroupBy(groupBy);
+        if (normalizedGroupBy is null)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Unsupported heatmap grouping.",
+                Detail = "Supported groupBy values are deviceGroup, ownerTeam, businessLabel, businessService, platform, and severity.",
+            });
+        }
+
+        var (filteredAssetIds, minPublishedDate) = BuildFilterContext(tenantId, filter);
+        var exposureQuery = _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+            .Where(exposure => exposure.TenantId == tenantId && exposure.Status == ExposureStatus.Open);
+
+        if (filteredAssetIds != null)
+        {
+            exposureQuery = exposureQuery.Where(exposure => filteredAssetIds.Contains(exposure.DeviceId));
+        }
+
+        if (minPublishedDate.HasValue)
+        {
+            exposureQuery = exposureQuery.Where(exposure => exposure.Vulnerability.PublishedDate >= minPublishedDate.Value);
+        }
+
+        var rows = normalizedGroupBy switch
+        {
+            "deviceGroup" => await BuildDeviceGroupHeatmapAsync(exposureQuery, ct),
+            "ownerTeam" => await BuildOwnerTeamHeatmapAsync(exposureQuery, tenantId, ct),
+            "businessLabel" => await BuildBusinessLabelHeatmapAsync(exposureQuery, tenantId, ct),
+            "platform" => await BuildPlatformHeatmapAsync(exposureQuery, ct),
+            "severity" => await BuildSeverityHeatmapAsync(exposureQuery, ct),
+            _ => [],
+        };
+
+        return Ok(rows);
     }
 
     [HttpGet("trends")]
@@ -1321,6 +1353,188 @@ public class DashboardController : ControllerBase
             : null;
 
         return (filteredAssetIdQuery, minPublishedDate);
+    }
+
+    private static string? NormalizeHeatmapGroupBy(string? groupBy)
+    {
+        return groupBy?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "devicegroup" or "device-group" or "device_group" => "deviceGroup",
+            "ownerteam" or "owner-team" or "owner_team" or "owner" or "team" => "ownerTeam",
+            "businesslabel" or "business-label" or "business_label" or "businessservice" or "business-service" or "business_service" => "businessLabel",
+            "platform" or "os" or "osplatform" or "os-platform" or "os_platform" => "platform",
+            "severity" => "severity",
+            _ => null,
+        };
+    }
+
+    private static List<HeatmapRowDto> SortHeatmapRows(IEnumerable<HeatmapRowDto> rows)
+    {
+        return rows
+            .OrderByDescending(row => row.Critical)
+            .ThenByDescending(row => row.High)
+            .ThenByDescending(row => row.Medium)
+            .ThenByDescending(row => row.Low)
+            .ThenBy(row => row.Label)
+            .Take(20)
+            .ToList();
+    }
+
+    private static HeatmapRowDto BuildHeatmapRow(string label, IEnumerable<Severity> severities)
+    {
+        var counts = severities
+            .GroupBy(severity => severity)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        return new HeatmapRowDto(
+            label,
+            counts.GetValueOrDefault(Severity.Critical),
+            counts.GetValueOrDefault(Severity.High),
+            counts.GetValueOrDefault(Severity.Medium),
+            counts.GetValueOrDefault(Severity.Low)
+        );
+    }
+
+    private static async Task<List<HeatmapRowDto>> BuildDeviceGroupHeatmapAsync(
+        IQueryable<DeviceVulnerabilityExposure> exposureQuery,
+        CancellationToken ct)
+    {
+        var rows = await exposureQuery
+            .Select(exposure => new
+            {
+                Label = exposure.Device.GroupName ?? "No device group",
+                Severity = exposure.Vulnerability.VendorSeverity,
+            })
+            .ToListAsync(ct);
+
+        return SortHeatmapRows(rows
+            .GroupBy(row => row.Label)
+            .Select(group => BuildHeatmapRow(group.Key, group.Select(row => row.Severity))));
+    }
+
+    private static async Task<List<HeatmapRowDto>> BuildPlatformHeatmapAsync(
+        IQueryable<DeviceVulnerabilityExposure> exposureQuery,
+        CancellationToken ct)
+    {
+        var rows = await exposureQuery
+            .Select(exposure => new
+            {
+                Label = exposure.Device.OsPlatform ?? "Unknown platform",
+                Severity = exposure.Vulnerability.VendorSeverity,
+            })
+            .ToListAsync(ct);
+
+        return SortHeatmapRows(rows
+            .GroupBy(row => row.Label)
+            .Select(group => BuildHeatmapRow(group.Key, group.Select(row => row.Severity))));
+    }
+
+    private async Task<List<HeatmapRowDto>> BuildOwnerTeamHeatmapAsync(
+        IQueryable<DeviceVulnerabilityExposure> exposureQuery,
+        Guid tenantId,
+        CancellationToken ct)
+    {
+        var rows = await exposureQuery
+            .Select(exposure => new
+            {
+                TeamId = exposure.Device.OwnerTeamId ?? exposure.Device.FallbackTeamId,
+                Severity = exposure.Vulnerability.VendorSeverity,
+            })
+            .ToListAsync(ct);
+
+        var teamIds = rows
+            .Select(row => row.TeamId)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToList();
+
+        var teamNamesById = teamIds.Count == 0
+            ? new Dictionary<Guid, string>()
+            : await _dbContext.Teams.AsNoTracking()
+                .Where(team => team.TenantId == tenantId && teamIds.Contains(team.Id))
+                .ToDictionaryAsync(team => team.Id, team => team.Name, ct);
+
+        return SortHeatmapRows(rows
+            .GroupBy(row => row.TeamId)
+            .Select(group =>
+            {
+                var label = group.Key.HasValue && teamNamesById.TryGetValue(group.Key.Value, out var teamName)
+                    ? teamName
+                    : "Unowned";
+
+                return BuildHeatmapRow(label, group.Select(row => row.Severity));
+            }));
+    }
+
+    private async Task<List<HeatmapRowDto>> BuildBusinessLabelHeatmapAsync(
+        IQueryable<DeviceVulnerabilityExposure> exposureQuery,
+        Guid tenantId,
+        CancellationToken ct)
+    {
+        var exposureRows = await exposureQuery
+            .Select(exposure => new
+            {
+                exposure.DeviceId,
+                Severity = exposure.Vulnerability.VendorSeverity,
+            })
+            .ToListAsync(ct);
+
+        if (exposureRows.Count == 0)
+        {
+            return [];
+        }
+
+        var deviceIds = exposureRows.Select(row => row.DeviceId).Distinct().ToList();
+        var labelRows = await (
+            from deviceLabel in _dbContext.DeviceBusinessLabels.AsNoTracking()
+            join label in _dbContext.BusinessLabels.AsNoTracking()
+                on deviceLabel.BusinessLabelId equals label.Id
+            where deviceLabel.TenantId == tenantId
+                  && label.TenantId == tenantId
+                  && label.IsActive
+                  && deviceIds.Contains(deviceLabel.DeviceId)
+            select new
+            {
+                deviceLabel.DeviceId,
+                label.Name,
+            }
+        ).ToListAsync(ct);
+
+        var labelsByDeviceId = labelRows
+            .GroupBy(row => row.DeviceId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(row => row.Name).Distinct().ToList());
+
+        var rows = exposureRows.SelectMany(row =>
+        {
+            if (!labelsByDeviceId.TryGetValue(row.DeviceId, out var labels) || labels.Count == 0)
+            {
+                labels = ["Unlabeled"];
+            }
+
+            return labels.Select(label => new { Label = label, row.Severity });
+        });
+
+        return SortHeatmapRows(rows
+            .GroupBy(row => row.Label)
+            .Select(group => BuildHeatmapRow(group.Key, group.Select(row => row.Severity))));
+    }
+
+    private static async Task<List<HeatmapRowDto>> BuildSeverityHeatmapAsync(
+        IQueryable<DeviceVulnerabilityExposure> exposureQuery,
+        CancellationToken ct)
+    {
+        var severities = await exposureQuery
+            .Select(exposure => exposure.Vulnerability.VendorSeverity)
+            .ToListAsync(ct);
+
+        var severityOrder = new[] { Severity.Critical, Severity.High, Severity.Medium, Severity.Low };
+        return severityOrder
+            .Select(severity => BuildHeatmapRow(severity.ToString(), severities.Where(item => item == severity)))
+            .Where(row => row.Critical + row.High + row.Medium + row.Low > 0)
+            .ToList();
     }
 
     private static IEnumerable<DateOnly> EachDay(DateOnly startDate, DateOnly endDate)

--- a/tests/PatchHound.Tests/Api/DashboardControllerHeatmapTests.cs
+++ b/tests/PatchHound.Tests/Api/DashboardControllerHeatmapTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Api.Models.Dashboard;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class DashboardControllerHeatmapTests : IDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DashboardController _controller;
+
+    public DashboardControllerHeatmapTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId = Guid.NewGuid());
+        _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+
+        _controller = new DashboardController(
+            _dbContext,
+            new DashboardQueryService(_dbContext, Substitute.For<IRiskChangeBriefAiSummaryService>()),
+            _tenantContext,
+            new TenantSnapshotResolver(_dbContext)
+        );
+    }
+
+    [Fact]
+    public async Task GetHeatmap_DeviceGroup_ReturnsSeverityCounts()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        seed.DeviceA.UpdateInventoryDetails(null, null, "Windows", null, null, null, null, null, groupName: "Production");
+        seed.DeviceB.UpdateInventoryDetails(null, null, "Linux", null, null, null, null, null, groupName: "Workstations");
+        await _dbContext.SaveChangesAsync();
+
+        var action = await _controller.GetHeatmap(new DashboardFilterQuery(), "deviceGroup", CancellationToken.None);
+
+        var dto = ReadOk(action);
+        dto.Should().ContainEquivalentOf(new HeatmapRowDto("Production", 1, 0, 0, 0));
+        dto.Should().ContainEquivalentOf(new HeatmapRowDto("Workstations", 0, 1, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetHeatmap_OwnerTeam_UsesTeamOwnerAndUnownedBucket()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        var team = Team.Create(_tenantId, "Infrastructure");
+        seed.DeviceA.AssignTeamOwner(team.Id);
+        _dbContext.Teams.Add(team);
+        await _dbContext.SaveChangesAsync();
+
+        var action = await _controller.GetHeatmap(new DashboardFilterQuery(), "ownerTeam", CancellationToken.None);
+
+        var dto = ReadOk(action);
+        dto.Should().ContainEquivalentOf(new HeatmapRowDto("Infrastructure", 1, 0, 0, 0));
+        dto.Should().ContainEquivalentOf(new HeatmapRowDto("Unowned", 0, 1, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetHeatmap_BusinessLabel_IncludesUnlabeledBucket()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        var label = BusinessLabel.Create(_tenantId, "Customer Portal", null, null);
+        _dbContext.BusinessLabels.Add(label);
+        _dbContext.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, label.Id));
+        await _dbContext.SaveChangesAsync();
+
+        var action = await _controller.GetHeatmap(new DashboardFilterQuery(), "businessService", CancellationToken.None);
+
+        var dto = ReadOk(action);
+        dto.Should().ContainEquivalentOf(new HeatmapRowDto("Customer Portal", 1, 0, 0, 0));
+        dto.Should().ContainEquivalentOf(new HeatmapRowDto("Unlabeled", 0, 1, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetHeatmap_Platform_AppliesDashboardFilters()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        seed.DeviceA.UpdateInventoryDetails(null, null, "Windows", null, null, null, null, null, groupName: "Production");
+        seed.DeviceB.UpdateInventoryDetails(null, null, "Linux", null, null, null, null, null, groupName: "Workstations");
+        await _dbContext.SaveChangesAsync();
+
+        var action = await _controller.GetHeatmap(
+            new DashboardFilterQuery(Platform: "Windows"),
+            "platform",
+            CancellationToken.None);
+
+        var dto = ReadOk(action);
+        dto.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new HeatmapRowDto("Windows", 1, 0, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetHeatmap_UnsupportedGroup_ReturnsBadRequest()
+    {
+        await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+
+        var action = await _controller.GetHeatmap(new DashboardFilterQuery(), "businessUnit", CancellationToken.None);
+
+        action.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    private static List<HeatmapRowDto> ReadOk(ActionResult<List<HeatmapRowDto>> action)
+    {
+        var ok = action.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeAssignableTo<List<HeatmapRowDto>>().Subject;
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements GET /api/dashboard/heatmap for deviceGroup, ownerTeam, businessLabel/businessService, platform, and severity groupings.
- Applies existing dashboard filters to heatmap queries and returns 400 for unsupported groupings.
- Adds controller tests for group counts, filters, unlabeled/unowned buckets, and unsupported grouping behavior.

## Verification
- dotnet test tests\PatchHound.Tests\PatchHound.Tests.csproj --filter "FullyQualifiedName~DashboardControllerHeatmapTests" -v minimal
- dotnet build PatchHound.slnx

## Notes
- GitNexus impact was LOW for GetHeatmap and HeatmapRowDto before edits.
- GitNexus staged detect_changes reported LOW risk with no affected execution flows.
- Post-commit npx gitnexus analyze was attempted but blocked by sandbox/network and then rejected by escalation review because it would execute npm-fetched code.

Closes #55