### PR TITLE
Add business value categories with risk-weight multipliers to labels

### DIFF
--- a/frontend/src/api/business-labels.schemas.ts
+++ b/frontend/src/api/business-labels.schemas.ts
@@ -1,11 +1,48 @@
 import { z } from 'zod'
 
+export const businessLabelWeightCategorySchema = z.enum([
+  'Informational',
+  'Normal',
+  'Sensitive',
+  'Critical',
+])
+
+export type BusinessLabelWeightCategory = z.infer<typeof businessLabelWeightCategorySchema>
+
+export const WEIGHT_CATEGORY_CONFIG: Record<
+  BusinessLabelWeightCategory,
+  { label: string; description: string; riskWeight: number }
+> = {
+  Informational: {
+    label: 'Informational',
+    description: 'Low business value. Reduces risk score (0.5×).',
+    riskWeight: 0.5,
+  },
+  Normal: {
+    label: 'Normal',
+    description: 'Standard business value. No score adjustment (1.0×).',
+    riskWeight: 1.0,
+  },
+  Sensitive: {
+    label: 'Sensitive',
+    description: 'Elevated business value. Increases risk score (1.5×).',
+    riskWeight: 1.5,
+  },
+  Critical: {
+    label: 'Critical',
+    description: 'Critical business value. Significantly increases risk score (2.0×).',
+    riskWeight: 2.0,
+  },
+}
+
 export const businessLabelSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   description: z.string().nullable(),
   color: z.string().nullable(),
   isActive: z.boolean(),
+  weightCategory: businessLabelWeightCategorySchema,
+  riskWeight: z.number(),
   createdAt: z.string(),
   updatedAt: z.string(),
 })
@@ -15,6 +52,7 @@ export const saveBusinessLabelSchema = z.object({
   description: z.string().nullable().optional(),
   color: z.string().nullable().optional(),
   isActive: z.boolean().optional(),
+  weightCategory: businessLabelWeightCategorySchema.optional(),
 })
 
 export type BusinessLabel = z.infer<typeof businessLabelSchema>

--- a/frontend/src/api/devices.schemas.ts
+++ b/frontend/src/api/devices.schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { pagedResponseMetaSchema } from './pagination.schemas'
 import { remediationTaskSummarySchema } from './remediation-tasks.schemas'
+import { businessLabelWeightCategorySchema } from './business-labels.schemas'
 
 // Phase 1 canonical cleanup (Task 15): schemas for the device-native
 // /api/devices surface. Fields that previously lived on the legacy
@@ -14,6 +15,8 @@ const businessLabelSummarySchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
   color: z.string().nullable(),
