### PR TITLE
Add executive accountability rollups

### DIFF
--- a/frontend/src/api/dashboard.schemas.ts
+++ b/frontend/src/api/dashboard.schemas.ts
@@ -34,6 +34,41 @@ export const executiveExposureSummarySchema = z.object({
   topDriverDetail: z.string().nullable(),
 })
 
+export const executiveAccountabilityRowSchema = z.object({
+  teamId: z.string().uuid().nullable(),
+  ownerName: z.string(),
+  ownerAssignmentSource: z.string(),
+  riskScore: z.number(),
+  criticalOpenExposureCount: z.number(),
+  highOpenExposureCount: z.number(),
+  assetCount: z.number(),
+  openEpisodeCount: z.number(),
+  overduePatchingTaskCount: z.number(),
+  overdueApprovalCount: z.number(),
+  awaitingDecisionCount: z.number(),
+  acceptedRiskCount: z.number(),
+  manualOwnedAssetCount: z.number(),
+  ruleOwnedAssetCount: z.number(),
+  defaultRoutedAssetCount: z.number(),
+  manualOwnedSoftwareCount: z.number(),
+  ruleOwnedSoftwareCount: z.number(),
+  defaultRoutedSoftwareCount: z.number(),
+  unownedAssetCount: z.number(),
+  unownedSoftwareCount: z.number(),
+})
+
+export const executiveAccountabilitySummarySchema = z.object({
+  unownedAssetCount: z.number(),
+  unownedSoftwareCount: z.number(),
+  defaultRoutedAssetCount: z.number(),
+  defaultRoutedSoftwareCount: z.number(),
+  awaitingDecisionCount: z.number(),
+  overdueApprovalCount: z.number(),
+  overduePatchingTaskCount: z.number(),
+  acceptedRiskCount: z.number(),
+  topOwners: z.array(executiveAccountabilityRowSchema),
+})
+
 export const dashboardSummarySchema = z.object({
   exposureScore: z.number(),
   vulnerabilitiesBySeverity: z.record(z.string(), z.number()),
@@ -118,6 +153,7 @@ export const dashboardSummarySchema = z.object({
     previousDays: z.number().nullable(),
   })).optional(),
   executiveExposure: executiveExposureSummarySchema.nullable().optional(),
+  accountability: executiveAccountabilitySummarySchema.nullable().optional(),
 })
 
 export const trendItemSchema = z.object({
@@ -134,6 +170,7 @@ export const dashboardRiskChangeBriefSchema = dashboardSummarySchema.shape.riskC
 
 export type DashboardSummary = z.infer<typeof dashboardSummarySchema>
 export type ExecutiveExposureSummary = z.infer<typeof executiveExposureSummarySchema>
+export type ExecutiveAccountabilitySummary = z.infer<typeof executiveAccountabilitySummarySchema>
 export type TopVulnerability = z.infer<typeof topVulnerabilitySchema>
 export type UnhandledVulnerability = z.infer<typeof unhandledVulnerabilitySchema>
 export type TrendData = z.infer<typeof trendDataSchema>

--- a/frontend/src/components/features/dashboard/CisoExecutiveOverview.tsx
+++ b/frontend/src/components/features/dashboard/CisoExecutiveOverview.tsx
@@ -354,6 +354,21 @@ function ExecutiveSignalCard({
   )
 }
 
+function sourceTone(source: string) {
+  switch (source) {
+    case 'Rule':
+      return 'border-chart-3/30 text-chart-3'
+    case 'Manual':
+      return 'border-primary/30 text-primary'
+    case 'Default':
+      return 'border-tone-warning-border text-tone-warning-foreground'
+    case 'Unowned':
+      return 'border-destructive/35 text-destructive'
+    default:
+      return 'border-border text-muted-foreground'
+  }
+}
+
 export function CisoExecutiveOverview({
   summary,
   trends,
@@ -383,6 +398,12 @@ export function CisoExecutiveOverview({
     : movementIsImproving
       ? 'contained'
       : 'contained'
+  const accountability = summary.accountability
+  const accountabilityOpenWork = (accountability?.awaitingDecisionCount ?? 0)
+    + (accountability?.overdueApprovalCount ?? 0)
+    + (accountability?.overduePatchingTaskCount ?? 0)
+  const unownedCount = (accountability?.unownedAssetCount ?? 0) + (accountability?.unownedSoftwareCount ?? 0)
+  const defaultRoutedCount = (accountability?.defaultRoutedAssetCount ?? 0) + (accountability?.defaultRoutedSoftwareCount ?? 0)
 
   return (
     <section className="space-y-6 pb-4">
@@ -538,6 +559,66 @@ export function CisoExecutiveOverview({
           icon={Trophy}
         />
       </div>
+
+      {accountability ? (
+        <Card className="rounded-[1.6rem] border-border/70">
+          <CardHeader>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <CardTitle>Ownership Accountability</CardTitle>
+                <CardDescription>
+                  Owner-level risk, unanswered workflow decisions, and routing gaps.
+                </CardDescription>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="outline" className={cn('rounded-full px-3 py-1 text-xs', unownedCount > 0 && 'border-destructive/35 text-destructive')}>
+                  {unownedCount} unowned
+                </Badge>
+                <Badge variant="outline" className={cn('rounded-full px-3 py-1 text-xs', defaultRoutedCount > 0 && 'border-tone-warning-border text-tone-warning-foreground')}>
+                  {defaultRoutedCount} default-routed
+                </Badge>
+                <Badge variant="outline" className={cn('rounded-full px-3 py-1 text-xs', accountabilityOpenWork > 0 && 'border-primary/35 text-primary')}>
+                  {accountabilityOpenWork} blocked
+                </Badge>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {accountability.topOwners.slice(0, 5).map((owner) => {
+              const urgentWork = owner.overduePatchingTaskCount + owner.overdueApprovalCount + owner.awaitingDecisionCount
+              const routedCount = owner.manualOwnedAssetCount + owner.ruleOwnedAssetCount + owner.defaultRoutedAssetCount
+                + owner.manualOwnedSoftwareCount + owner.ruleOwnedSoftwareCount + owner.defaultRoutedSoftwareCount
+              return (
+                <div key={owner.teamId ?? owner.ownerName} className="rounded-[1.2rem] border border-border/60 bg-background/40 px-4 py-3">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="font-medium tracking-tight">{owner.ownerName}</div>
+                        <Badge variant="outline" className={cn('rounded-full px-2 py-0.5 text-[11px]', sourceTone(owner.ownerAssignmentSource))}>
+                          {owner.ownerAssignmentSource}
+                        </Badge>
+                      </div>
+                      <div className="mt-1 text-sm text-muted-foreground">
+                        {owner.criticalOpenExposureCount} critical, {owner.highOpenExposureCount} high, {urgentWork} decision or overdue items.
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <div className="text-2xl font-semibold tracking-[-0.05em]">{Math.round(owner.riskScore)}</div>
+                      <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">owner risk</div>
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-4">
+                    <div>{owner.assetCount || owner.unownedAssetCount} assets</div>
+                    <div>{routedCount || owner.unownedSoftwareCount} routed items</div>
+                    <div>{owner.acceptedRiskCount} accepted risk</div>
+                    <div>{owner.openEpisodeCount} open episodes</div>
+                  </div>
+                </div>
+              )
+            })}
+          </CardContent>
+        </Card>
+      ) : null}
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(20rem,1fr)]">
         <Card className="rounded-[1.6rem] border-border/70">

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -246,6 +246,7 @@ public class DashboardController : ControllerBase
             vulnsByDeviceGroup,
             hasFilters,
             ct);
+        var accountability = await BuildExecutiveAccountabilitySummaryAsync(tenantId, now, ct);
         var exposureScore = executiveExposure.Score;
 
         // Device health breakdown — NOT affected by vulnerability filters
@@ -338,7 +339,8 @@ public class DashboardController : ControllerBase
                 metricSparklines,
                 ageBuckets,
                 mttrBySeverity,
-                executiveExposure
+                executiveExposure,
+                accountability
             )
         );
     }
@@ -1366,6 +1368,277 @@ public class DashboardController : ControllerBase
         return (filteredAssetIdQuery, minPublishedDate);
     }
 
+    private async Task<ExecutiveAccountabilitySummaryDto> BuildExecutiveAccountabilitySummaryAsync(
+        Guid tenantId,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        var teams = await _dbContext.Teams.AsNoTracking()
+            .Where(team => team.TenantId == tenantId)
+            .Select(team => new { team.Id, team.Name, team.IsDefault })
+            .ToListAsync(ct);
+        var teamsById = teams.ToDictionary(team => team.Id);
+        var defaultTeamIds = teams.Where(team => team.IsDefault).Select(team => team.Id).ToHashSet();
+
+        var teamRiskRows = await _dbContext.TeamRiskScores.AsNoTracking()
+            .Where(score => score.TenantId == tenantId)
+            .Select(score => new
+            {
+                score.TeamId,
+                score.OverallScore,
+                score.CriticalEpisodeCount,
+                score.HighEpisodeCount,
+                score.AssetCount,
+                score.OpenEpisodeCount,
+            })
+            .ToListAsync(ct);
+        var teamRiskByTeamId = teamRiskRows.ToDictionary(row => row.TeamId);
+
+        var deviceOwnershipRows = await _dbContext.Devices.AsNoTracking()
+            .Where(device => device.TenantId == tenantId)
+            .Select(device => new
+            {
+                device.Id,
+                device.OwnerTeamId,
+                device.OwnerTeamRuleId,
+                device.FallbackTeamId,
+            })
+            .ToListAsync(ct);
+
+        var softwareOwnershipRows = await _dbContext.SoftwareTenantRecords.AsNoTracking()
+            .Where(record => record.TenantId == tenantId)
+            .Select(record => new
+            {
+                record.SoftwareProductId,
+                record.OwnerTeamId,
+                record.OwnerTeamRuleId,
+            })
+            .ToListAsync(ct);
+
+        var workflowRows = await _dbContext.RemediationWorkflows.AsNoTracking()
+            .Where(workflow => workflow.TenantId == tenantId)
+            .Select(workflow => new
+            {
+                workflow.Id,
+                workflow.RemediationCaseId,
+                workflow.SoftwareOwnerTeamId,
+                workflow.CurrentStage,
+                workflow.Status,
+            })
+            .ToListAsync(ct);
+        var workflowsById = workflowRows.ToDictionary(workflow => workflow.Id);
+
+        var caseProductRows = await _dbContext.RemediationCases.AsNoTracking()
+            .Where(remediationCase => remediationCase.TenantId == tenantId)
+            .Select(remediationCase => new
+            {
+                remediationCase.Id,
+                remediationCase.SoftwareProductId,
+            })
+            .ToListAsync(ct);
+        var caseProductByCaseId = caseProductRows.ToDictionary(row => row.Id, row => row.SoftwareProductId);
+        var softwareOwnerByProductId = softwareOwnershipRows
+            .Where(row => row.OwnerTeamId.HasValue)
+            .ToDictionary(row => row.SoftwareProductId, row => row.OwnerTeamId!.Value);
+
+        Guid? ResolveRemediationOwner(Guid? workflowId, Guid remediationCaseId)
+        {
+            if (workflowId.HasValue && workflowsById.TryGetValue(workflowId.Value, out var workflow))
+            {
+                return workflow.SoftwareOwnerTeamId;
+            }
+
+            return caseProductByCaseId.TryGetValue(remediationCaseId, out var productId)
+                && softwareOwnerByProductId.TryGetValue(productId, out var ownerTeamId)
+                    ? ownerTeamId
+                    : null;
+        }
+
+        var overduePatchingRows = await _dbContext.PatchingTasks.AsNoTracking()
+            .Where(task => task.TenantId == tenantId
+                && task.Status != PatchingTaskStatus.Completed
+                && task.DueDate < now)
+            .Select(task => new
+            {
+                task.OwnerTeamId,
+            })
+            .ToListAsync(ct);
+        var overduePatchingByTeamId = overduePatchingRows
+            .GroupBy(task => task.OwnerTeamId)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var overdueApprovalRows = await _dbContext.ApprovalTasks.AsNoTracking()
+            .Where(task => task.TenantId == tenantId
+                && task.Status == ApprovalTaskStatus.Pending
+                && task.ExpiresAt < now)
+            .Select(task => new
+            {
+                task.RemediationWorkflowId,
+                task.RemediationCaseId,
+            })
+            .ToListAsync(ct);
+        var overdueApprovalByTeamId = overdueApprovalRows
+            .Select(row => ResolveRemediationOwner(row.RemediationWorkflowId, row.RemediationCaseId))
+            .Where(teamId => teamId.HasValue)
+            .GroupBy(teamId => teamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var awaitingDecisionByTeamId = workflowRows
+            .Where(workflow => workflow.Status == RemediationWorkflowStatus.Active
+                && workflow.CurrentStage == RemediationWorkflowStage.RemediationDecision)
+            .GroupBy(workflow => workflow.SoftwareOwnerTeamId)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var acceptedRiskRows = await _dbContext.RemediationDecisions.AsNoTracking()
+            .Where(decision => decision.TenantId == tenantId
+                && decision.Outcome == RemediationOutcome.RiskAcceptance
+                && decision.ApprovalStatus == DecisionApprovalStatus.Approved)
+            .Select(decision => new
+            {
+                decision.RemediationWorkflowId,
+                decision.RemediationCaseId,
+            })
+            .ToListAsync(ct);
+        var acceptedRiskByTeamId = acceptedRiskRows
+            .Select(row => ResolveRemediationOwner(row.RemediationWorkflowId, row.RemediationCaseId))
+            .Where(teamId => teamId.HasValue)
+            .GroupBy(teamId => teamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var manualAssetsByTeamId = deviceOwnershipRows
+            .Where(row => row.OwnerTeamId.HasValue
+                && row.OwnerTeamRuleId is null
+                && !defaultTeamIds.Contains(row.OwnerTeamId.Value))
+            .GroupBy(row => row.OwnerTeamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var ruleAssetsByTeamId = deviceOwnershipRows
+            .Where(row => row.OwnerTeamId.HasValue && row.OwnerTeamRuleId is not null)
+            .GroupBy(row => row.OwnerTeamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var defaultAssetsByTeamId = deviceOwnershipRows
+            .Select(row => row.OwnerTeamId ?? row.FallbackTeamId)
+            .Where(teamId => teamId.HasValue && defaultTeamIds.Contains(teamId.Value))
+            .GroupBy(teamId => teamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var manualSoftwareByTeamId = softwareOwnershipRows
+            .Where(row => row.OwnerTeamId.HasValue
+                && row.OwnerTeamRuleId is null
+                && !defaultTeamIds.Contains(row.OwnerTeamId.Value))
+            .GroupBy(row => row.OwnerTeamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var ruleSoftwareByTeamId = softwareOwnershipRows
+            .Where(row => row.OwnerTeamId.HasValue && row.OwnerTeamRuleId is not null)
+            .GroupBy(row => row.OwnerTeamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var defaultSoftwareByTeamId = softwareOwnershipRows
+            .Where(row => row.OwnerTeamId.HasValue && defaultTeamIds.Contains(row.OwnerTeamId.Value))
+            .GroupBy(row => row.OwnerTeamId!.Value)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var unownedAssetCount = deviceOwnershipRows.Count(row =>
+            !row.OwnerTeamId.HasValue && !row.FallbackTeamId.HasValue);
+        var unownedSoftwareCount = softwareOwnershipRows.Count(row => !row.OwnerTeamId.HasValue);
+        var defaultRoutedAssetCount = defaultAssetsByTeamId.Values.Sum();
+        var defaultRoutedSoftwareCount = defaultSoftwareByTeamId.Values.Sum();
+
+        var teamIds = teamRiskByTeamId.Keys
+            .Concat(overduePatchingByTeamId.Keys)
+            .Concat(overdueApprovalByTeamId.Keys)
+            .Concat(awaitingDecisionByTeamId.Keys)
+            .Concat(acceptedRiskByTeamId.Keys)
+            .Concat(manualAssetsByTeamId.Keys)
+            .Concat(ruleAssetsByTeamId.Keys)
+            .Concat(defaultAssetsByTeamId.Keys)
+            .Concat(manualSoftwareByTeamId.Keys)
+            .Concat(ruleSoftwareByTeamId.Keys)
+            .Concat(defaultSoftwareByTeamId.Keys)
+            .Distinct()
+            .ToList();
+
+        var rows = teamIds.Select(teamId =>
+        {
+            teamRiskByTeamId.TryGetValue(teamId, out var risk);
+            var manualAssetCount = manualAssetsByTeamId.GetValueOrDefault(teamId);
+            var ruleAssetCount = ruleAssetsByTeamId.GetValueOrDefault(teamId);
+            var defaultAssetCount = defaultAssetsByTeamId.GetValueOrDefault(teamId);
+            var manualSoftwareCount = manualSoftwareByTeamId.GetValueOrDefault(teamId);
+            var ruleSoftwareCount = ruleSoftwareByTeamId.GetValueOrDefault(teamId);
+            var defaultSoftwareCount = defaultSoftwareByTeamId.GetValueOrDefault(teamId);
+            var ownerName = teamsById.TryGetValue(teamId, out var team) ? team.Name : "Unknown team";
+
+            return new ExecutiveAccountabilityRowDto(
+                teamId,
+                ownerName,
+                DescribeOwnerAssignmentSource(
+                    manualAssetCount + manualSoftwareCount,
+                    ruleAssetCount + ruleSoftwareCount,
+                    defaultAssetCount + defaultSoftwareCount),
+                risk?.OverallScore ?? 0m,
+                risk?.CriticalEpisodeCount ?? 0,
+                risk?.HighEpisodeCount ?? 0,
+                risk?.AssetCount ?? 0,
+                risk?.OpenEpisodeCount ?? 0,
+                overduePatchingByTeamId.GetValueOrDefault(teamId),
+                overdueApprovalByTeamId.GetValueOrDefault(teamId),
+                awaitingDecisionByTeamId.GetValueOrDefault(teamId),
+                acceptedRiskByTeamId.GetValueOrDefault(teamId),
+                manualAssetCount,
+                ruleAssetCount,
+                defaultAssetCount,
+                manualSoftwareCount,
+                ruleSoftwareCount,
+                defaultSoftwareCount,
+                0,
+                0);
+        }).ToList();
+
+        if (unownedAssetCount + unownedSoftwareCount > 0)
+        {
+            rows.Add(new ExecutiveAccountabilityRowDto(
+                null,
+                "Unowned",
+                "Unowned",
+                0m,
+                0,
+                0,
+                unownedAssetCount,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                unownedAssetCount,
+                unownedSoftwareCount));
+        }
+
+        var topOwners = rows
+            .OrderByDescending(row => row.RiskScore)
+            .ThenByDescending(row => row.OverdueApprovalCount + row.OverduePatchingTaskCount)
+            .ThenByDescending(row => row.AwaitingDecisionCount)
+            .ThenByDescending(row => row.AcceptedRiskCount)
+            .ThenByDescending(row => row.UnownedAssetCount + row.UnownedSoftwareCount)
+            .Take(8)
+            .ToList();
+
+        return new ExecutiveAccountabilitySummaryDto(
+            unownedAssetCount,
+            unownedSoftwareCount,
+            defaultRoutedAssetCount,
+            defaultRoutedSoftwareCount,
+            awaitingDecisionByTeamId.Values.Sum(),
+            overdueApprovalByTeamId.Values.Sum(),
+            overduePatchingByTeamId.Values.Sum(),
+            acceptedRiskByTeamId.Values.Sum(),
+            topOwners);
+    }
+
     private async Task<ExecutiveExposureSummaryDto> BuildExecutiveExposureSummaryAsync(
         Guid tenantId,
         DashboardFilterQuery filter,
@@ -1590,6 +1863,19 @@ public class DashboardController : ControllerBase
             < 0m => "Improving",
             _ => "Stable",
         };
+    }
+
+    private static string DescribeOwnerAssignmentSource(
+        int manualCount,
+        int ruleCount,
+        int defaultCount)
+    {
+        if (defaultCount > 0 && defaultCount >= manualCount && defaultCount >= ruleCount)
+        {
+            return "Default";
+        }
+
+        return ruleCount > manualCount ? "Rule" : "Manual";
     }
 
     private static string? NormalizeHeatmapGroupBy(string? groupBy)

--- a/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
+++ b/src/PatchHound.Api/Models/Dashboard/DashboardSummaryDto.cs
@@ -22,7 +22,8 @@ public record DashboardSummaryDto(
     MetricSparklinesDto? MetricSparklines = null,
     List<VulnerabilityAgeBucketDto>? VulnerabilityAgeBuckets = null,
     List<MttrBySeverityDto>? MttrBySeverity = null,
-    ExecutiveExposureSummaryDto? ExecutiveExposure = null
+    ExecutiveExposureSummaryDto? ExecutiveExposure = null,
+    ExecutiveAccountabilitySummaryDto? Accountability = null
 );
 
 public record ExecutiveExposureSummaryDto(
@@ -36,6 +37,41 @@ public record ExecutiveExposureSummaryDto(
     int HighAssetCount,
     string? TopDriver,
     string? TopDriverDetail
+);
+
+public record ExecutiveAccountabilitySummaryDto(
+    int UnownedAssetCount,
+    int UnownedSoftwareCount,
+    int DefaultRoutedAssetCount,
+    int DefaultRoutedSoftwareCount,
+    int AwaitingDecisionCount,
+    int OverdueApprovalCount,
+    int OverduePatchingTaskCount,
+    int AcceptedRiskCount,
+    List<ExecutiveAccountabilityRowDto> TopOwners
+);
+
+public record ExecutiveAccountabilityRowDto(
+    Guid? TeamId,
+    string OwnerName,
+    string OwnerAssignmentSource,
+    decimal RiskScore,
+    int CriticalOpenExposureCount,
+    int HighOpenExposureCount,
+    int AssetCount,
+    int OpenEpisodeCount,
+    int OverduePatchingTaskCount,
+    int OverdueApprovalCount,
+    int AwaitingDecisionCount,
+    int AcceptedRiskCount,
+    int ManualOwnedAssetCount,
+    int RuleOwnedAssetCount,
+    int DefaultRoutedAssetCount,
+    int ManualOwnedSoftwareCount,
+    int RuleOwnedSoftwareCount,
+    int DefaultRoutedSoftwareCount,
+    int UnownedAssetCount,
+    int UnownedSoftwareCount
 );
 
 public record TopVulnerabilityDto(

--- a/tests/PatchHound.Tests/Api/DashboardControllerAccountabilitySummaryTests.cs
+++ b/tests/PatchHound.Tests/Api/DashboardControllerAccountabilitySummaryTests.cs
@@ -1,0 +1,199 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Api.Models.Dashboard;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class DashboardControllerAccountabilitySummaryTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _otherTenantId = Guid.NewGuid();
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DashboardController _controller;
+
+    public DashboardControllerAccountabilitySummaryTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId);
+        _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+
+        _controller = new DashboardController(
+            _dbContext,
+            new DashboardQueryService(_dbContext, Substitute.For<IRiskChangeBriefAiSummaryService>()),
+            _tenantContext,
+            new TenantSnapshotResolver(_dbContext)
+        );
+    }
+
+    [Fact]
+    public async Task GetSummary_ReturnsExecutiveAccountabilityRollups_ByOwnerSourceAndTenant()
+    {
+        var manualTeam = Team.Create(_tenantId, "Manual Owners");
+        var ruleTeam = Team.Create(_tenantId, "Rule Owners");
+        var defaultTeam = Team.CreateDefault(_tenantId, "Default Queue");
+        var otherTenantTeam = Team.Create(_otherTenantId, "Other Tenant");
+        await _dbContext.AddRangeAsync(manualTeam, ruleTeam, defaultTeam, otherTenantTeam);
+
+        var sourceId = Guid.NewGuid();
+        var manualDevice = Device.Create(_tenantId, sourceId, "manual-device", "Manual Device", Criticality.High);
+        manualDevice.AssignTeamOwner(manualTeam.Id);
+        var ruleDevice = Device.Create(_tenantId, sourceId, "rule-device", "Rule Device", Criticality.High);
+        ruleDevice.AssignTeamOwnerFromRule(ruleTeam.Id, Guid.NewGuid());
+        var defaultDevice = Device.Create(_tenantId, sourceId, "default-device", "Default Device", Criticality.Medium);
+        defaultDevice.SetFallbackTeamFromRule(defaultTeam.Id, Guid.NewGuid());
+        var unownedDevice = Device.Create(_tenantId, sourceId, "unowned-device", "Unowned Device", Criticality.Low);
+        var otherTenantDevice = Device.Create(_otherTenantId, sourceId, "other-device", "Other Device", Criticality.High);
+        otherTenantDevice.AssignTeamOwner(otherTenantTeam.Id);
+        await _dbContext.AddRangeAsync(manualDevice, ruleDevice, defaultDevice, unownedDevice, otherTenantDevice);
+
+        var manualProduct = SoftwareProduct.Create("Manual", "Agent", null);
+        var ruleProduct = SoftwareProduct.Create("Rule", "Agent", null);
+        var defaultProduct = SoftwareProduct.Create("Default", "Agent", null);
+        var unownedProduct = SoftwareProduct.Create("Unowned", "Agent", null);
+        var otherTenantProduct = SoftwareProduct.Create("Other", "Agent", null);
+        await _dbContext.AddRangeAsync(manualProduct, ruleProduct, defaultProduct, unownedProduct, otherTenantProduct);
+        await _dbContext.SaveChangesAsync();
+
+        var manualSoftware = SoftwareTenantRecord.Create(_tenantId, null, manualProduct.Id, DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow);
+        manualSoftware.AssignOwnerTeam(manualTeam.Id);
+        var ruleSoftware = SoftwareTenantRecord.Create(_tenantId, null, ruleProduct.Id, DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow);
+        ruleSoftware.AssignOwnerTeamFromRule(ruleTeam.Id, Guid.NewGuid());
+        var defaultSoftware = SoftwareTenantRecord.Create(_tenantId, null, defaultProduct.Id, DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow);
+        defaultSoftware.AssignOwnerTeam(defaultTeam.Id);
+        var unownedSoftware = SoftwareTenantRecord.Create(_tenantId, null, unownedProduct.Id, DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow);
+        var otherTenantSoftware = SoftwareTenantRecord.Create(_otherTenantId, null, otherTenantProduct.Id, DateTimeOffset.UtcNow.AddDays(-10), DateTimeOffset.UtcNow);
+        otherTenantSoftware.AssignOwnerTeam(otherTenantTeam.Id);
+        await _dbContext.AddRangeAsync(manualSoftware, ruleSoftware, defaultSoftware, unownedSoftware, otherTenantSoftware);
+
+        _dbContext.TeamRiskScores.AddRange(
+            TeamRiskScore.Create(_tenantId, manualTeam.Id, 860m, 860m, 2, 1, 0, 0, 1, 3, "[]", "1"),
+            TeamRiskScore.Create(_tenantId, ruleTeam.Id, 780m, 780m, 1, 2, 0, 0, 1, 3, "[]", "1"),
+            TeamRiskScore.Create(_tenantId, defaultTeam.Id, 620m, 620m, 0, 1, 0, 0, 1, 1, "[]", "1"),
+            TeamRiskScore.Create(_otherTenantId, otherTenantTeam.Id, 999m, 999m, 9, 9, 0, 0, 1, 18, "[]", "1")
+        );
+
+        var manualCase = RemediationCase.Create(_tenantId, manualProduct.Id);
+        var manualWorkflow = RemediationWorkflow.Create(_tenantId, manualCase.Id, manualTeam.Id);
+        var manualDecision = RemediationDecision.Create(_tenantId, manualCase.Id, RemediationOutcome.ApprovedForPatching, null, Guid.NewGuid());
+        manualDecision.AttachToWorkflow(manualWorkflow.Id);
+        var overduePatching = PatchingTask.Create(_tenantId, manualCase.Id, manualDecision.Id, manualTeam.Id, DateTimeOffset.UtcNow.AddDays(-1));
+        overduePatching.AttachToWorkflow(manualWorkflow.Id);
+
+        var ruleCase = RemediationCase.Create(_tenantId, ruleProduct.Id);
+        var ruleWorkflow = RemediationWorkflow.Create(_tenantId, ruleCase.Id, ruleTeam.Id, RemediationWorkflowStage.RemediationDecision);
+        var ruleDecision = RemediationDecision.Create(
+            _tenantId,
+            ruleCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Accepted for one cycle",
+            Guid.NewGuid(),
+            DecisionApprovalStatus.PendingApproval);
+        ruleDecision.AttachToWorkflow(ruleWorkflow.Id);
+        var overdueApproval = ApprovalTask.Create(
+            _tenantId,
+            ruleCase.Id,
+            ruleDecision.Id,
+            RemediationOutcome.RiskAcceptance,
+            ApprovalTaskStatus.Pending,
+            DateTimeOffset.UtcNow.AddDays(-1));
+        overdueApproval.AttachToWorkflow(ruleWorkflow.Id);
+
+        var defaultCase = RemediationCase.Create(_tenantId, defaultProduct.Id);
+        var defaultWorkflow = RemediationWorkflow.Create(_tenantId, defaultCase.Id, defaultTeam.Id);
+        var acceptedRisk = RemediationDecision.Create(
+            _tenantId,
+            defaultCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Default queue accepted temporarily",
+            Guid.NewGuid(),
+            DecisionApprovalStatus.Approved);
+        acceptedRisk.AttachToWorkflow(defaultWorkflow.Id);
+
+        var otherCase = RemediationCase.Create(_otherTenantId, otherTenantProduct.Id);
+        var otherWorkflow = RemediationWorkflow.Create(_otherTenantId, otherCase.Id, otherTenantTeam.Id, RemediationWorkflowStage.RemediationDecision);
+
+        await _dbContext.AddRangeAsync(
+            manualCase,
+            manualWorkflow,
+            manualDecision,
+            overduePatching,
+            ruleCase,
+            ruleWorkflow,
+            ruleDecision,
+            overdueApproval,
+            defaultCase,
+            defaultWorkflow,
+            acceptedRisk,
+            otherCase,
+            otherWorkflow);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await GetSummaryAsync();
+
+        dto.Accountability.Should().NotBeNull();
+        var accountability = dto.Accountability!;
+        accountability.UnownedAssetCount.Should().Be(1);
+        accountability.UnownedSoftwareCount.Should().Be(1);
+        accountability.DefaultRoutedAssetCount.Should().Be(1);
+        accountability.DefaultRoutedSoftwareCount.Should().Be(1);
+        accountability.AwaitingDecisionCount.Should().Be(1);
+        accountability.OverdueApprovalCount.Should().Be(1);
+        accountability.OverduePatchingTaskCount.Should().Be(1);
+        accountability.AcceptedRiskCount.Should().Be(1);
+
+        accountability.TopOwners.Should().NotContain(row => row.OwnerName == "Other Tenant");
+
+        var manualRow = accountability.TopOwners.Should().Contain(row => row.TeamId == manualTeam.Id).Subject;
+        manualRow.OwnerAssignmentSource.Should().Be("Manual");
+        manualRow.OverduePatchingTaskCount.Should().Be(1);
+        manualRow.CriticalOpenExposureCount.Should().Be(2);
+
+        var ruleRow = accountability.TopOwners.Should().Contain(row => row.TeamId == ruleTeam.Id).Subject;
+        ruleRow.OwnerAssignmentSource.Should().Be("Rule");
+        ruleRow.AwaitingDecisionCount.Should().Be(1);
+        ruleRow.OverdueApprovalCount.Should().Be(1);
+
+        var defaultRow = accountability.TopOwners.Should().Contain(row => row.TeamId == defaultTeam.Id).Subject;
+        defaultRow.OwnerAssignmentSource.Should().Be("Default");
+        defaultRow.DefaultRoutedAssetCount.Should().Be(1);
+        defaultRow.DefaultRoutedSoftwareCount.Should().Be(1);
+        defaultRow.AcceptedRiskCount.Should().Be(1);
+
+        var unownedRow = accountability.TopOwners.Should().Contain(row => row.TeamId == null).Subject;
+        unownedRow.UnownedAssetCount.Should().Be(1);
+        unownedRow.UnownedSoftwareCount.Should().Be(1);
+    }
+
+    private async Task<DashboardSummaryDto> GetSummaryAsync()
+    {
+        var action = await _controller.GetSummary(new DashboardFilterQuery(), CancellationToken.None);
+
+        var ok = action.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeOfType<DashboardSummaryDto>().Subject;
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}


### PR DESCRIPTION
Summary: adds tenant-wide executive accountability rollups to dashboard summary, including top owner/team rows, manual/rule/default routing counts, unowned assets/software, overdue patching, overdue approvals, awaiting decisions, and accepted risk. Surfaces the rollups in the executive dashboard and adds focused controller coverage for manual/rule/default ownership and tenant isolation. Validation: dotnet test DashboardControllerAccountabilitySummaryTests; dotnet build PatchHound.slnx; npm run lint; npm run typecheck; npm test -- --run. Closes #52