### PR TITLE
Fix duplicate key crash in GET /api/dashboard/summary

### DIFF
--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -1439,7 +1439,8 @@ public class DashboardController : ControllerBase
         var caseProductByCaseId = caseProductRows.ToDictionary(row => row.Id, row => row.SoftwareProductId);
         var softwareOwnerByProductId = softwareOwnershipRows
             .Where(row => row.OwnerTeamId.HasValue)
-            .ToDictionary(row => row.SoftwareProductId, row => row.OwnerTeamId!.Value);
+            .GroupBy(row => row.SoftwareProductId)
+            .ToDictionary(g => g.Key, g => g.First().OwnerTeamId!.Value);
 
         Guid? ResolveRemediationOwner(Guid? workflowId, Guid remediationCaseId)
         {


### PR DESCRIPTION
## Summary

- `BuildExecutiveAccountabilitySummaryAsync` called `.ToDictionary(row => row.SoftwareProductId, ...)` on `SoftwareTenantRecords`, but a product can appear in multiple rows across snapshots — causing an `ArgumentException: An item with the same key has already been added` at runtime.
- Fix: group by `SoftwareProductId` first, then take the first owner-assigned row per product when building the dictionary.

## Root cause

`SoftwareTenantRecord` is keyed by `(TenantId, SoftwareProductId, SnapshotId)`. Querying all records for a tenant without deduplicating yields one row per snapshot per product. Owner assignment is a property of the product (not the snapshot), so any row carries the same value — picking `First()` is safe.

## Test plan

- [ ] Reproduce: ensure tenant has a software product with ownership set and multiple snapshot records, then hit `GET /api/dashboard/summary` — previously threw 500, now returns 200.
- [ ] Confirm no regression in dashboard summary response shape.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)