+  weightCategory: businessLabelWeightCategorySchema,
+  riskWeight: z.number(),
 })
 
 export const deviceSchema = z.object({

--- a/frontend/src/components/features/devices/DeviceDetailPageView.tsx
+++ b/frontend/src/components/features/devices/DeviceDetailPageView.tsx
@@ -3,7 +3,8 @@ import { Link } from '@tanstack/react-router'
 import { Loader2, RotateCcw } from 'lucide-react'
 import type { DeviceDetail } from '@/api/devices.schemas'
 import type { DeviceExposure } from '@/api/devices.schemas'
-import type { BusinessLabel } from '@/api/business-labels.schemas'
+import type { BusinessLabel, BusinessLabelWeightCategory } from '@/api/business-labels.schemas'
+import { WEIGHT_CATEGORY_CONFIG } from '@/api/business-labels.schemas'
 import type { SecurityProfile } from '@/api/security-profiles.schemas'
 import type { DeviceSoftwareItem } from '@/api/software.schemas'
 import { Badge } from '@/components/ui/badge'
@@ -89,7 +90,7 @@ export function DeviceDetailPageView({
                 {device.groupName ? <Pill>{device.groupName}</Pill> : null}
                 {device.securityProfile ? <Pill>{device.securityProfile.name}</Pill> : null}
                 {device.businessLabels.slice(0, 3).map((label) => (
-                  <BusinessLabelBadge key={label.id} name={label.name} color={label.color} />
+                  <BusinessLabelBadge key={label.id} name={label.name} color={label.color} weightCategory={label.weightCategory} />
                 ))}
                 {device.businessLabels.length > 3 ? (
                   <Pill>+{device.businessLabels.length - 3} labels</Pill>
@@ -312,6 +313,7 @@ export function DeviceDetailPageView({
                                 key={label.id}
                                 name={label.name}
                                 color={label.color}
+                                weightCategory={label.weightCategory}
                               />
                             ))
                           ) : (
@@ -755,7 +757,7 @@ export function DeviceDetailPageView({
               {device.businessLabels.length > 0 ? (
                 <div className="mt-3 flex flex-wrap gap-2">
                   {device.businessLabels.map((label) => (
-                    <BusinessLabelBadge key={label.id} name={label.name} color={label.color} />
+                    <BusinessLabelBadge key={label.id} name={label.name} color={label.color} weightCategory={label.weightCategory} />
                   ))}
                 </div>
               ) : (
@@ -866,17 +868,41 @@ export function DeviceDetailPageView({
   )
 }
 
-function BusinessLabelBadge({ name, color }: { name: string; color: string | null }) {
+function BusinessLabelBadge({
+  name,
+  color,
+  weightCategory,
+}: {
+  name: string
+  color: string | null
+  weightCategory: BusinessLabelWeightCategory
+}) {
+  const cfg = WEIGHT_CATEGORY_CONFIG[weightCategory]
+  const markerColorClass =
+    weightCategory === 'Informational'
+      ? 'text-muted-foreground'
+      : weightCategory === 'Sensitive'
+        ? 'text-amber-500'
+        : weightCategory === 'Critical'
+          ? 'text-destructive'
+          : null
+
   return (
     <Badge
       variant="outline"
       className="rounded-full border-border/70 bg-background/60 px-2.5 py-0.5 text-xs text-foreground"
+      title={`${cfg.label} business value, ${cfg.riskWeight}x risk weight`}
     >
       <span
         className="mr-1.5 inline-flex size-2 rounded-full border border-black/10"
         style={{ backgroundColor: color ?? 'var(--muted-foreground)' }}
       />
       {name}
+      {markerColorClass !== null && (
+        <span className={`ml-1 text-[10px] font-semibold leading-none ${markerColorClass}`}>
+          {cfg.riskWeight}×
+        </span>
+      )}
     </Badge>
   )
 }

--- a/frontend/src/routes/_authed/admin/business-labels.tsx
+++ b/frontend/src/routes/_authed/admin/business-labels.tsx
@@ -9,7 +9,8 @@ import {
   fetchBusinessLabels,
   updateBusinessLabel,
 } from '@/api/business-labels.functions'
-import type { BusinessLabel, SaveBusinessLabel } from '@/api/business-labels.schemas'
+import type { BusinessLabel, BusinessLabelWeightCategory, SaveBusinessLabel } from '@/api/business-labels.schemas'
+import { WEIGHT_CATEGORY_CONFIG, businessLabelWeightCategorySchema } from '@/api/business-labels.schemas'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -45,6 +46,7 @@ const emptyDraft = (): LabelDraft => ({
   description: '',
   color: '#2563eb',
   isActive: true,
+  weightCategory: 'Normal',
 })
 
 function BusinessLabelsPage() {
@@ -173,6 +175,7 @@ function BusinessLabelsPage() {
                           <BusinessLabelChip
                             name={label.name}
                             color={label.color}
+                            weightCategory={label.weightCategory}
                           />
                           <Badge
                             variant="outline"
@@ -187,6 +190,9 @@ function BusinessLabelsPage() {
                             {label.description?.trim() ||
                               "No description provided yet."}
                           </CardDescription>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {WEIGHT_CATEGORY_CONFIG[label.weightCategory].description}
+                          </p>
                         </div>
                       </div>
                       <div className="flex gap-2">
@@ -202,6 +208,7 @@ function BusinessLabelsPage() {
                               description: label.description,
                               color: label.color,
                               isActive: label.isActive,
+                              weightCategory: label.weightCategory,
                             });
                             setEditorOpen(true);
                           }}
@@ -329,6 +336,36 @@ function BusinessLabelsPage() {
                 </p>
               </button>
             </div>
+
+            <div className="grid gap-2">
+              <span className="text-sm font-medium">Business value category</span>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {businessLabelWeightCategorySchema.options.map((cat) => {
+                  const cfg = WEIGHT_CATEGORY_CONFIG[cat]
+                  const isSelected = (draft.weightCategory ?? 'Normal') === cat
+                  return (
+                    <button
+                      key={cat}
+                      type="button"
+                      className={`rounded-2xl border px-4 py-3 text-left transition-colors ${
+                        isSelected
+                          ? 'border-primary bg-primary/5'
+                          : 'border-border/70 bg-muted/20 hover:bg-muted/40'
+                      }`}
+                      onClick={() =>
+                        setDraft((current) => ({ ...current, weightCategory: cat }))
+                      }
+                    >
+                      <div className="flex items-center justify-between">
+                        <p className="text-sm font-medium">{cfg.label}</p>
+                        <WeightMarker category={cat} />
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">{cfg.description}</p>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
           </div>
 
           <DialogFooter>
@@ -389,14 +426,57 @@ function BusinessLabelsPage() {
   );
 }
 
-function BusinessLabelChip({ name, color }: { name: string; color: string | null }) {
+function BusinessLabelChip({
+  name,
+  color,
+  weightCategory,
+}: {
+  name: string
+  color: string | null
+  weightCategory: BusinessLabelWeightCategory
+}) {
+  const cfg = WEIGHT_CATEGORY_CONFIG[weightCategory]
   return (
-    <Badge variant="outline" className="rounded-full border-border/70 bg-background/50 px-3 py-1 text-foreground">
+    <Badge
+      variant="outline"
+      className="rounded-full border-border/70 bg-background/50 px-3 py-1 text-foreground"
+      title={`${cfg.label} business value, ${cfg.riskWeight}x risk weight`}
+    >
       <span
         className="mr-2 inline-flex size-2.5 rounded-full border border-black/10"
         style={{ backgroundColor: color ?? 'var(--muted-foreground)' }}
       />
       {name}
+      <WeightMarker category={weightCategory} className="ml-2" />
     </Badge>
+  )
+}
+
+function WeightMarker({
+  category,
+  className,
+}: {
+  category: BusinessLabelWeightCategory
+  className?: string
+}) {
+  const cfg = WEIGHT_CATEGORY_CONFIG[category]
+  const colorClass =
+    category === 'Informational'
+      ? 'text-muted-foreground'
+      : category === 'Normal'
+        ? 'text-muted-foreground/60'
+        : category === 'Sensitive'
+          ? 'text-amber-500'
+          : 'text-destructive'
+
+  if (category === 'Normal') return null
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-sm px-1 text-[10px] font-semibold leading-none ${colorClass} ${className ?? ''}`}
+      title={`${cfg.label} business value, ${cfg.riskWeight}x risk weight`}
+    >
+      {cfg.riskWeight}×
+    </span>
   )
 }

--- a/src/PatchHound.Api/Controllers/BusinessLabelsController.cs
+++ b/src/PatchHound.Api/Controllers/BusinessLabelsController.cs
@@ -48,7 +48,7 @@ public class BusinessLabelsController(
         if (string.IsNullOrWhiteSpace(request.Name))
             return BadRequest(new ProblemDetails { Title = "Name is required." });
 
-        if (!Enum.IsDefined(typeof(BusinessLabelWeightCategory), request.WeightCategory))
+        if (!TryParseWeightCategory(request.WeightCategory, out var weightCategory))
             return BadRequest(new ProblemDetails { Title = "Invalid weight category." });
 
         var exists = await dbContext.BusinessLabels.AnyAsync(
@@ -58,10 +58,10 @@ public class BusinessLabelsController(
         if (exists)
             return BadRequest(new ProblemDetails { Title = "A business label with that name already exists." });
 
-        var label = BusinessLabel.Create(tenantId, request.Name, request.Description, request.Color, request.WeightCategory);
+        var label = BusinessLabel.Create(tenantId, request.Name, request.Description, request.Color, weightCategory);
         if (!request.IsActive)
         {
-            label.Update(label.Name, label.Description, label.Color, false, request.WeightCategory);
+            label.Update(label.Name, label.Description, label.Color, false, weightCategory);
         }
 
         await dbContext.BusinessLabels.AddAsync(label, ct);
@@ -86,7 +86,7 @@ public class BusinessLabelsController(
         if (label is null)
             return NotFound(new ProblemDetails { Title = "Business label not found." });
 
-        if (!Enum.IsDefined(typeof(BusinessLabelWeightCategory), request.WeightCategory))
+        if (!TryParseWeightCategory(request.WeightCategory, out var weightCategory))
             return BadRequest(new ProblemDetails { Title = "Invalid weight category." });
 
         var normalizedName = request.Name.Trim();
@@ -97,7 +97,7 @@ public class BusinessLabelsController(
         if (nameInUse)
             return BadRequest(new ProblemDetails { Title = "A business label with that name already exists." });
 
-        label.Update(request.Name, request.Description, request.Color, request.IsActive, request.WeightCategory);
+        label.Update(request.Name, request.Description, request.Color, request.IsActive, weightCategory);
         await dbContext.SaveChangesAsync(ct);
 
         return Ok(ToDto(label));
@@ -127,9 +127,20 @@ public class BusinessLabelsController(
             item.Description,
             item.Color,
             item.IsActive,
-            item.WeightCategory,
+            item.WeightCategory.ToString(),
             item.RiskWeight,
             item.CreatedAt,
             item.UpdatedAt
         );
+
+    private static bool TryParseWeightCategory(string? value, out BusinessLabelWeightCategory category)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            category = BusinessLabelWeightCategory.Normal;
+            return true;
+        }
+        return Enum.TryParse(value, ignoreCase: false, out category)
+            && Enum.IsDefined(typeof(BusinessLabelWeightCategory), category);
+    }
 }

--- a/src/PatchHound.Api/Controllers/BusinessLabelsController.cs
+++ b/src/PatchHound.Api/Controllers/BusinessLabelsController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Auth;
 using PatchHound.Api.Models.Assets;
 using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Infrastructure.Data;
 
@@ -27,18 +28,11 @@ public class BusinessLabelsController(
         var items = await dbContext.BusinessLabels.AsNoTracking()
             .Where(item => item.TenantId == tenantId)
             .OrderBy(item => item.Name)
-            .Select(item => new BusinessLabelDto(
-                item.Id,
-                item.Name,
-                item.Description,
-                item.Color,
-                item.IsActive,
-                item.CreatedAt,
-                item.UpdatedAt
-            ))
             .ToListAsync(ct);
 
-        return Ok(items);
+        var dtos = items.Select(ToDto).ToList();
+
+        return Ok(dtos);
     }
 
     [HttpPost]
@@ -54,6 +48,9 @@ public class BusinessLabelsController(
         if (string.IsNullOrWhiteSpace(request.Name))
             return BadRequest(new ProblemDetails { Title = "Name is required." });
 
+        if (!Enum.IsDefined(typeof(BusinessLabelWeightCategory), request.WeightCategory))
+            return BadRequest(new ProblemDetails { Title = "Invalid weight category." });
+
         var exists = await dbContext.BusinessLabels.AnyAsync(
             item => item.TenantId == tenantId && item.Name == request.Name.Trim(),
             ct
@@ -61,10 +58,10 @@ public class BusinessLabelsController(
         if (exists)
             return BadRequest(new ProblemDetails { Title = "A business label with that name already exists." });
 
-        var label = BusinessLabel.Create(tenantId, request.Name, request.Description, request.Color);
+        var label = BusinessLabel.Create(tenantId, request.Name, request.Description, request.Color, request.WeightCategory);
         if (!request.IsActive)
         {
-            label.Update(label.Name, label.Description, label.Color, false);
+            label.Update(label.Name, label.Description, label.Color, false, request.WeightCategory);
         }
 
         await dbContext.BusinessLabels.AddAsync(label, ct);
@@ -89,6 +86,9 @@ public class BusinessLabelsController(
         if (label is null)
             return NotFound(new ProblemDetails { Title = "Business label not found." });
 
+        if (!Enum.IsDefined(typeof(BusinessLabelWeightCategory), request.WeightCategory))
+            return BadRequest(new ProblemDetails { Title = "Invalid weight category." });
+
         var normalizedName = request.Name.Trim();
         var nameInUse = await dbContext.BusinessLabels.AnyAsync(
             item => item.TenantId == tenantId && item.Id != id && item.Name == normalizedName,
@@ -97,7 +97,7 @@ public class BusinessLabelsController(
         if (nameInUse)
             return BadRequest(new ProblemDetails { Title = "A business label with that name already exists." });
 
-        label.Update(request.Name, request.Description, request.Color, request.IsActive);
+        label.Update(request.Name, request.Description, request.Color, request.IsActive, request.WeightCategory);
         await dbContext.SaveChangesAsync(ct);
 
         return Ok(ToDto(label));
@@ -127,6 +127,8 @@ public class BusinessLabelsController(
             item.Description,
             item.Color,
             item.IsActive,
+            item.WeightCategory,
+            item.RiskWeight,
             item.CreatedAt,
             item.UpdatedAt
         );

--- a/src/PatchHound.Api/Controllers/DevicesController.cs
+++ b/src/PatchHound.Api/Controllers/DevicesController.cs
@@ -205,7 +205,7 @@ public class DevicesController : ControllerBase
 
         var businessLabelsByDeviceId = await _dbContext.DeviceBusinessLabels
             .AsNoTracking()
-            .Where(link => deviceIds.Contains(link.DeviceId))
+            .Where(link => link.TenantId == _tenantContext.CurrentTenantId.Value && deviceIds.Contains(link.DeviceId))
             .Select(link => new
             {
                 link.DeviceId,
@@ -229,7 +229,7 @@ public class DevicesController : ControllerBase
                         item.Name,
                         item.Description,
                         item.Color,
-                        item.WeightCategory,
+                        item.WeightCategory.ToString(),
                         BusinessLabel.CategoryWeights[item.WeightCategory]
                     ))
                     .ToList() as IReadOnlyList<BusinessLabelSummaryDto>

--- a/src/PatchHound.Api/Controllers/DevicesController.cs
+++ b/src/PatchHound.Api/Controllers/DevicesController.cs
@@ -213,6 +213,7 @@ public class DevicesController : ControllerBase
                 link.BusinessLabel.Name,
                 link.BusinessLabel.Description,
                 link.BusinessLabel.Color,
+                link.BusinessLabel.WeightCategory,
             })
             .ToListAsync(ct);
         var businessLabelLookup = businessLabelsByDeviceId
@@ -227,7 +228,9 @@ public class DevicesController : ControllerBase
                         item.Id,
                         item.Name,
                         item.Description,
-                        item.Color
+                        item.Color,
+                        item.WeightCategory,
+                        BusinessLabel.CategoryWeights[item.WeightCategory]
                     ))
                     .ToList() as IReadOnlyList<BusinessLabelSummaryDto>
             );

--- a/src/PatchHound.Api/Models/Assets/AssetDto.cs
+++ b/src/PatchHound.Api/Models/Assets/AssetDto.cs
@@ -1,5 +1,3 @@
-using PatchHound.Core.Enums;
-
 namespace PatchHound.Api.Models.Assets;
 
 public record AssetDto(
@@ -38,7 +36,7 @@ public record BusinessLabelSummaryDto(
     string Name,
     string? Description,
     string? Color,
-    BusinessLabelWeightCategory WeightCategory,
+    string WeightCategory,
     decimal RiskWeight
 );
 

--- a/src/PatchHound.Api/Models/Assets/AssetDto.cs
+++ b/src/PatchHound.Api/Models/Assets/AssetDto.cs
@@ -1,3 +1,5 @@
+using PatchHound.Core.Enums;
+
 namespace PatchHound.Api.Models.Assets;
 
 public record AssetDto(
@@ -35,7 +37,9 @@ public record BusinessLabelSummaryDto(
     Guid Id,
     string Name,
     string? Description,
-    string? Color
+    string? Color,
+    BusinessLabelWeightCategory WeightCategory,
+    decimal RiskWeight
 );
 
 public record UpdateAssetBusinessLabelsRequest(

--- a/src/PatchHound.Api/Models/Assets/BusinessLabelDtos.cs
+++ b/src/PatchHound.Api/Models/Assets/BusinessLabelDtos.cs
@@ -1,3 +1,5 @@
+using PatchHound.Core.Enums;
+
 namespace PatchHound.Api.Models.Assets;
 
 public record BusinessLabelDto(
@@ -6,6 +8,8 @@ public record BusinessLabelDto(
     string? Description,
     string? Color,
     bool IsActive,
+    BusinessLabelWeightCategory WeightCategory,
+    decimal RiskWeight,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt
 );
@@ -14,5 +18,6 @@ public record SaveBusinessLabelRequest(
     string Name,
     string? Description,
     string? Color,
-    bool IsActive = true
+    bool IsActive = true,
+    BusinessLabelWeightCategory WeightCategory = BusinessLabelWeightCategory.Normal
 );

--- a/src/PatchHound.Api/Models/Assets/BusinessLabelDtos.cs
+++ b/src/PatchHound.Api/Models/Assets/BusinessLabelDtos.cs
@@ -1,5 +1,3 @@
-using PatchHound.Core.Enums;
-
 namespace PatchHound.Api.Models.Assets;
 
 public record BusinessLabelDto(
@@ -8,7 +6,7 @@ public record BusinessLabelDto(
     string? Description,
     string? Color,
     bool IsActive,
-    BusinessLabelWeightCategory WeightCategory,
+    string WeightCategory,
     decimal RiskWeight,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt
@@ -19,5 +17,5 @@ public record SaveBusinessLabelRequest(
     string? Description,
     string? Color,
     bool IsActive = true,
-    BusinessLabelWeightCategory WeightCategory = BusinessLabelWeightCategory.Normal
+    string? WeightCategory = null
 );

--- a/src/PatchHound.Api/Services/DeviceDetailQueryService.cs
+++ b/src/PatchHound.Api/Services/DeviceDetailQueryService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Models.Assets;
 using PatchHound.Api.Models.Devices;
+using PatchHound.Core.Entities;
 using PatchHound.Infrastructure.Data;
 
 namespace PatchHound.Api.Services;
@@ -56,21 +57,31 @@ public class DeviceDetailQueryService
                 .FirstOrDefaultAsync(ct)
             : null;
 
-        var businessLabels = await _dbContext.DeviceBusinessLabels
+        var businessLabelRows = await _dbContext.DeviceBusinessLabels
             .AsNoTracking()
             .Where(link => link.DeviceId == deviceId)
             .OrderBy(link => link.BusinessLabel.Name)
-            .Select(link => new BusinessLabelSummaryDto(
+            .Select(link => new
+            {
                 link.BusinessLabel.Id,
                 link.BusinessLabel.Name,
                 link.BusinessLabel.Description,
-                link.BusinessLabel.Color
-            ))
+                link.BusinessLabel.Color,
+                link.BusinessLabel.WeightCategory,
+            })
             .ToListAsync(ct);
-        businessLabels = businessLabels
+        var businessLabels = businessLabelRows
             .GroupBy(label => label.Id)
             .Select(group => group.First())
             .OrderBy(label => label.Name)
+            .Select(label => new BusinessLabelSummaryDto(
+                label.Id,
+                label.Name,
+                label.Description,
+                label.Color,
+                label.WeightCategory,
+                BusinessLabel.CategoryWeights[label.WeightCategory]
+            ))
             .ToList();
 
         var ownerUserName = device.OwnerUserId is Guid ownerUserId

--- a/src/PatchHound.Api/Services/DeviceDetailQueryService.cs
+++ b/src/PatchHound.Api/Services/DeviceDetailQueryService.cs
@@ -59,7 +59,7 @@ public class DeviceDetailQueryService
 
         var businessLabelRows = await _dbContext.DeviceBusinessLabels
             .AsNoTracking()
-            .Where(link => link.DeviceId == deviceId)
+            .Where(link => link.TenantId == tenantId && link.DeviceId == deviceId)
             .OrderBy(link => link.BusinessLabel.Name)
             .Select(link => new
             {
@@ -79,7 +79,7 @@ public class DeviceDetailQueryService
                 label.Name,
                 label.Description,
                 label.Color,
-                label.WeightCategory,
+                label.WeightCategory.ToString(),
                 BusinessLabel.CategoryWeights[label.WeightCategory]
             ))
             .ToList();

--- a/src/PatchHound.Core/Entities/BusinessLabel.cs
+++ b/src/PatchHound.Core/Entities/BusinessLabel.cs
@@ -1,15 +1,29 @@
+using PatchHound.Core.Enums;
+
 namespace PatchHound.Core.Entities;
 
 public class BusinessLabel
 {
+    public static readonly IReadOnlyDictionary<BusinessLabelWeightCategory, decimal> CategoryWeights =
+        new Dictionary<BusinessLabelWeightCategory, decimal>
+        {
+            [BusinessLabelWeightCategory.Informational] = 0.5m,
+            [BusinessLabelWeightCategory.Normal] = 1.0m,
+            [BusinessLabelWeightCategory.Sensitive] = 1.5m,
+            [BusinessLabelWeightCategory.Critical] = 2.0m,
+        };
+
     public Guid Id { get; private set; }
     public Guid TenantId { get; private set; }
     public string Name { get; private set; } = null!;
     public string? Description { get; private set; }
     public string? Color { get; private set; }
     public bool IsActive { get; private set; }
+    public BusinessLabelWeightCategory WeightCategory { get; private set; }
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
+
+    public decimal RiskWeight => CategoryWeights[WeightCategory];
 
     private BusinessLabel() { }
 
@@ -17,7 +31,8 @@ public class BusinessLabel
         Guid tenantId,
         string name,
         string? description,
-        string? color
+        string? color,
+        BusinessLabelWeightCategory weightCategory = BusinessLabelWeightCategory.Normal
     )
     {
         var now = DateTimeOffset.UtcNow;
@@ -29,17 +44,19 @@ public class BusinessLabel
             Description = description?.Trim(),
             Color = color?.Trim(),
             IsActive = true,
+            WeightCategory = weightCategory,
             CreatedAt = now,
             UpdatedAt = now,
         };
     }
 
-    public void Update(string name, string? description, string? color, bool isActive)
+    public void Update(string name, string? description, string? color, bool isActive, BusinessLabelWeightCategory weightCategory = BusinessLabelWeightCategory.Normal)
     {
         Name = name.Trim();
         Description = description?.Trim();
         Color = color?.Trim();
         IsActive = isActive;
+        WeightCategory = weightCategory;
         UpdatedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/src/PatchHound.Core/Enums/BusinessLabelWeightCategory.cs
+++ b/src/PatchHound.Core/Enums/BusinessLabelWeightCategory.cs
@@ -1,0 +1,9 @@
+namespace PatchHound.Core.Enums;
+
+public enum BusinessLabelWeightCategory
+{
+    Informational,
+    Normal,
+    Sensitive,
+    Critical,
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/BusinessLabelConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/BusinessLabelConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
 
 namespace PatchHound.Infrastructure.Data.Configurations;
 
@@ -15,5 +16,11 @@ public class BusinessLabelConfiguration : IEntityTypeConfiguration<BusinessLabel
         builder.Property(item => item.Name).HasMaxLength(128);
         builder.Property(item => item.Description).HasMaxLength(512);
         builder.Property(item => item.Color).HasMaxLength(32);
+        builder.Property(item => item.WeightCategory)
+            .HasConversion<string>()
+            .HasMaxLength(32)
+            .HasDefaultValue(BusinessLabelWeightCategory.Normal);
+
+        builder.Ignore(item => item.RiskWeight);
     }
 }

--- a/src/PatchHound.Infrastructure/Migrations/20260502080140_AddBusinessLabelWeightCategory.Designer.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260502080140_AddBusinessLabelWeightCategory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502080140_AddBusinessLabelWeightCategory")]
+    partial class AddBusinessLabelWeightCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Migrations/20260502080140_AddBusinessLabelWeightCategory.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260502080140_AddBusinessLabelWeightCategory.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBusinessLabelWeightCategory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "WeightCategory",
+                table: "BusinessLabels",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "Normal");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "WeightCategory",
+                table: "BusinessLabels");
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
+++ b/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
@@ -490,19 +490,22 @@ public class RiskScoreService(
             return (item.AssetId, EpisodeRiskScore: score, RiskBand: band, HasReduction: hasReduction);
         });
 
-        // Load the highest active business-label weight per device.
-        // Only labels that are IsActive=true contribute to the weight.
-        var labelWeights = await dbContext.DeviceBusinessLabels.AsNoTracking()
+        // Load the highest active business-label weight per device. The CASE expression
+        // translates to SQL so aggregation happens server-side — only one row per device
+        // returns even when many labels are assigned.
+        var deviceLabelWeights = await dbContext.DeviceBusinessLabels.AsNoTracking()
             .Where(dbl => dbl.TenantId == tenantId && dbl.BusinessLabel.IsActive)
-            .Select(dbl => new { dbl.DeviceId, dbl.BusinessLabel.WeightCategory })
-            .ToListAsync(ct);
-
-        var deviceLabelWeights = labelWeights
-            .GroupBy(item => item.DeviceId)
-            .ToDictionary(
-                g => g.Key,
-                g => g.Max(item => BusinessLabel.CategoryWeights[item.WeightCategory])
-            );
+            .GroupBy(dbl => dbl.DeviceId)
+            .Select(g => new
+            {
+                DeviceId = g.Key,
+                MaxWeight = g.Max(dbl =>
+                    dbl.BusinessLabel.WeightCategory == BusinessLabelWeightCategory.Critical ? 2.0m
+                    : dbl.BusinessLabel.WeightCategory == BusinessLabelWeightCategory.Sensitive ? 1.5m
+                    : dbl.BusinessLabel.WeightCategory == BusinessLabelWeightCategory.Informational ? 0.5m
+                    : 1.0m),
+            })
+            .ToDictionaryAsync(item => item.DeviceId, item => item.MaxWeight, ct);
 
         return BuildAssetRiskResults(
             adjusted.Select(item => (item.AssetId, item.EpisodeRiskScore, item.RiskBand, item.HasReduction)),
@@ -531,14 +534,19 @@ public class RiskScoreService(
                 var lowCount = group.Count(item => item.RiskBand == "Low");
                 var reducedCount = group.Count(item => item.HasReduction);
 
-                var baseScore = Math.Round(
-                    (0.7m * maxEpisodeRisk)
-                    + (0.2m * topThreeAverage)
-                    + Math.Min(criticalCount * 35m, 120m)
-                    + Math.Min(highCount * 15m, 60m)
-                    + Math.Min(mediumCount * 5m, 20m)
-                    + Math.Min(lowCount * 1m, 5m),
-                    2);
+                // Clamp the unweighted score first so the multiplier applies to the
+                // same value reported as the asset's pre-label "base" risk.
+                var baseScore = Math.Clamp(
+                    Math.Round(
+                        (0.7m * maxEpisodeRisk)
+                        + (0.2m * topThreeAverage)
+                        + Math.Min(criticalCount * 35m, 120m)
+                        + Math.Min(highCount * 15m, 60m)
+                        + Math.Min(mediumCount * 5m, 20m)
+                        + Math.Min(lowCount * 1m, 5m),
+                        2),
+                    0m,
+                    1000m);
 
                 var labelWeight = deviceLabelWeights?.GetValueOrDefault(group.Key, 1.0m) ?? 1.0m;
                 var overallScore = Math.Clamp(Math.Round(baseScore * labelWeight, 2), 0m, 1000m);

--- a/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
+++ b/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
@@ -490,13 +490,29 @@ public class RiskScoreService(
             return (item.AssetId, EpisodeRiskScore: score, RiskBand: band, HasReduction: hasReduction);
         });
 
+        // Load the highest active business-label weight per device.
+        // Only labels that are IsActive=true contribute to the weight.
+        var labelWeights = await dbContext.DeviceBusinessLabels.AsNoTracking()
+            .Where(dbl => dbl.TenantId == tenantId && dbl.BusinessLabel.IsActive)
+            .Select(dbl => new { dbl.DeviceId, dbl.BusinessLabel.WeightCategory })
+            .ToListAsync(ct);
+
+        var deviceLabelWeights = labelWeights
+            .GroupBy(item => item.DeviceId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Max(item => BusinessLabel.CategoryWeights[item.WeightCategory])
+            );
+
         return BuildAssetRiskResults(
-            adjusted.Select(item => (item.AssetId, item.EpisodeRiskScore, item.RiskBand, item.HasReduction))
+            adjusted.Select(item => (item.AssetId, item.EpisodeRiskScore, item.RiskBand, item.HasReduction)),
+            deviceLabelWeights
         );
     }
 
     private static List<AssetRiskResult> BuildAssetRiskResults(
-        IEnumerable<(Guid AssetId, decimal EpisodeRiskScore, string RiskBand, bool HasReduction)> episodeScores
+        IEnumerable<(Guid AssetId, decimal EpisodeRiskScore, string RiskBand, bool HasReduction)> episodeScores,
+        Dictionary<Guid, decimal>? deviceLabelWeights = null
     )
     {
         return episodeScores
@@ -515,17 +531,17 @@ public class RiskScoreService(
                 var lowCount = group.Count(item => item.RiskBand == "Low");
                 var reducedCount = group.Count(item => item.HasReduction);
 
-                var overallScore = Math.Clamp(
-                    Math.Round(
-                        (0.7m * maxEpisodeRisk)
-                        + (0.2m * topThreeAverage)
-                        + Math.Min(criticalCount * 35m, 120m)
-                        + Math.Min(highCount * 15m, 60m)
-                        + Math.Min(mediumCount * 5m, 20m)
-                        + Math.Min(lowCount * 1m, 5m),
-                        2),
-                    0m,
-                    1000m);
+                var baseScore = Math.Round(
+                    (0.7m * maxEpisodeRisk)
+                    + (0.2m * topThreeAverage)
+                    + Math.Min(criticalCount * 35m, 120m)
+                    + Math.Min(highCount * 15m, 60m)
+                    + Math.Min(mediumCount * 5m, 20m)
+                    + Math.Min(lowCount * 1m, 5m),
+                    2);
+
+                var labelWeight = deviceLabelWeights?.GetValueOrDefault(group.Key, 1.0m) ?? 1.0m;
+                var overallScore = Math.Clamp(Math.Round(baseScore * labelWeight, 2), 0m, 1000m);
 
                 var factors = new List<RiskFactor>
                 {
@@ -541,6 +557,11 @@ public class RiskScoreService(
                     factors.Add(new("RemediationReduction",
                         $"{reducedCount} episode(s) score reduced by active remediation decision (factor {RemediationAdjustmentFactor}).",
                         -reducedCount));
+
+                if (labelWeight != 1.0m)
+                    factors.Add(new("BusinessLabelWeight",
+                        $"Asset score multiplied by business label weight {labelWeight}x.",
+                        Math.Round(overallScore - baseScore, 2)));
 
                 var factorsJson = JsonSerializer.Serialize(factors);
 

--- a/tests/PatchHound.Tests/Api/BusinessLabelsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/BusinessLabelsControllerTests.cs
@@ -46,20 +46,20 @@ public class BusinessLabelsControllerTests : IDisposable
 
         var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
-        dto.WeightCategory.Should().Be(BusinessLabelWeightCategory.Normal);
+        dto.WeightCategory.Should().Be("Normal");
         dto.RiskWeight.Should().Be(1.0m);
     }
 
     [Fact]
     public async Task Create_PersistsWeightCategory()
     {
-        var request = new SaveBusinessLabelRequest("Finance", null, null, true, BusinessLabelWeightCategory.Critical);
+        var request = new SaveBusinessLabelRequest("Finance", null, null, true, "Critical");
 
         var result = await _controller.Create(request, CancellationToken.None);
 
         var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
-        dto.WeightCategory.Should().Be(BusinessLabelWeightCategory.Critical);
+        dto.WeightCategory.Should().Be("Critical");
         dto.RiskWeight.Should().Be(2.0m);
 
         var saved = await _dbContext.BusinessLabels.SingleAsync();
@@ -78,7 +78,7 @@ public class BusinessLabelsControllerTests : IDisposable
         var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         var dtos = ok.Value.Should().BeAssignableTo<IReadOnlyList<BusinessLabelDto>>().Subject;
         dtos.Should().ContainSingle();
-        dtos[0].WeightCategory.Should().Be(BusinessLabelWeightCategory.Sensitive);
+        dtos[0].WeightCategory.Should().Be("Sensitive");
         dtos[0].RiskWeight.Should().Be(1.5m);
     }
 
@@ -89,12 +89,12 @@ public class BusinessLabelsControllerTests : IDisposable
         await _dbContext.BusinessLabels.AddAsync(label);
         await _dbContext.SaveChangesAsync();
 
-        var request = new SaveBusinessLabelRequest("Shared", null, null, true, BusinessLabelWeightCategory.Informational);
+        var request = new SaveBusinessLabelRequest("Shared", null, null, true, "Informational");
         var result = await _controller.Update(label.Id, request, CancellationToken.None);
 
         var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
-        dto.WeightCategory.Should().Be(BusinessLabelWeightCategory.Informational);
+        dto.WeightCategory.Should().Be("Informational");
         dto.RiskWeight.Should().Be(0.5m);
     }
 
@@ -103,7 +103,7 @@ public class BusinessLabelsControllerTests : IDisposable
     [Fact]
     public async Task Create_RejectsInvalidWeightCategory()
     {
-        var request = new SaveBusinessLabelRequest("Bad", null, null, true, (BusinessLabelWeightCategory)999);
+        var request = new SaveBusinessLabelRequest("Bad", null, null, true, "NotARealCategory");
 
         var result = await _controller.Create(request, CancellationToken.None);
 
@@ -117,10 +117,22 @@ public class BusinessLabelsControllerTests : IDisposable
         await _dbContext.BusinessLabels.AddAsync(label);
         await _dbContext.SaveChangesAsync();
 
-        var request = new SaveBusinessLabelRequest("Existing", null, null, true, (BusinessLabelWeightCategory)999);
+        var request = new SaveBusinessLabelRequest("Existing", null, null, true, "NotARealCategory");
         var result = await _controller.Update(label.Id, request, CancellationToken.None);
 
         result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Create_DefaultsToNormalWhenWeightCategoryIsNull()
+    {
+        var request = new SaveBusinessLabelRequest("OmittedCategory", null, null, true, null);
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
+        dto.WeightCategory.Should().Be("Normal");
     }
 
     // ── RiskWeight derivation ───────────────────────────────────────────────────

--- a/tests/PatchHound.Tests/Api/BusinessLabelsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/BusinessLabelsControllerTests.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Controllers;
+using PatchHound.Api.Models.Assets;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class BusinessLabelsControllerTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly BusinessLabelsController _controller;
+
+    public BusinessLabelsControllerTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId);
+        _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(options, TestServiceProviderFactory.Create(_tenantContext));
+        _controller = new BusinessLabelsController(_dbContext, _tenantContext);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // ── Defaults ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_DefaultsToNormalWeightCategory()
+    {
+        var request = new SaveBusinessLabelRequest("Production", null, null);
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
+        dto.WeightCategory.Should().Be(BusinessLabelWeightCategory.Normal);
+        dto.RiskWeight.Should().Be(1.0m);
+    }
+
+    [Fact]
+    public async Task Create_PersistsWeightCategory()
+    {
+        var request = new SaveBusinessLabelRequest("Finance", null, null, true, BusinessLabelWeightCategory.Critical);
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
+        dto.WeightCategory.Should().Be(BusinessLabelWeightCategory.Critical);
+        dto.RiskWeight.Should().Be(2.0m);
+
+        var saved = await _dbContext.BusinessLabels.SingleAsync();
+        saved.WeightCategory.Should().Be(BusinessLabelWeightCategory.Critical);
+    }
+
+    [Fact]
+    public async Task List_IncludesWeightCategoryAndRiskWeight()
+    {
+        var label = BusinessLabel.Create(_tenantId, "HR", null, null, BusinessLabelWeightCategory.Sensitive);
+        await _dbContext.BusinessLabels.AddAsync(label);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.List(CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dtos = ok.Value.Should().BeAssignableTo<IReadOnlyList<BusinessLabelDto>>().Subject;
+        dtos.Should().ContainSingle();
+        dtos[0].WeightCategory.Should().Be(BusinessLabelWeightCategory.Sensitive);
+        dtos[0].RiskWeight.Should().Be(1.5m);
+    }
+
+    [Fact]
+    public async Task Update_ChangesWeightCategory()
+    {
+        var label = BusinessLabel.Create(_tenantId, "Shared", null, null, BusinessLabelWeightCategory.Normal);
+        await _dbContext.BusinessLabels.AddAsync(label);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new SaveBusinessLabelRequest("Shared", null, null, true, BusinessLabelWeightCategory.Informational);
+        var result = await _controller.Update(label.Id, request, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<BusinessLabelDto>().Subject;
+        dto.WeightCategory.Should().Be(BusinessLabelWeightCategory.Informational);
+        dto.RiskWeight.Should().Be(0.5m);
+    }
+
+    // ── Validation ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_RejectsInvalidWeightCategory()
+    {
+        var request = new SaveBusinessLabelRequest("Bad", null, null, true, (BusinessLabelWeightCategory)999);
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Update_RejectsInvalidWeightCategory()
+    {
+        var label = BusinessLabel.Create(_tenantId, "Existing", null, null);
+        await _dbContext.BusinessLabels.AddAsync(label);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new SaveBusinessLabelRequest("Existing", null, null, true, (BusinessLabelWeightCategory)999);
+        var result = await _controller.Update(label.Id, request, CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // ── RiskWeight derivation ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(BusinessLabelWeightCategory.Informational, 0.5)]
+    [InlineData(BusinessLabelWeightCategory.Normal, 1.0)]
+    [InlineData(BusinessLabelWeightCategory.Sensitive, 1.5)]
+    [InlineData(BusinessLabelWeightCategory.Critical, 2.0)]
+    public void BusinessLabel_RiskWeight_DerivedFromCategory(BusinessLabelWeightCategory category, double expectedWeight)
+    {
+        var label = BusinessLabel.Create(Guid.NewGuid(), "Test", null, null, category);
+        label.RiskWeight.Should().Be((decimal)expectedWeight);
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/BusinessLabelRiskWeightTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/BusinessLabelRiskWeightTests.cs
@@ -1,0 +1,177 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+/// <summary>
+/// Tests that verify business label weights are applied to asset risk scores
+/// during RecalculateForTenantAsync.
+/// </summary>
+public class BusinessLabelRiskWeightTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+    private readonly RiskScoreService _svc;
+
+    public BusinessLabelRiskWeightTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+        _svc = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    // ── Highest active label weight wins ─────────────────────────────────────
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_AppliesHighestActiveLabelWeight()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Baseline: no labels on DeviceA
+        await _svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+        var baselineScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+
+        // Assign a Normal (1.0x) and a Sensitive (1.5x) label — highest wins
+        var normalLabel = BusinessLabel.Create(_tenantId, "Normal", null, null, BusinessLabelWeightCategory.Normal);
+        var sensitiveLabel = BusinessLabel.Create(_tenantId, "Sensitive", null, null, BusinessLabelWeightCategory.Sensitive);
+        await _db.AddRangeAsync(normalLabel, sensitiveLabel);
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, normalLabel.Id));
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, sensitiveLabel.Id));
+        _db.DeviceRiskScores.RemoveRange(_db.DeviceRiskScores);
+        await _db.SaveChangesAsync();
+
+        var svc2 = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await svc2.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var weightedScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+
+        // Sensitive (1.5x) should have been applied — score must be higher than baseline
+        weightedScore.Should().BeGreaterThan(baselineScore);
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_CriticalLabelDoublesBaseScore()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Record baseline score without any label
+        await _svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+        var baselineScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        _db.DeviceRiskScores.RemoveRange(_db.DeviceRiskScores);
+        await _db.SaveChangesAsync();
+
+        // Assign a Critical (2.0x) label
+        var criticalLabel = BusinessLabel.Create(_tenantId, "Critical", null, null, BusinessLabelWeightCategory.Critical);
+        await _db.AddAsync(criticalLabel);
+        await _db.SaveChangesAsync();
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, criticalLabel.Id));
+        await _db.SaveChangesAsync();
+
+        var svc2 = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await svc2.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var weightedScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+
+        // 2x multiplier — clamped at 1000
+        var expectedMax = Math.Clamp(Math.Round(baselineScore * 2.0m, 2), 0m, 1000m);
+        weightedScore.Should().Be(expectedMax);
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_InformationalLabelReducesScore()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        await _svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+        var baselineScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        _db.DeviceRiskScores.RemoveRange(_db.DeviceRiskScores);
+        await _db.SaveChangesAsync();
+
+        var infoLabel = BusinessLabel.Create(_tenantId, "Info", null, null, BusinessLabelWeightCategory.Informational);
+        await _db.AddAsync(infoLabel);
+        await _db.SaveChangesAsync();
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, infoLabel.Id));
+        await _db.SaveChangesAsync();
+
+        var svc2 = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await svc2.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var weightedScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        var expected = Math.Clamp(Math.Round(baselineScore * 0.5m, 2), 0m, 1000m);
+        weightedScore.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_InactiveLabelNotApplied()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        // Baseline
+        await _svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+        var baselineScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        _db.DeviceRiskScores.RemoveRange(_db.DeviceRiskScores);
+        await _db.SaveChangesAsync();
+
+        // Create a Critical label but mark it inactive
+        var criticalLabel = BusinessLabel.Create(_tenantId, "Critical-Inactive", null, null, BusinessLabelWeightCategory.Critical);
+        criticalLabel.Update(criticalLabel.Name, criticalLabel.Description, criticalLabel.Color, isActive: false, BusinessLabelWeightCategory.Critical);
+        await _db.AddAsync(criticalLabel);
+        await _db.SaveChangesAsync();
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, criticalLabel.Id));
+        await _db.SaveChangesAsync();
+
+        var svc2 = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await svc2.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var score = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        score.Should().Be(baselineScore);
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_ScoreClampsAt1000()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        var criticalLabel = BusinessLabel.Create(_tenantId, "Critical", null, null, BusinessLabelWeightCategory.Critical);
+        await _db.AddAsync(criticalLabel);
+        await _db.SaveChangesAsync();
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, criticalLabel.Id));
+        await _db.SaveChangesAsync();
+
+        await _svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var score = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        score.Should().BeLessThanOrEqualTo(1000m);
+        score.Should().BeGreaterThanOrEqualTo(0m);
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_NormalLabelLeavesScoreUnchanged()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+
+        await _svc.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+        var baselineScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        _db.DeviceRiskScores.RemoveRange(_db.DeviceRiskScores);
+        await _db.SaveChangesAsync();
+
+        var normalLabel = BusinessLabel.Create(_tenantId, "Normal", null, null, BusinessLabelWeightCategory.Normal);
+        await _db.AddAsync(normalLabel);
+        await _db.SaveChangesAsync();
+        _db.DeviceBusinessLabels.Add(DeviceBusinessLabel.Create(_tenantId, seed.DeviceA.Id, normalLabel.Id));
+        await _db.SaveChangesAsync();
+
+        var svc2 = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await svc2.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+
+        var score = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
+        score.Should().Be(baselineScore);
+    }
+}


### PR DESCRIPTION
## Summary

- Each `BusinessLabel` now carries a fixed `WeightCategory`: Informational (0.5×), Normal (1.0×), Sensitive (1.5×), Critical (2.0×). Existing labels default to Normal.
- `RiskScoreService` loads the highest active label weight per device and multiplies the asset `overallScore` by it, clamped to 0–1000. A `BusinessLabelWeight` risk factor entry is added when the multiplier is not 1.0. Episode CVSS, risk-band counts, and remediation reductions are unchanged.
- Downstream software, team, device-group, and tenant rollups inherit the adjusted asset score automatically.
- Admin UI gains a 4-option category picker with descriptions; device pills get a trailing weight marker (muted gray / amber / destructive) for non-Normal categories. The configurable label color remains the primary pill identity.

## Why

The existing risk score reflects technical severity but not business value. This lets operators tag assets with business context (Finance, Executive, Production, etc.) and have that context flow directly into the score so dashboards and remediation queues prioritize what actually matters to the business.

## Notes for reviewers

- Custom numeric weights are deliberately not allowed in this iteration — only the four preset categories.
- "Highest active wins" when multiple labels are assigned (inactive labels are ignored).
- Migration `20260502080140_AddBusinessLabelWeightCategory` adds the column with a `Normal` default, so all existing rows transparently get 1.0× and scoring is unchanged on first deploy.
- `BusinessLabelSummaryDto` (used by `/api/devices` and detail endpoints) gained `weightCategory` + `riskWeight`, matching the new frontend schema.

## Test plan

- [x] `dotnet test PatchHound.slnx` — 682/682 passing, including new `BusinessLabelsControllerTests` (8) and `BusinessLabelRiskWeightTests` (6).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new warnings (1 pre-existing, unrelated).
- [ ] Manual: create a Critical label, assign it to a device with open exposures, run a risk recalc, confirm the asset score roughly doubles and the BusinessLabelWeight factor appears in the score detail.
- [ ] Manual: toggle the same label to Inactive, recalc, confirm the score returns to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)