### PR TITLE
Implement executive exposure dashboard summary

### DIFF
--- a/frontend/src/api/dashboard.schemas.ts
+++ b/frontend/src/api/dashboard.schemas.ts
@@ -21,6 +21,19 @@ export const unhandledVulnerabilitySchema = z.object({
   latestSeenAt: z.string().datetime({ offset: true }),
 })
 
+export const executiveExposureSummarySchema = z.object({
+  score: z.number(),
+  riskLevel: z.string(),
+  scoreDelta: z.number().nullable(),
+  trend: z.string(),
+  scope: z.string(),
+  assetCount: z.number(),
+  criticalAssetCount: z.number(),
+  highAssetCount: z.number(),
+  topDriver: z.string().nullable(),
+  topDriverDetail: z.string().nullable(),
+})
+
 export const dashboardSummarySchema = z.object({
   exposureScore: z.number(),
   vulnerabilitiesBySeverity: z.record(z.string(), z.number()),
@@ -104,6 +117,7 @@ export const dashboardSummarySchema = z.object({
     days: z.number(),
     previousDays: z.number().nullable(),
   })).optional(),
+  executiveExposure: executiveExposureSummarySchema.nullable().optional(),
 })
 
 export const trendItemSchema = z.object({
@@ -119,6 +133,7 @@ export const trendDataSchema = z.object({
 export const dashboardRiskChangeBriefSchema = dashboardSummarySchema.shape.riskChangeBrief
 
 export type DashboardSummary = z.infer<typeof dashboardSummarySchema>
+export type ExecutiveExposureSummary = z.infer<typeof executiveExposureSummarySchema>
 export type TopVulnerability = z.infer<typeof topVulnerabilitySchema>
 export type UnhandledVulnerability = z.infer<typeof unhandledVulnerabilitySchema>
 export type TrendData = z.infer<typeof trendDataSchema>

--- a/frontend/src/components/features/dashboard/CisoExecutiveOverview.tsx
+++ b/frontend/src/components/features/dashboard/CisoExecutiveOverview.tsx
@@ -1,15 +1,11 @@
 import { ArrowDownRight, ArrowUpRight, Building2, Clock3, Flame, RefreshCw, Siren, Trophy } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts'
-import type { DashboardSummary, TrendData } from '@/api/dashboard.schemas'
-import { fetchRiskScoreSummary } from '@/api/risk-score.functions'
-import type { RiskScoreSummary } from '@/api/risk-score.schemas'
+import type { DashboardSummary, ExecutiveExposureSummary, TrendData } from '@/api/dashboard.schemas'
 import { MetricInfoTooltip } from '@/components/features/dashboard/MetricInfoTooltip'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { useTenantScope } from '@/components/layout/tenant-scope'
 import { cn } from '@/lib/utils'
 import type { LucideIcon } from 'lucide-react'
 
@@ -113,6 +109,23 @@ function deriveTone(summary: DashboardSummary): {
   headline: string
   narrative: string
 } {
+  const exposure = summary.executiveExposure
+  if (exposure?.riskLevel === 'Critical') {
+    return {
+      tone: 'critical',
+      headline: 'Cyber exposure needs leadership attention',
+      narrative: exposure.topDriverDetail ?? 'The current exposure score is in the critical band and should be actively managed through the next reporting cycle.',
+    }
+  }
+
+  if (exposure?.riskLevel === 'High' || exposure?.trend === 'Worsening') {
+    return {
+      tone: 'watch',
+      headline: 'Cyber exposure is elevated',
+      narrative: exposure.topDriverDetail ?? 'The current score or recent movement shows enough pressure to warrant management follow-through.',
+    }
+  }
+
   const critical = summary.vulnerabilitiesBySeverity.Critical ?? 0
   const overdue = summary.overdueTaskCount
   const recurrence = summary.recurrenceRatePercent
@@ -170,27 +183,51 @@ function riskGaugeBand(score: number): RiskGaugeBand {
   return 'contained'
 }
 
-function riskGaugeLabel(score: number) {
-  return riskGaugeBands.find((band) => band.band === riskGaugeBand(score))?.label ?? 'Contained'
+function normalizeRiskLevel(level: string | undefined): RiskGaugeBand {
+  const normalized = level?.toLowerCase()
+  if (normalized === 'critical' || normalized === 'high' || normalized === 'elevated' || normalized === 'contained') {
+    return normalized
+  }
+
+  return 'contained'
 }
 
 function riskGaugeBandMeta(score: number) {
   return riskGaugeBands.find((band) => band.band === riskGaugeBand(score)) ?? riskGaugeBands[0]
 }
 
+function describeExecutiveTrend(exposure: ExecutiveExposureSummary | null | undefined) {
+  if (!exposure) {
+    return 'Awaiting risk rollup'
+  }
+
+  if (exposure.trend === 'Filtered') {
+    return 'Trend hidden for filtered scope'
+  }
+
+  if (exposure.scoreDelta === null) {
+    return 'No baseline yet'
+  }
+
+  const direction = exposure.scoreDelta > 0 ? '+' : ''
+  return `${direction}${Math.round(exposure.scoreDelta)} vs prior snapshot`
+}
+
 function RiskScoreGauge({
-  summary,
+  exposure,
   isLoading,
 }: {
-  summary?: RiskScoreSummary
+  exposure?: ExecutiveExposureSummary | null
   isLoading: boolean
 }) {
-  const score = summary?.overallScore ?? 0
+  const score = exposure?.score ?? 0
   const clampedScore = Math.min(1000, Math.max(0, score))
-  const bandLabel = summary ? riskGaugeLabel(score) : 'Preparing'
-  const activeBand = riskGaugeBandMeta(score)
-  const bandTone = summary ? activeBand.colorClass : 'text-muted-foreground'
-  const chartData = [{ score: clampedScore, fill: summary ? activeBand.fill : 'var(--color-muted-foreground)' }]
+  const activeBand = exposure
+    ? riskGaugeBands.find((band) => band.band === normalizeRiskLevel(exposure.riskLevel)) ?? riskGaugeBandMeta(score)
+    : riskGaugeBandMeta(score)
+  const bandLabel = exposure ? activeBand.label : 'Preparing'
+  const bandTone = exposure ? activeBand.colorClass : 'text-muted-foreground'
+  const chartData = [{ score: clampedScore, fill: exposure ? activeBand.fill : 'var(--color-muted-foreground)' }]
 
   return (
     <div className="rounded-[1.6rem] border border-border/70 bg-background/60 p-5 shadow-sm backdrop-blur-sm">
@@ -209,7 +246,7 @@ function RiskScoreGauge({
       <div
         className="relative mt-5 flex h-[190px] items-center justify-center"
         role="img"
-        aria-label={`Current total risk score ${summary ? Math.round(score) : 'loading'} with ${bandLabel.toLowerCase()} status`}
+        aria-label={`Current total risk score ${exposure ? Math.round(score) : 'loading'} with ${bandLabel.toLowerCase()} status`}
       >
         <RadialBarChart
           width={280}
@@ -233,7 +270,7 @@ function RiskScoreGauge({
         </RadialBarChart>
         <div className="pointer-events-none absolute inset-x-0 bottom-6 text-center">
           <div className={cn('text-5xl font-semibold tracking-[-0.05em]', bandTone)}>
-            {summary ? Math.round(score) : isLoading ? '...' : 'N/A'}
+            {exposure ? Math.round(score) : isLoading ? '...' : 'N/A'}
           </div>
           <div className="mt-1 text-xs uppercase tracking-[0.16em] text-muted-foreground">
             Current risk score
@@ -243,16 +280,16 @@ function RiskScoreGauge({
 
       <div className="mt-1 flex items-end justify-between gap-4">
         <div className="text-xs text-muted-foreground">
-          {summary?.calculatedAt ? `Calculated ${new Date(summary.calculatedAt).toLocaleString()}` : 'Awaiting risk rollup'}
+          {describeExecutiveTrend(exposure)}
         </div>
         <div className="text-right text-xs text-muted-foreground">
-          <div>{summary?.assetCount ?? 0} scored assets</div>
-          <div>{summary?.criticalAssetCount ?? 0} critical / {summary?.highAssetCount ?? 0} high</div>
+          <div>{exposure?.assetCount ?? 0} scored assets</div>
+          <div>{exposure?.criticalAssetCount ?? 0} critical / {exposure?.highAssetCount ?? 0} high</div>
         </div>
       </div>
       <div className="mt-4 grid grid-cols-4 gap-1 text-[10px] uppercase tracking-[0.12em]">
         {riskGaugeBands.map((band) => {
-          const isActive = summary && band.band === activeBand.band
+          const isActive = exposure && band.band === activeBand.band
           return (
             <div
               key={band.band}
@@ -321,18 +358,11 @@ export function CisoExecutiveOverview({
   summary,
   trends,
   isLoading,
-  filters,
+  filters: _filters,
 }: Props) {
-  const { selectedTenantId } = useTenantScope()
-  const riskScoreQuery = useQuery({
-    queryKey: ['risk-score', 'summary', selectedTenantId, filters.minAgeDays, filters.platform, filters.deviceGroup],
-    queryFn: () => fetchRiskScoreSummary({ data: filters }),
-    enabled: Boolean(selectedTenantId),
-    placeholderData: (previousData) => previousData,
-    staleTime: 30_000,
-  })
   const tone = deriveTone(summary)
   const trend = getTrendDirection(trends)
+  const executiveExposure = summary.executiveExposure
   const criticalCount = summary.vulnerabilitiesBySeverity.Critical ?? 0
   const highCount = summary.vulnerabilitiesBySeverity.High ?? 0
   const topDeviceGroup = [...summary.vulnerabilitiesByDeviceGroup]
@@ -429,10 +459,10 @@ export function CisoExecutiveOverview({
                 <div className="rounded-[1.4rem] border border-border/70 bg-background/50 px-4 py-4 backdrop-blur-sm">
                   <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Top pressure area</div>
                   <div className="mt-2 text-lg font-medium tracking-tight">
-                    {topDeviceGroup?.deviceGroupName ?? 'No device-group pressure detected'}
+                    {executiveExposure?.topDriver ?? topDeviceGroup?.deviceGroupName ?? 'No active risk driver detected'}
                   </div>
                   <div className="mt-1 text-sm text-muted-foreground">
-                    {describePressureArea(topDeviceGroup)}
+                    {executiveExposure?.topDriverDetail ?? describePressureArea(topDeviceGroup)}
                   </div>
                 </div>
                 <div className="rounded-[1.4rem] border border-border/70 bg-background/50 px-4 py-4 backdrop-blur-sm">
@@ -448,7 +478,7 @@ export function CisoExecutiveOverview({
             </div>
 
             <div className="space-y-4">
-              <RiskScoreGauge summary={riskScoreQuery.data} isLoading={isLoading || riskScoreQuery.isFetching} />
+              <RiskScoreGauge exposure={executiveExposure} isLoading={isLoading} />
               <div className="rounded-[1.6rem] border border-border/70 bg-background/55 p-5 backdrop-blur-sm">
               <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
                 <Building2 className="size-4" />

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -48,6 +48,7 @@ public class DashboardController : ControllerBase
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
         }
         var (filteredAssetIds, minPublishedDate) = BuildFilterContext(tenantId, filter);
+        var hasFilters = filteredAssetIds is not null || minPublishedDate.HasValue;
 
         var riskChangeBrief = await _dashboardQueryService.BuildRiskChangeBriefAsync(
             tenantId,
@@ -196,8 +197,6 @@ public class DashboardController : ControllerBase
             );
         }).ToList();
 
-        var exposureScore = 0m;
-
         // SLA compliance and remediation metrics — tenant-wide, NOT affected by dashboard filters
         var patchingTasks = await _dbContext
             .PatchingTasks.AsNoTracking()
@@ -223,6 +222,7 @@ public class DashboardController : ControllerBase
         // Vulnerability exposure by device group — derived from DeviceGroupRiskScores (canonical).
         var vulnsByDeviceGroup = await _dbContext.DeviceGroupRiskScores.AsNoTracking()
             .Where(score => score.TenantId == tenantId)
+            .Where(score => string.IsNullOrEmpty(filter.DeviceGroup) || score.DeviceGroupName == filter.DeviceGroup)
             .OrderByDescending(score => score.OverallScore)
             .ThenByDescending(score => score.OpenEpisodeCount)
             .Take(10)
@@ -237,6 +237,16 @@ public class DashboardController : ControllerBase
                 score.OpenEpisodeCount
             ))
             .ToListAsync(ct);
+
+        var executiveExposure = await BuildExecutiveExposureSummaryAsync(
+            tenantId,
+            filter,
+            filteredAssetIds,
+            minPublishedDate,
+            vulnsByDeviceGroup,
+            hasFilters,
+            ct);
+        var exposureScore = executiveExposure.Score;
 
         // Device health breakdown — NOT affected by vulnerability filters
         var deviceHealthRows = await _dbContext
@@ -327,7 +337,8 @@ public class DashboardController : ControllerBase
                 slaComplianceTrend,
                 metricSparklines,
                 ageBuckets,
-                mttrBySeverity
+                mttrBySeverity,
+                executiveExposure
             )
         );
     }
@@ -1355,6 +1366,232 @@ public class DashboardController : ControllerBase
         return (filteredAssetIdQuery, minPublishedDate);
     }
 
+    private async Task<ExecutiveExposureSummaryDto> BuildExecutiveExposureSummaryAsync(
+        Guid tenantId,
+        DashboardFilterQuery filter,
+        IQueryable<Guid>? filteredAssetIds,
+        DateTimeOffset? minPublishedDate,
+        List<DeviceGroupVulnerabilityDto> deviceGroups,
+        bool hasFilters,
+        CancellationToken ct)
+    {
+        var query = _dbContext.DeviceRiskScores.AsNoTracking()
+            .Where(score => score.TenantId == tenantId);
+
+        if (filteredAssetIds is not null)
+        {
+            query = query.Where(score => filteredAssetIds.Contains(score.DeviceId));
+        }
+
+        if (minPublishedDate.HasValue)
+        {
+            query = query.Where(score => _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                .Any(exposure =>
+                    exposure.TenantId == tenantId
+                    && exposure.DeviceId == score.DeviceId
+                    && exposure.Status == ExposureStatus.Open
+                    && exposure.Vulnerability.PublishedDate >= minPublishedDate.Value));
+        }
+
+        var assetScores = await query
+            .OrderByDescending(score => score.OverallScore)
+            .Select(score => new RiskScoreService.AssetRiskResult(
+                score.DeviceId,
+                score.OverallScore,
+                score.MaxEpisodeRiskScore,
+                score.CriticalCount,
+                score.HighCount,
+                score.MediumCount,
+                score.LowCount,
+                score.OpenEpisodeCount,
+                score.FactorsJson
+            ))
+            .ToListAsync(ct);
+
+        var tenantRisk = RiskScoreService.CalculateTenantRisk(assetScores);
+        var scoreDelta = hasFilters
+            ? null
+            : await CalculateTenantRiskDeltaAsync(tenantId, tenantRisk.OverallScore, ct);
+        var trend = hasFilters ? "Filtered" : DescribeScoreTrend(scoreDelta);
+        var topDriver = await FindExecutiveTopDriverAsync(
+            tenantId,
+            filter,
+            filteredAssetIds,
+            minPublishedDate,
+            deviceGroups,
+            ct);
+
+        return new ExecutiveExposureSummaryDto(
+            tenantRisk.OverallScore,
+            DescribeRiskLevel(tenantRisk.OverallScore),
+            scoreDelta,
+            trend,
+            hasFilters ? "Filtered" : "Tenant",
+            tenantRisk.AssetCount,
+            tenantRisk.CriticalAssetCount,
+            tenantRisk.HighAssetCount,
+            topDriver?.Title,
+            topDriver?.Detail
+        );
+    }
+
+    private async Task<decimal?> CalculateTenantRiskDeltaAsync(
+        Guid tenantId,
+        decimal currentScore,
+        CancellationToken ct)
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var baseline = await _dbContext.TenantRiskScoreSnapshots.AsNoTracking()
+            .Where(snapshot => snapshot.TenantId == tenantId && snapshot.Date < today)
+            .OrderByDescending(snapshot => snapshot.Date)
+            .FirstOrDefaultAsync(ct);
+
+        return baseline is null
+            ? null
+            : Math.Round(currentScore - baseline.OverallScore, 2);
+    }
+
+    private async Task<ExecutiveTopDriver?> FindExecutiveTopDriverAsync(
+        Guid tenantId,
+        DashboardFilterQuery filter,
+        IQueryable<Guid>? filteredAssetIds,
+        DateTimeOffset? minPublishedDate,
+        List<DeviceGroupVulnerabilityDto> deviceGroups,
+        CancellationToken ct)
+    {
+        var candidates = new List<ExecutiveTopDriver>();
+
+        IEnumerable<DeviceGroupVulnerabilityDto> groupDriverCandidates = string.IsNullOrEmpty(filter.DeviceGroup) && filteredAssetIds is not null
+            ? []
+            : deviceGroups;
+        var topGroup = groupDriverCandidates
+            .Where(group => group.CurrentRiskScore.HasValue)
+            .OrderByDescending(group => group.CurrentRiskScore)
+            .FirstOrDefault();
+        if (topGroup is not null)
+        {
+            candidates.Add(new ExecutiveTopDriver(
+                $"Device group: {topGroup.DeviceGroupName}",
+                $"{topGroup.OpenEpisodeCount ?? 0} open episodes across {topGroup.AssetCount ?? 0} assets.",
+                topGroup.CurrentRiskScore ?? 0m));
+        }
+
+        var assetQuery =
+            from score in _dbContext.DeviceRiskScores.AsNoTracking()
+            join device in _dbContext.Devices.AsNoTracking()
+                on score.DeviceId equals device.Id
+            where score.TenantId == tenantId && device.TenantId == tenantId
+            select new { score, device };
+
+        if (filteredAssetIds is not null)
+        {
+            assetQuery = assetQuery.Where(item => filteredAssetIds.Contains(item.score.DeviceId));
+        }
+
+        if (minPublishedDate.HasValue)
+        {
+            assetQuery = assetQuery.Where(item => _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                .Any(exposure =>
+                    exposure.TenantId == tenantId
+                    && exposure.DeviceId == item.score.DeviceId
+                    && exposure.Status == ExposureStatus.Open
+                    && exposure.Vulnerability.PublishedDate >= minPublishedDate.Value));
+        }
+
+        var topAsset = await assetQuery
+            .OrderByDescending(item => item.score.OverallScore)
+            .Select(item => new
+            {
+                item.device.Name,
+                item.score.OverallScore,
+                item.score.OpenEpisodeCount,
+                item.score.CriticalCount,
+                item.score.HighCount,
+            })
+            .FirstOrDefaultAsync(ct);
+        if (topAsset is not null)
+        {
+            candidates.Add(new ExecutiveTopDriver(
+                $"Asset: {topAsset.Name}",
+                $"{topAsset.CriticalCount} critical and {topAsset.HighCount} high exposures among {topAsset.OpenEpisodeCount} open episodes.",
+                topAsset.OverallScore));
+        }
+
+        var softwareQuery =
+            from score in _dbContext.SoftwareRiskScores.AsNoTracking()
+            join product in _dbContext.SoftwareProducts.AsNoTracking()
+                on score.SoftwareProductId equals product.Id
+            where score.TenantId == tenantId
+            select new { score, product };
+
+        if (filteredAssetIds is not null)
+        {
+            softwareQuery = softwareQuery.Where(item => _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                .Any(exposure =>
+                    exposure.TenantId == tenantId
+                    && exposure.SoftwareProductId == item.score.SoftwareProductId
+                    && exposure.Status == ExposureStatus.Open
+                    && filteredAssetIds.Contains(exposure.DeviceId)));
+        }
+
+        if (minPublishedDate.HasValue)
+        {
+            softwareQuery = softwareQuery.Where(item => _dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+                .Any(exposure =>
+                    exposure.TenantId == tenantId
+                    && exposure.SoftwareProductId == item.score.SoftwareProductId
+                    && exposure.Status == ExposureStatus.Open
+                    && exposure.Vulnerability.PublishedDate >= minPublishedDate.Value));
+        }
+
+        var topSoftware = await softwareQuery
+            .OrderByDescending(item => item.score.OverallScore)
+            .Select(item => new
+            {
+                item.product.Name,
+                item.product.Vendor,
+                item.score.OverallScore,
+                item.score.OpenExposureCount,
+                item.score.AffectedDeviceCount,
+            })
+            .FirstOrDefaultAsync(ct);
+        if (topSoftware is not null)
+        {
+            candidates.Add(new ExecutiveTopDriver(
+                $"Software: {topSoftware.Vendor} {topSoftware.Name}",
+                $"{topSoftware.OpenExposureCount} open exposures across {topSoftware.AffectedDeviceCount} devices.",
+                topSoftware.OverallScore));
+        }
+
+        return candidates
+            .OrderByDescending(candidate => candidate.Score)
+            .FirstOrDefault();
+    }
+
+    private static string DescribeRiskLevel(decimal score) =>
+        score switch
+        {
+            >= 900m => "Critical",
+            >= 750m => "High",
+            >= 500m => "Elevated",
+            _ => "Contained",
+        };
+
+    private static string DescribeScoreTrend(decimal? delta)
+    {
+        if (!delta.HasValue)
+        {
+            return "NoBaseline";
+        }
+
+        return delta.Value switch
+        {
+            > 0m => "Worsening",
+            < 0m => "Improving",
+            _ => "Stable",
+        };
+    }
+
     private static string? NormalizeHeatmapGroupBy(string? groupBy)
     {
         return groupBy?.Trim().ToLowerInvariant() switch
@@ -1558,6 +1795,12 @@ public class DashboardController : ControllerBase
         string HighestSeverity,
         int VulnerabilityCount,
         int AffectedDeviceCount
+    );
+
+    private sealed record ExecutiveTopDriver(
+        string Title,
+        string Detail,
+        decimal Score
     );
 
     private sealed record OwnerTopDriverRow(

--- a/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
+++ b/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
@@ -21,7 +21,21 @@ public record DashboardSummaryDto(
     List<SlaComplianceTrendPointDto>? SlaComplianceTrend = null,
     MetricSparklinesDto? MetricSparklines = null,
     List<VulnerabilityAgeBucketDto>? VulnerabilityAgeBuckets = null,
-    List<MttrBySeverityDto>? MttrBySeverity = null
+    List<MttrBySeverityDto>? MttrBySeverity = null,
+    ExecutiveExposureSummaryDto? ExecutiveExposure = null
+);
+
+public record ExecutiveExposureSummaryDto(
+    decimal Score,
+    string RiskLevel,
+    decimal? ScoreDelta,
+    string Trend,
+    string Scope,
+    int AssetCount,
+    int CriticalAssetCount,
+    int HighAssetCount,
+    string? TopDriver,
+    string? TopDriverDetail
 );
 
 public record TopVulnerabilityDto(

--- a/tests/PatchHound.Tests/Api/DashboardControllerExecutiveSummaryTests.cs
+++ b/tests/PatchHound.Tests/Api/DashboardControllerExecutiveSummaryTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Api.Models.Dashboard;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class DashboardControllerExecutiveSummaryTests : IDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DashboardController _controller;
+
+    public DashboardControllerExecutiveSummaryTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId = Guid.NewGuid());
+        _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+
+        _controller = new DashboardController(
+            _dbContext,
+            new DashboardQueryService(_dbContext, Substitute.For<IRiskChangeBriefAiSummaryService>()),
+            _tenantContext,
+            new TenantSnapshotResolver(_dbContext)
+        );
+    }
+
+    [Fact]
+    public async Task GetSummary_PopulatesExecutiveExposureScoreAndTopDriver_WhenRiskRollupsExist()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        SeedRiskScores(seed);
+        _dbContext.TenantRiskScoreSnapshots.Add(TenantRiskScoreSnapshot.Create(
+            _tenantId,
+            DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
+            700m,
+            2,
+            0,
+            1));
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await GetSummaryAsync();
+
+        dto.ExposureScore.Should().BeGreaterThan(0m);
+        dto.ExecutiveExposure.Should().NotBeNull();
+        dto.ExecutiveExposure!.Score.Should().Be(dto.ExposureScore);
+        dto.ExecutiveExposure.RiskLevel.Should().Be("High");
+        dto.ExecutiveExposure.ScoreDelta.Should().BeGreaterThan(0m);
+        dto.ExecutiveExposure.Trend.Should().Be("Worsening");
+        dto.ExecutiveExposure.Scope.Should().Be("Tenant");
+        dto.ExecutiveExposure.TopDriver.Should().Be("Device group: Tier 0 Servers");
+        dto.ExecutiveExposure.TopDriverDetail.Should().Contain("open episodes");
+    }
+
+    [Fact]
+    public async Task GetSummary_ReturnsNoBaselineTrend_WhenTenantHasNoPriorSnapshot()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        SeedRiskScores(seed);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await GetSummaryAsync();
+
+        dto.ExecutiveExposure.Should().NotBeNull();
+        dto.ExecutiveExposure!.Score.Should().BeGreaterThan(0m);
+        dto.ExecutiveExposure.ScoreDelta.Should().BeNull();
+        dto.ExecutiveExposure.Trend.Should().Be("NoBaseline");
+    }
+
+    [Fact]
+    public async Task GetSummary_ReturnsImprovingTrend_WhenCurrentScoreIsBelowPriorSnapshot()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_dbContext, _tenantId);
+        SeedRiskScores(seed);
+        _dbContext.TenantRiskScoreSnapshots.Add(TenantRiskScoreSnapshot.Create(
+            _tenantId,
+            DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
+            900m,
+            2,
+            1,
+            1));
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await GetSummaryAsync();
+
+        dto.ExecutiveExposure.Should().NotBeNull();
+        dto.ExecutiveExposure!.ScoreDelta.Should().BeLessThan(0m);
+        dto.ExecutiveExposure.Trend.Should().Be("Improving");
+    }
+
+    private void SeedRiskScores(CanonicalSeed seed)
+    {
+        _dbContext.DeviceRiskScores.AddRange(
+            DeviceRiskScore.Create(_tenantId, seed.DeviceA.Id, 900m, 900m, 1, 0, 0, 0, 1, "[]", "1"),
+            DeviceRiskScore.Create(_tenantId, seed.DeviceB.Id, 820m, 820m, 0, 1, 0, 0, 1, "[]", "1")
+        );
+        _dbContext.DeviceGroupRiskScores.Add(DeviceGroupRiskScore.Create(
+            _tenantId,
+            "tier-0",
+            "tier-0",
+            "Tier 0 Servers",
+            930m,
+            900m,
+            1,
+            1,
+            0,
+            0,
+            2,
+            2,
+            "[]",
+            "1"));
+        _dbContext.SoftwareRiskScores.Add(SoftwareRiskScore.Create(
+            _tenantId,
+            seed.ProductA.Id,
+            760m,
+            900m,
+            1,
+            0,
+            0,
+            0,
+            1,
+            1,
+            "[]",
+            "1"));
+    }
+
+    private async Task<DashboardSummaryDto> GetSummaryAsync()
+    {
+        var action = await _controller.GetSummary(new DashboardFilterQuery(), CancellationToken.None);
+
+        var ok = action.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeOfType<DashboardSummaryDto>().Subject;
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}


### PR DESCRIPTION
Summary: populate dashboard exposure score from risk rollups, add executiveExposure fields for risk level, delta, trend, scope, asset counts, and top driver, surface them in the CISO overview, and add focused backend tests. Validation: dotnet test DashboardControllerExecutiveSummaryTests; dotnet build PatchHound.slnx; npm run lint; npm run typecheck; npm test -- --run. Closes #48