### PR TITLE
Security analyst workbench + role-aware My Tasks queue (#62)

### DIFF
--- a/frontend/src/api/remediation.functions.ts
+++ b/frontend/src/api/remediation.functions.ts
@@ -149,6 +149,8 @@ export const fetchDecisionList = createServerFn({ method: 'GET' })
       decisionState: z.string().optional(),
       missedMaintenanceWindow: z.boolean().optional(),
       needsAnalystRecommendation: z.boolean().optional(),
+      needsRemediationDecision: z.boolean().optional(),
+      needsApproval: z.boolean().optional(),
       page: z.number().optional(),
       pageSize: z.number().optional(),
     })

--- a/frontend/src/api/remediation.functions.ts
+++ b/frontend/src/api/remediation.functions.ts
@@ -148,6 +148,7 @@ export const fetchDecisionList = createServerFn({ method: 'GET' })
       approvalStatus: z.string().optional(),
       decisionState: z.string().optional(),
       missedMaintenanceWindow: z.boolean().optional(),
+      needsAnalystRecommendation: z.boolean().optional(),
       page: z.number().optional(),
       pageSize: z.number().optional(),
     })

--- a/frontend/src/api/remediation.schemas.ts
+++ b/frontend/src/api/remediation.schemas.ts
@@ -43,11 +43,15 @@ export const decisionVulnSchema = z.object({
   vulnerabilityDefinitionId: z.string().uuid(),
   externalId: z.string(),
   title: z.string(),
+  description: z.string().nullable(),
   vendorSeverity: z.string(),
   vendorScore: z.number().nullable(),
   effectiveSeverity: z.string().nullable(),
   effectiveScore: z.number().nullable(),
   cvssVector: z.string().nullable(),
+  firstSeenAt: z.string().nullable(),
+  affectedDeviceCount: z.number(),
+  affectedVersionCount: z.number(),
   knownExploited: z.boolean(),
   publicExploit: z.boolean(),
   activeAlert: z.boolean(),
@@ -140,6 +144,15 @@ export const decisionAiSummarySchema = z.object({
   unavailableMessage: z.string().nullable(),
 })
 
+export const decisionBusinessLabelSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  color: z.string().nullable(),
+  weightCategory: z.string(),
+  riskWeight: z.number(),
+  affectedDeviceCount: z.number(),
+})
+
 export const decisionApprovalResolutionSchema = z.object({
   status: z.string(),
   justification: z.string().nullable(),
@@ -151,10 +164,14 @@ export const decisionContextSchema = z.object({
   remediationCaseId: z.string().uuid(),
   tenantSoftwareId: z.string().uuid().nullable(),
   softwareName: z.string(),
+  softwareVendor: z.string().nullable(),
+  softwareCategory: z.string().nullable(),
+  softwareDescription: z.string().nullable(),
   softwareOwnerTeamId: z.string().uuid().nullable(),
   softwareOwnerTeamName: z.string().nullable(),
   softwareOwnerAssignmentSource: z.string(),
   criticality: z.string(),
+  businessLabels: z.array(decisionBusinessLabelSchema),
   summary: decisionSummarySchema,
   workflow: decisionWorkflowSummarySchema,
   workflowState: decisionWorkflowStateSchema,
@@ -163,6 +180,7 @@ export const decisionContextSchema = z.object({
   latestApprovalResolution: decisionApprovalResolutionSchema.nullable(),
   recommendations: z.array(analystRecommendationSchema),
   topVulnerabilities: z.array(decisionVulnSchema),
+  openVulnerabilities: z.array(decisionVulnSchema),
   riskScore: decisionRiskSchema.nullable(),
   sla: decisionSlaSchema.nullable(),
   aiSummary: decisionAiSummarySchema,
@@ -213,6 +231,7 @@ export const pagedDecisionListSchema = z.object({
 export type DecisionContext = z.infer<typeof decisionContextSchema>
 export type RemediationDecision = z.infer<typeof remediationDecisionSchema>
 export type AnalystRecommendation = z.infer<typeof analystRecommendationSchema>
+export type DecisionBusinessLabel = z.infer<typeof decisionBusinessLabelSchema>
 export type DecisionVuln = z.infer<typeof decisionVulnSchema>
 export type DecisionSummary = z.infer<typeof decisionSummarySchema>
 export type DecisionWorkflowSummary = z.infer<typeof decisionWorkflowSummarySchema>

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
@@ -166,4 +166,28 @@ describe('SecurityAnalystWorkbench', () => {
     expect(screen.getByText('A remotely exploitable vulnerability.')).toBeInTheDocument()
     expect(screen.getByText('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')).toBeInTheDocument()
   })
+
+  it('applies the AI draft over an existing saved recommendation', () => {
+    renderWorkbench({
+      ...dataFixture,
+      recommendations: [
+        {
+          id: '77777777-7777-7777-7777-777777777777',
+          vulnerabilityId: null,
+          recommendedOutcome: 'RiskAcceptance',
+          rationale: 'Existing analyst text.',
+          priorityOverride: 'Medium',
+          analystId: '88888888-8888-8888-8888-888888888888',
+          analystDisplayName: 'Casey Analyst',
+          createdAt: '2026-05-02T01:00:00Z',
+        },
+      ],
+    })
+
+    expect(screen.getByLabelText(/Recommendation rationale/i)).toHaveValue('Existing analyst text.')
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply draft/i }))
+
+    expect(screen.getByLabelText(/Recommendation rationale/i)).toHaveValue('Prioritize patching because exploitation is known.')
+  })
 })

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
@@ -1,0 +1,169 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AnchorHTMLAttributes, TextareaHTMLAttributes } from 'react'
+import type { DecisionContext } from '@/api/remediation.schemas'
+import { SecurityAnalystWorkbench } from './SecurityAnalystWorkbench'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props}>{children}</a>,
+}))
+
+vi.mock('@/api/remediation.functions', () => ({
+  addRecommendation: vi.fn(),
+  generateRemediationAiSummary: vi.fn(),
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}))
+
+const dataFixture: DecisionContext = {
+  remediationCaseId: '11111111-1111-1111-1111-111111111111',
+  tenantSoftwareId: '22222222-2222-2222-2222-222222222222',
+  softwareName: 'Contoso Agent',
+  softwareVendor: 'Contoso',
+  softwareCategory: 'Endpoint agent',
+  softwareDescription: 'Endpoint security agent installed on managed workstations.',
+  softwareOwnerTeamId: '33333333-3333-3333-3333-333333333333',
+  softwareOwnerTeamName: 'Platform Engineering',
+  softwareOwnerAssignmentSource: 'Rule',
+  criticality: 'High',
+  businessLabels: [
+    {
+      id: '44444444-4444-4444-4444-444444444444',
+      name: 'Revenue',
+      color: '#22c55e',
+      weightCategory: 'Critical',
+      riskWeight: 2,
+      affectedDeviceCount: 5,
+    },
+  ],
+  summary: {
+    totalVulnerabilities: 1,
+    criticalCount: 1,
+    highCount: 0,
+    mediumCount: 0,
+    lowCount: 0,
+    withKnownExploit: 1,
+    withActiveAlert: 0,
+  },
+  workflow: {
+    affectedDeviceCount: 5,
+    affectedOwnerTeamCount: 1,
+    openPatchingTaskCount: 0,
+    completedPatchingTaskCount: 0,
+    openEpisodeTrend: [],
+  },
+  workflowState: {
+    workflowId: '55555555-5555-5555-5555-555555555555',
+    currentStage: 'SecurityAnalysis',
+    currentStageLabel: 'Security Analysis',
+    currentStageDescription: 'Security roles review shared exposure and record a recommendation and priority.',
+    currentActorSummary: 'Security analyst',
+    canActOnCurrentStage: true,
+    currentUserRoles: ['SecurityAnalyst'],
+    currentUserTeams: [],
+    expectedRoles: ['SecurityAnalyst'],
+    expectedTeamName: null,
+    isInExpectedTeam: null,
+    isRecurrence: false,
+    hasActiveWorkflow: true,
+    stages: [],
+  },
+  currentDecision: null,
+  previousDecision: null,
+  latestApprovalResolution: null,
+  recommendations: [],
+  topVulnerabilities: [],
+  openVulnerabilities: [
+    {
+      vulnerabilityId: '66666666-6666-6666-6666-666666666666',
+      vulnerabilityDefinitionId: '66666666-6666-6666-6666-666666666666',
+      externalId: 'CVE-2026-4242',
+      title: 'Remote code execution',
+      description: 'A remotely exploitable vulnerability.',
+      vendorSeverity: 'Critical',
+      vendorScore: 9.8,
+      effectiveSeverity: 'Critical',
+      effectiveScore: 9.8,
+      cvssVector: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
+      firstSeenAt: '2026-05-01T00:00:00Z',
+      affectedDeviceCount: 5,
+      affectedVersionCount: 1,
+      knownExploited: true,
+      publicExploit: true,
+      activeAlert: false,
+      epssScore: 0.42,
+      episodeRiskScore: null,
+      overrideOutcome: null,
+    },
+  ],
+  riskScore: null,
+  sla: {
+    criticalDays: 7,
+    highDays: 14,
+    mediumDays: 30,
+    lowDays: 60,
+    slaStatus: 'DueSoon',
+    dueDate: '2026-05-09T00:00:00Z',
+  },
+  aiSummary: {
+    content: null,
+    ownerRecommendation: null,
+    analystAssessment: 'Prioritize patching because exploitation is known.',
+    exceptionRecommendation: null,
+    recommendedOutcome: 'ApprovedForPatching',
+    recommendedPriority: 'Critical',
+    status: 'Completed',
+    isStale: false,
+    reviewStatus: null,
+    reviewedAt: null,
+    reviewedByDisplayName: null,
+    generatedAt: '2026-05-02T00:00:00Z',
+    requestedAt: null,
+    completedAt: null,
+    providerType: null,
+    profileName: null,
+    model: null,
+    canGenerate: true,
+    isGenerating: false,
+    lastError: null,
+    unavailableMessage: null,
+  },
+}
+
+function renderWorkbench(data: DecisionContext = dataFixture) {
+  const queryClient = new QueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SecurityAnalystWorkbench
+        data={data}
+        caseId={data.remediationCaseId}
+        queryKey={['security-analyst-workbench', data.remediationCaseId]}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+describe('SecurityAnalystWorkbench', () => {
+  it('promotes software context, AI guidance, and recommendation capture', () => {
+    renderWorkbench()
+
+    expect(screen.getByRole('heading', { name: /Contoso Agent/i })).toBeInTheDocument()
+    expect(screen.getByText('Endpoint security agent installed on managed workstations.')).toBeInTheDocument()
+    expect(screen.getByText('Revenue')).toBeInTheDocument()
+    expect(screen.getAllByText('Prioritize patching because exploitation is known.').length).toBeGreaterThan(0)
+    expect(screen.getByLabelText(/Recommendation rationale/i)).toHaveValue('Prioritize patching because exploitation is known.')
+  })
+
+  it('opens vulnerability essentials from the compact list', () => {
+    renderWorkbench()
+
+    fireEvent.click(screen.getByRole('button', { name: /Details/i }))
+
+    expect(screen.getByRole('heading', { name: 'CVE-2026-4242' })).toBeInTheDocument()
+    expect(screen.getByText('A remotely exploitable vulnerability.')).toBeInTheDocument()
+    expect(screen.getByText('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
@@ -91,7 +91,10 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
           priorityOverride: priorityOverride || undefined,
         },
       })
-      await queryClient.invalidateQueries({ queryKey })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey }),
+        queryClient.invalidateQueries({ queryKey: ['my-tasks'] }),
+      ])
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to save the analyst recommendation.'))
     } finally {

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { Bot, ExternalLink, LoaderCircle, SearchCheck, ShieldAlert } from 'lucide-react'
+import { Bot, ExternalLink, LoaderCircle, Save, SearchCheck, ShieldAlert, Sparkles, TriangleAlert } from 'lucide-react'
 import type { DecisionContext, DecisionVuln } from '@/api/remediation.schemas'
 import { addRecommendation, generateRemediationAiSummary } from '@/api/remediation.functions'
 import { Button } from '@/components/ui/button'
@@ -53,6 +53,24 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
 
   const vulnerabilities = data.openVulnerabilities.length > 0 ? data.openVulnerabilities : data.topVulnerabilities
   const topDrivers = useMemo(() => vulnerabilities.slice(0, 4), [vulnerabilities])
+  const hiddenDriverCount = Math.max(vulnerabilities.length - topDrivers.length, 0)
+  const threatDriverCount = vulnerabilities.filter((vulnerability) =>
+    vulnerability.knownExploited || vulnerability.publicExploit || vulnerability.activeAlert
+  ).length
+  const highestRiskDriver = useMemo(
+    () => vulnerabilities.reduce<DecisionVuln | null>((highest, vulnerability) => {
+      const score = vulnerability.effectiveScore ?? vulnerability.vendorScore ?? 0
+      const highestScore = highest?.effectiveScore ?? highest?.vendorScore ?? 0
+      return score > highestScore ? vulnerability : highest
+    }, null),
+    [vulnerabilities],
+  )
+  const highestRiskDriverDetail = highestRiskDriver
+    ? formatSeverityScore(
+      highestRiskDriver.effectiveSeverity ?? highestRiskDriver.vendorSeverity,
+      highestRiskDriver.effectiveScore ?? highestRiskDriver.vendorScore,
+    )
+    : 'No active exposure'
   const canSave = recommendedOutcome !== '' && rationale.trim().length > 0
   const displaySoftwareName = startCase(data.softwareName)
   const softwareIdentity = data.softwareVendor
@@ -95,9 +113,9 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
   }
 
   function useAiDraft() {
-    setRecommendedOutcome((current) => current || data.aiSummary.recommendedOutcome || '')
-    setRationale((current) => current || data.aiSummary.analystAssessment || '')
-    setPriorityOverride((current) => current || data.aiSummary.recommendedPriority || '')
+    setRecommendedOutcome(data.aiSummary.recommendedOutcome || recommendedOutcome)
+    setRationale(data.aiSummary.analystAssessment || rationale)
+    setPriorityOverride(data.aiSummary.recommendedPriority || priorityOverride)
   }
 
   return (
@@ -142,24 +160,50 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
         <WorkbenchMetric label="SLA" value={data.sla?.slaStatus ?? 'Not set'} detail={data.sla?.dueDate ? `Due ${formatNullableDateTime(data.sla.dueDate)}` : 'No due date'} />
       </div>
 
-      {data.businessLabels.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
-          {data.businessLabels.map((label) => (
-            <span
-              key={label.id}
-              className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs"
-              title={`${label.weightCategory} business value, ${label.riskWeight.toFixed(1)}x risk weight`}
-            >
-              <span
-                className="size-2 rounded-full border border-border/60"
-                style={{ backgroundColor: label.color ?? 'transparent' }}
-              />
-              {label.name}
-              <span className="text-muted-foreground">({label.affectedDeviceCount})</span>
-            </span>
-          ))}
+      <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(300px,0.44fr)]">
+        <div className="grid gap-3 md:grid-cols-3">
+          <RiskDriver
+            label="Top driver"
+            value={highestRiskDriver?.externalId ?? 'None'}
+            detail={highestRiskDriverDetail}
+            tone={highestRiskDriver ? 'danger' : 'neutral'}
+          />
+          <RiskDriver
+            label="Threat signals"
+            value={threatDriverCount.toLocaleString()}
+            detail="KEV, public exploit, or active alert"
+            tone={threatDriverCount > 0 ? 'danger' : 'neutral'}
+          />
+          <RiskDriver
+            label="Decision inputs"
+            value={data.aiSummary.status ?? 'Not requested'}
+            detail={data.recommendations.length > 0 ? 'Recommendation already captured' : 'Awaiting analyst recommendation'}
+            tone={data.recommendations.length > 0 ? 'success' : 'neutral'}
+          />
         </div>
-      ) : null}
+
+        {data.businessLabels.length > 0 ? (
+          <div className="rounded-lg border border-border/70 bg-card px-4 py-3">
+            <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Business impact</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {data.businessLabels.map((label) => (
+                <span
+                  key={label.id}
+                  className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background px-2.5 py-1 text-xs"
+                  title={`${label.weightCategory} business value, ${label.riskWeight.toFixed(1)}x risk weight`}
+                >
+                  <span
+                    className="size-2 rounded-full border border-border/60"
+                    style={{ backgroundColor: label.color ?? 'transparent' }}
+                  />
+                  <span className="font-medium">{label.name}</span>
+                  <span className="text-muted-foreground">{label.affectedDeviceCount}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
 
       {error ? (
         <div role="alert" className="rounded-lg border border-destructive/35 bg-destructive/8 px-4 py-3 text-sm text-destructive">
@@ -192,11 +236,30 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
               </div>
             ) : null}
 
+            {(data.aiSummary.analystAssessment || data.aiSummary.recommendedOutcome || data.aiSummary.recommendedPriority) ? (
+              <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2.5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 text-sm font-medium">
+                      <Sparkles className="size-4 text-primary" />
+                      AI draft available
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Apply the latest generated priority, action, and rationale to the form for analyst review.
+                    </p>
+                  </div>
+                  <Button type="button" variant="outline" size="sm" onClick={useAiDraft}>
+                    Apply draft
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
             <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
               <div className="space-y-2">
-                <label className="text-sm font-medium">Recommended remediation</label>
+                <label htmlFor="recommended-outcome" className="text-sm font-medium">Recommended remediation</label>
                 <Select value={recommendedOutcome} onValueChange={(value) => setRecommendedOutcome(value ?? '')}>
-                  <SelectTrigger>
+                  <SelectTrigger id="recommended-outcome">
                     <SelectValue placeholder="Select action..." />
                   </SelectTrigger>
                   <SelectContent>
@@ -207,9 +270,9 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
                 </Select>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium">Priority</label>
+                <label htmlFor="priority-override" className="text-sm font-medium">Priority</label>
                 <Select value={priorityOverride || 'none'} onValueChange={(value) => setPriorityOverride(value === 'none' ? '' : value ?? '')}>
-                  <SelectTrigger>
+                  <SelectTrigger id="priority-override">
                     <SelectValue placeholder="No priority" />
                   </SelectTrigger>
                   <SelectContent>
@@ -236,13 +299,9 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
 
             <div className="flex flex-wrap gap-2">
               <Button onClick={handleSaveRecommendation} disabled={!canSave || isSaving}>
+                {isSaving ? <LoaderCircle className="size-4 animate-spin" /> : <Save className="size-4" />}
                 {isSaving ? 'Saving...' : currentRecommendation ? 'Update recommendation' : 'Save recommendation'}
               </Button>
-              {(data.aiSummary.analystAssessment || data.aiSummary.recommendedOutcome || data.aiSummary.recommendedPriority) ? (
-                <Button type="button" variant="outline" onClick={useAiDraft}>
-                  Use AI draft
-                </Button>
-              ) : null}
             </div>
           </CardContent>
         </Card>
@@ -258,11 +317,14 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold">Open vulnerabilities</h2>
-            <p className="text-sm text-muted-foreground">Highest-risk drivers first. Open a row for essentials without leaving the workbench.</p>
+            <p className="text-sm text-muted-foreground">
+              Highest-risk drivers first. Showing {topDrivers.length.toLocaleString()} of {vulnerabilities.length.toLocaleString()}
+              {hiddenDriverCount > 0 ? `, with ${hiddenDriverCount.toLocaleString()} more in the full case` : ''}.
+            </p>
           </div>
         </div>
-        <div className="overflow-hidden rounded-lg border border-border/70 bg-card">
-          <table className="min-w-full divide-y divide-border/70 text-sm">
+        <div className="overflow-x-auto rounded-lg border border-border/70 bg-card">
+          <table className="min-w-[760px] divide-y divide-border/70 text-sm">
             <thead className="bg-muted/35 text-left text-xs uppercase tracking-[0.12em] text-muted-foreground">
               <tr>
                 <th className="px-4 py-3">Vulnerability</th>
@@ -274,7 +336,7 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
             </thead>
             <tbody className="divide-y divide-border/60">
               {topDrivers.map((vulnerability) => (
-                <tr key={vulnerability.vulnerabilityId}>
+                <tr key={vulnerability.vulnerabilityId} className="transition-colors hover:bg-muted/25">
                   <td className="px-4 py-3">
                     <div className="font-medium">{vulnerability.externalId}</div>
                     <div className="line-clamp-1 max-w-xl text-xs text-muted-foreground">{vulnerability.title}</div>
@@ -292,7 +354,12 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
                     {vulnerability.affectedDeviceCount} devices
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <Button variant="ghost" size="sm" onClick={() => setSelectedVulnerability(vulnerability)}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      aria-label={`Open details for ${vulnerability.externalId}`}
+                      onClick={() => setSelectedVulnerability(vulnerability)}
+                    >
                       Details
                     </Button>
                   </td>
@@ -327,6 +394,40 @@ function WorkbenchMetric({ label, value, detail }: { label: string; value: strin
       <p className="mt-1 truncate text-xs text-muted-foreground">{detail}</p>
     </div>
   )
+}
+
+function RiskDriver({
+  label,
+  value,
+  detail,
+  tone,
+}: {
+  label: string
+  value: string
+  detail: string
+  tone: 'danger' | 'success' | 'neutral'
+}) {
+  return (
+    <div className={cn(
+      'rounded-lg border px-4 py-3',
+      tone === 'danger'
+        ? 'border-destructive/30 bg-destructive/8'
+        : tone === 'success'
+          ? 'border-emerald-500/25 bg-emerald-500/8'
+          : 'border-border/70 bg-card',
+    )}>
+      <div className="flex items-center gap-2">
+        {tone === 'danger' ? <TriangleAlert className="size-4 text-destructive" /> : null}
+        <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      </div>
+      <p className="mt-1 truncate text-base font-semibold">{value}</p>
+      <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function formatSeverityScore(severity: string, score: number | null | undefined) {
+  return score == null ? severity : `${severity} ${score.toFixed(1)}`
 }
 
 function AiRiskBrief({

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
@@ -1,0 +1,483 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { Bot, ExternalLink, LoaderCircle, SearchCheck, ShieldAlert } from 'lucide-react'
+import type { DecisionContext, DecisionVuln } from '@/api/remediation.schemas'
+import { addRecommendation, generateRemediationAiSummary } from '@/api/remediation.functions'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Textarea } from '@/components/ui/textarea'
+import { getApiErrorMessage } from '@/lib/api-errors'
+import { formatDateTime, formatNullableDateTime, startCase } from '@/lib/formatting'
+import { toneBadge } from '@/lib/tone-classes'
+import { cn } from '@/lib/utils'
+import {
+  formatSoftwareOwnerRoutingDetail,
+  outcomeLabel,
+  outcomeTone,
+  severityTone,
+} from './remediation-utils'
+
+type SecurityAnalystWorkbenchProps = {
+  data: DecisionContext
+  caseId: string
+  queryKey: readonly unknown[]
+}
+
+const OUTCOMES = [
+  'ApprovedForPatching',
+  'RiskAcceptance',
+  'AlternateMitigation',
+  'PatchingDeferred',
+] as const
+
+export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAnalystWorkbenchProps) {
+  const queryClient = useQueryClient()
+  const currentRecommendation = data.recommendations[0] ?? null
+  const [selectedVulnerability, setSelectedVulnerability] = useState<DecisionVuln | null>(null)
+  const [recommendedOutcome, setRecommendedOutcome] = useState(currentRecommendation?.recommendedOutcome ?? data.aiSummary.recommendedOutcome ?? '')
+  const [rationale, setRationale] = useState(currentRecommendation?.rationale ?? data.aiSummary.analystAssessment ?? '')
+  const [priorityOverride, setPriorityOverride] = useState(currentRecommendation?.priorityOverride ?? data.aiSummary.recommendedPriority ?? '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [isGeneratingAi, setIsGeneratingAi] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const vulnerabilities = data.openVulnerabilities.length > 0 ? data.openVulnerabilities : data.topVulnerabilities
+  const topDrivers = useMemo(() => vulnerabilities.slice(0, 4), [vulnerabilities])
+  const canSave = recommendedOutcome !== '' && rationale.trim().length > 0
+  const displaySoftwareName = startCase(data.softwareName)
+  const softwareIdentity = data.softwareVendor
+    && !displaySoftwareName.toLowerCase().startsWith(data.softwareVendor.toLowerCase())
+    ? `${data.softwareVendor} ${displaySoftwareName}`
+    : displaySoftwareName
+
+  async function handleSaveRecommendation() {
+    if (!canSave) return
+    setIsSaving(true)
+    setError(null)
+    try {
+      await addRecommendation({
+        data: {
+          caseId,
+          recommendedOutcome,
+          rationale: rationale.trim(),
+          priorityOverride: priorityOverride || undefined,
+        },
+      })
+      await queryClient.invalidateQueries({ queryKey })
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to save the analyst recommendation.'))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleGenerateAiSummary() {
+    setIsGeneratingAi(true)
+    setError(null)
+    try {
+      await generateRemediationAiSummary({ data: { caseId } })
+      await queryClient.invalidateQueries({ queryKey })
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to request AI risk guidance.'))
+    } finally {
+      setIsGeneratingAi(false)
+    }
+  }
+
+  function useAiDraft() {
+    setRecommendedOutcome((current) => current || data.aiSummary.recommendedOutcome || '')
+    setRationale((current) => current || data.aiSummary.analystAssessment || '')
+    setPriorityOverride((current) => current || data.aiSummary.recommendedPriority || '')
+  }
+
+  return (
+    <section className="space-y-5">
+      <header className="rounded-lg border border-border/70 bg-card px-5 py-4">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0 space-y-2">
+            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+              Security analyst workbench
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold leading-tight">
+                {softwareIdentity}
+              </h1>
+              {data.softwareCategory ? (
+                <Badge variant="outline">{data.softwareCategory}</Badge>
+              ) : null}
+              <Badge variant="outline">{data.workflowState.currentStageLabel}</Badge>
+            </div>
+            <p className="max-w-4xl text-sm leading-relaxed text-muted-foreground">
+              {data.softwareDescription
+                ?? 'Review the open exposure and capture the recommendation the asset owner will use to decide the remediation path.'}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              to="/remediation/cases/$caseId"
+              params={{ caseId }}
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm font-medium hover:bg-muted"
+            >
+              Full case
+              <ExternalLink className="size-3.5" />
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <WorkbenchMetric label="Open vulnerabilities" value={data.summary.totalVulnerabilities.toLocaleString()} detail={`${data.summary.criticalCount} critical · ${data.summary.highCount} high`} />
+        <WorkbenchMetric label="Affected devices" value={data.workflow.affectedDeviceCount.toLocaleString()} detail={`${data.workflow.affectedOwnerTeamCount} owner teams`} />
+        <WorkbenchMetric label="Owner routing" value={data.softwareOwnerTeamName ?? 'Default Team'} detail={formatSoftwareOwnerRoutingDetail(data.softwareOwnerTeamName, data.softwareOwnerAssignmentSource)} />
+        <WorkbenchMetric label="SLA" value={data.sla?.slaStatus ?? 'Not set'} detail={data.sla?.dueDate ? `Due ${formatNullableDateTime(data.sla.dueDate)}` : 'No due date'} />
+      </div>
+
+      {data.businessLabels.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {data.businessLabels.map((label) => (
+            <span
+              key={label.id}
+              className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs"
+              title={`${label.weightCategory} business value, ${label.riskWeight.toFixed(1)}x risk weight`}
+            >
+              <span
+                className="size-2 rounded-full border border-border/60"
+                style={{ backgroundColor: label.color ?? 'transparent' }}
+              />
+              {label.name}
+              <span className="text-muted-foreground">({label.affectedDeviceCount})</span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div role="alert" className="rounded-lg border border-destructive/35 bg-destructive/8 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.75fr)]">
+        <Card className="shadow-none">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <SearchCheck className="size-4 text-primary" />
+              Analyst recommendation
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {currentRecommendation ? (
+              <div className="rounded-lg border border-border/70 bg-muted/25 px-3 py-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-xs font-medium', toneBadge(outcomeTone(currentRecommendation.recommendedOutcome)))}>
+                    {outcomeLabel(currentRecommendation.recommendedOutcome)}
+                  </span>
+                  {currentRecommendation.priorityOverride ? (
+                    <span className="text-xs text-muted-foreground">{currentRecommendation.priorityOverride} priority</span>
+                  ) : null}
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Saved {currentRecommendation.analystDisplayName ? `by ${currentRecommendation.analystDisplayName} ` : ''}{formatDateTime(currentRecommendation.createdAt)}
+                </p>
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Recommended remediation</label>
+                <Select value={recommendedOutcome} onValueChange={(value) => setRecommendedOutcome(value ?? '')}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select action..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {OUTCOMES.map((outcome) => (
+                      <SelectItem key={outcome} value={outcome}>{outcomeLabel(outcome)}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Priority</label>
+                <Select value={priorityOverride || 'none'} onValueChange={(value) => setPriorityOverride(value === 'none' ? '' : value ?? '')}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="No priority" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No priority</SelectItem>
+                    <SelectItem value="Critical">Critical</SelectItem>
+                    <SelectItem value="High">High</SelectItem>
+                    <SelectItem value="Medium">Medium</SelectItem>
+                    <SelectItem value="Low">Low</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="analyst-recommendation-rationale" className="text-sm font-medium">Recommendation rationale</label>
+              <Textarea
+                id="analyst-recommendation-rationale"
+                value={rationale}
+                onChange={(event) => setRationale(event.target.value)}
+                rows={7}
+                placeholder="Explain the risk drivers, business impact, and why this remediation path is recommended..."
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={handleSaveRecommendation} disabled={!canSave || isSaving}>
+                {isSaving ? 'Saving...' : currentRecommendation ? 'Update recommendation' : 'Save recommendation'}
+              </Button>
+              {(data.aiSummary.analystAssessment || data.aiSummary.recommendedOutcome || data.aiSummary.recommendedPriority) ? (
+                <Button type="button" variant="outline" onClick={useAiDraft}>
+                  Use AI draft
+                </Button>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+
+        <AiRiskBrief
+          data={data}
+          isGenerating={isGeneratingAi}
+          onGenerate={() => void handleGenerateAiSummary()}
+        />
+      </div>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold">Open vulnerabilities</h2>
+            <p className="text-sm text-muted-foreground">Highest-risk drivers first. Open a row for essentials without leaving the workbench.</p>
+          </div>
+        </div>
+        <div className="overflow-hidden rounded-lg border border-border/70 bg-card">
+          <table className="min-w-full divide-y divide-border/70 text-sm">
+            <thead className="bg-muted/35 text-left text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">Vulnerability</th>
+                <th className="px-4 py-3">Severity</th>
+                <th className="px-4 py-3">Threats</th>
+                <th className="px-4 py-3">Scope</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/60">
+              {topDrivers.map((vulnerability) => (
+                <tr key={vulnerability.vulnerabilityId}>
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{vulnerability.externalId}</div>
+                    <div className="line-clamp-1 max-w-xl text-xs text-muted-foreground">{vulnerability.title}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-xs font-medium', toneBadge(severityTone(vulnerability.effectiveSeverity ?? vulnerability.vendorSeverity)))}>
+                      {vulnerability.effectiveSeverity ?? vulnerability.vendorSeverity}
+                      {vulnerability.effectiveScore != null ? ` ${vulnerability.effectiveScore.toFixed(1)}` : ''}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <ThreatBadges vulnerability={vulnerability} />
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {vulnerability.affectedDeviceCount} devices
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Button variant="ghost" size="sm" onClick={() => setSelectedVulnerability(vulnerability)}>
+                      Details
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {topDrivers.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-muted-foreground">
+                    No open vulnerabilities are linked to this remediation case.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <VulnerabilityEssentialsSheet
+        vulnerability={selectedVulnerability}
+        open={selectedVulnerability !== null}
+        onOpenChange={(open) => { if (!open) setSelectedVulnerability(null) }}
+      />
+    </section>
+  )
+}
+
+function WorkbenchMetric({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-card px-4 py-3">
+      <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate text-lg font-semibold">{value}</p>
+      <p className="mt-1 truncate text-xs text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function AiRiskBrief({
+  data,
+  isGenerating,
+  onGenerate,
+}: {
+  data: DecisionContext
+  isGenerating: boolean
+  onGenerate: () => void
+}) {
+  const hasAnalystGuidance = Boolean(data.aiSummary.analystAssessment || data.aiSummary.recommendedOutcome || data.aiSummary.recommendedPriority)
+  const isWorking = data.aiSummary.status === 'Queued' || data.aiSummary.status === 'Generating'
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {isWorking ? <LoaderCircle className="size-4 animate-spin text-primary" /> : <Bot className="size-4 text-primary" />}
+          AI risk brief
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {hasAnalystGuidance ? (
+          <>
+            {data.aiSummary.recommendedPriority ? (
+              <div>
+                <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Suggested priority</p>
+                <p className="mt-1 text-sm font-medium">{data.aiSummary.recommendedPriority}</p>
+              </div>
+            ) : null}
+            {data.aiSummary.recommendedOutcome ? (
+              <div>
+                <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Suggested action</p>
+                <p className="mt-1 text-sm font-medium">{outcomeLabel(data.aiSummary.recommendedOutcome)}</p>
+              </div>
+            ) : null}
+            {data.aiSummary.analystAssessment ? (
+              <p className="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+                {data.aiSummary.analystAssessment}
+              </p>
+            ) : null}
+            <p className="text-xs text-muted-foreground">
+              Generated {formatNullableDateTime(data.aiSummary.generatedAt)}
+            </p>
+          </>
+        ) : isWorking ? (
+          <p className="text-sm text-muted-foreground">
+            AI guidance is queued or generating. You can continue the analysis while it runs.
+          </p>
+        ) : data.aiSummary.canGenerate ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Ask AI for a concise analyst-oriented summary of the highest-risk open vulnerabilities.
+            </p>
+            <Button type="button" variant="outline" onClick={onGenerate} disabled={isGenerating}>
+              {isGenerating ? 'Asking AI...' : 'Ask AI'}
+            </Button>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {data.aiSummary.unavailableMessage ?? 'AI guidance is not available for this tenant.'}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ThreatBadges({ vulnerability }: { vulnerability: DecisionVuln }) {
+  const badges = [
+    vulnerability.knownExploited ? 'KEV' : null,
+    vulnerability.publicExploit ? 'Exploit' : null,
+    vulnerability.activeAlert ? 'Alert' : null,
+  ].filter(Boolean)
+
+  if (badges.length === 0) {
+    return <span className="text-xs text-muted-foreground">None</span>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {badges.map((badge) => (
+        <span key={badge} className={cn('rounded-full border px-1.5 py-0.5 text-[10px] font-medium', toneBadge('danger'))}>
+          {badge}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function VulnerabilityEssentialsSheet({
+  vulnerability,
+  open,
+  onOpenChange,
+}: {
+  vulnerability: DecisionVuln | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto border-l border-border/80 bg-card p-0 sm:max-w-xl">
+        <SheetHeader className="border-b border-border/70 p-5">
+          <SheetTitle>{vulnerability?.externalId ?? 'Vulnerability'}</SheetTitle>
+          <SheetDescription className="line-clamp-2">{vulnerability?.title ?? ''}</SheetDescription>
+        </SheetHeader>
+        {vulnerability ? (
+          <div className="space-y-5 p-5">
+            <div className="flex flex-wrap gap-2">
+              <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-xs font-medium', toneBadge(severityTone(vulnerability.effectiveSeverity ?? vulnerability.vendorSeverity)))}>
+                {vulnerability.effectiveSeverity ?? vulnerability.vendorSeverity}
+                {vulnerability.effectiveScore != null ? ` ${vulnerability.effectiveScore.toFixed(1)}` : ''}
+              </span>
+              {vulnerability.epssScore != null ? (
+                <Badge variant="outline">EPSS {(vulnerability.epssScore * 100).toFixed(1)}%</Badge>
+              ) : null}
+            </div>
+            {vulnerability.description ? (
+              <p className="text-sm leading-relaxed text-muted-foreground">{vulnerability.description}</p>
+            ) : null}
+            <div className="divide-y divide-border/60 rounded-lg border border-border/70">
+              <SheetInfoRow label="First seen">{formatNullableDateTime(vulnerability.firstSeenAt)}</SheetInfoRow>
+              <SheetInfoRow label="Affected devices">{vulnerability.affectedDeviceCount.toLocaleString()}</SheetInfoRow>
+              <SheetInfoRow label="Affected versions">{vulnerability.affectedVersionCount.toLocaleString()}</SheetInfoRow>
+              <SheetInfoRow label="Vendor score">{vulnerability.vendorScore != null ? vulnerability.vendorScore.toFixed(1) : '-'}</SheetInfoRow>
+              <SheetInfoRow label="CVSS vector">
+                {vulnerability.cvssVector ? <code className="break-all text-[11px] text-muted-foreground">{vulnerability.cvssVector}</code> : '-'}
+              </SheetInfoRow>
+            </div>
+            <div className="rounded-lg border border-border/70 bg-background px-3 py-3">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <ShieldAlert className="size-4 text-muted-foreground" />
+                Threat indicators
+              </div>
+              <div className="mt-3">
+                <ThreatBadges vulnerability={vulnerability} />
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function SheetInfoRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 px-3 py-2">
+      <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
+      <span className="text-right text-sm">{children}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/features/tasks/MyTasksPage.test.tsx
+++ b/frontend/src/components/features/tasks/MyTasksPage.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AnchorHTMLAttributes } from 'react'
+import type { PagedDecisionList } from '@/api/remediation.schemas'
+import { MyTasksPage } from './MyTasksPage'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}))
+
+const dataFixture: PagedDecisionList = {
+  items: [
+    {
+      remediationCaseId: '11111111-1111-1111-1111-111111111111',
+      softwareName: 'Contoso Agent',
+      criticality: 'High',
+      outcome: null,
+      approvalStatus: null,
+      decidedAt: null,
+      maintenanceWindowDate: null,
+      expiryDate: null,
+      totalVulnerabilities: 4,
+      criticalCount: 1,
+      highCount: 2,
+      riskScore: 810,
+      riskBand: 'High',
+      slaStatus: 'DueSoon',
+      slaDueDate: '2026-05-09T00:00:00Z',
+      affectedDeviceCount: 12,
+      openEpisodeTrend: [],
+      workflowStage: 'SecurityAnalysis',
+      softwareOwnerTeamName: 'Platform Engineering',
+      softwareOwnerAssignmentSource: 'Rule',
+    },
+  ],
+  totalCount: 1,
+  page: 1,
+  pageSize: 25,
+  totalPages: 1,
+  summary: {
+    softwareInScope: 1,
+    withDecision: 0,
+    pendingApproval: 0,
+    noDecision: 1,
+  },
+}
+
+describe('MyTasksPage', () => {
+  it('shows analyst recommendation tasks with a link to the security analyst workbench', () => {
+    render(<MyTasksPage data={dataFixture} onPageChange={() => {}} />)
+
+    expect(screen.getByRole('heading', { name: /My tasks/i })).toBeInTheDocument()
+    expect(screen.getByText('Contoso Agent')).toBeInTheDocument()
+    expect(screen.getAllByText(/Recommendation needed/i).length).toBeGreaterThan(0)
+    expect(screen.getByRole('link', { name: /Open workbench/i })).toHaveAttribute(
+      'href',
+      '/workbenches/security-analyst/cases/$caseId',
+    )
+  })
+})

--- a/frontend/src/components/features/tasks/MyTasksPage.test.tsx
+++ b/frontend/src/components/features/tasks/MyTasksPage.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AnchorHTMLAttributes } from 'react'
 import type { PagedDecisionList } from '@/api/remediation.schemas'
 import { MyTasksPage } from './MyTasksPage'
+import { bucketsForRoles } from './my-tasks-buckets'
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, to, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }) => (
@@ -10,7 +11,7 @@ vi.mock('@tanstack/react-router', () => ({
   ),
 }))
 
-const dataFixture: PagedDecisionList = {
+const makeList = (overrides?: Partial<PagedDecisionList>): PagedDecisionList => ({
   items: [
     {
       remediationCaseId: '11111111-1111-1111-1111-111111111111',
@@ -45,18 +46,88 @@ const dataFixture: PagedDecisionList = {
     pendingApproval: 0,
     noDecision: 1,
   },
-}
+  ...overrides,
+})
 
 describe('MyTasksPage', () => {
-  it('shows analyst recommendation tasks with a link to the security analyst workbench', () => {
-    render(<MyTasksPage data={dataFixture} onPageChange={() => {}} />)
+  it('renders the recommendation section with a link to the security analyst workbench', () => {
+    render(
+      <MyTasksPage
+        sections={[{ bucket: 'recommendation', data: makeList() }]}
+        onPageChange={() => {}}
+      />,
+    )
 
     expect(screen.getByRole('heading', { name: /My tasks/i })).toBeInTheDocument()
     expect(screen.getByText('Contoso Agent')).toBeInTheDocument()
-    expect(screen.getAllByText(/Recommendation needed/i).length).toBeGreaterThan(0)
+    expect(screen.getByRole('heading', { name: /Recommendation needed/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Open workbench/i })).toHaveAttribute(
       'href',
       '/workbenches/security-analyst/cases/$caseId',
     )
+  })
+
+  it('renders one section per bucket with the right CTA', () => {
+    render(
+      <MyTasksPage
+        sections={[
+          { bucket: 'recommendation', data: makeList() },
+          { bucket: 'decision', data: makeList({ totalCount: 2 }) },
+          { bucket: 'approval', data: makeList({ totalCount: 5 }) },
+        ]}
+        onPageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: /Recommendation needed/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Decision needed/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Approval needed/i })).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Open workbench/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /Open case/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /Review approval/i }).length).toBeGreaterThan(0)
+  })
+
+  it('shows an empty-row placeholder per bucket with no items', () => {
+    render(
+      <MyTasksPage
+        sections={[
+          { bucket: 'recommendation', data: makeList({ items: [], totalCount: 0 }) },
+        ]}
+        onPageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByText(/Nothing waiting in this queue/i)).toBeInTheDocument()
+  })
+
+  it('falls back to a friendly message when the user has no buckets', () => {
+    render(<MyTasksPage sections={[]} onPageChange={() => {}} />)
+    expect(screen.getByText(/don't have any task queues/i)).toBeInTheDocument()
+  })
+})
+
+describe('bucketsForRoles', () => {
+  it('gives GlobalAdmin every bucket', () => {
+    expect(bucketsForRoles(['GlobalAdmin'])).toEqual(['recommendation', 'decision', 'approval'])
+  })
+
+  it('maps SecurityAnalyst to recommendation only', () => {
+    expect(bucketsForRoles(['SecurityAnalyst'])).toEqual(['recommendation'])
+  })
+
+  it('maps AssetOwner to decision only', () => {
+    expect(bucketsForRoles(['AssetOwner'])).toEqual(['decision'])
+  })
+
+  it('maps SecurityManager to approval only', () => {
+    expect(bucketsForRoles(['SecurityManager'])).toEqual(['approval'])
+  })
+
+  it('combines buckets when the user holds multiple non-admin roles', () => {
+    expect(bucketsForRoles(['SecurityAnalyst', 'AssetOwner'])).toEqual(['recommendation', 'decision'])
+  })
+
+  it('returns an empty list for unrelated roles', () => {
+    expect(bucketsForRoles(['Stakeholder'])).toEqual([])
   })
 })

--- a/frontend/src/components/features/tasks/MyTasksPage.tsx
+++ b/frontend/src/components/features/tasks/MyTasksPage.tsx
@@ -8,13 +8,19 @@ import {
   formatSoftwareOwnerRoutingDetail,
   severityTone,
 } from '@/components/features/remediation/remediation-utils'
+import { BUCKET_LABELS, type TaskBucketKey } from './my-tasks-buckets'
+
+type Section = { bucket: TaskBucketKey; data: PagedDecisionList }
 
 type MyTasksPageProps = {
-  data: PagedDecisionList
+  sections: Section[]
   onPageChange: (page: number) => void
 }
 
-export function MyTasksPage({ data, onPageChange }: MyTasksPageProps) {
+export function MyTasksPage({ sections, onPageChange }: MyTasksPageProps) {
+  const totalCount = sections.reduce((sum, section) => sum + section.data.totalCount, 0)
+  const visibleCount = sections.reduce((sum, section) => sum + section.data.items.length, 0)
+
   return (
     <section className="space-y-5">
       <header className="rounded-[28px] border border-border/70 bg-[linear-gradient(135deg,color-mix(in_oklab,var(--primary)_8%,transparent),transparent_50%),var(--color-card)] p-5">
@@ -27,122 +33,168 @@ export function MyTasksPage({ data, onPageChange }: MyTasksPageProps) {
               My tasks
             </h1>
             <p className="max-w-3xl text-sm text-muted-foreground">
-              Remediation cases that are waiting for security analysis before owners can choose the remediation path.
+              Remediation cases waiting on your action, grouped by what each role needs to do next.
             </p>
           </div>
           <div className="grid min-w-[220px] gap-3 rounded-xl border border-border/70 bg-background/50 p-4">
-            <Metric label="Recommendation needed" value={data.totalCount.toLocaleString()} />
-            <Metric label="Visible on page" value={data.items.length.toLocaleString()} />
+            <Metric label="Open across all queues" value={totalCount.toLocaleString()} />
+            <Metric label="Visible on page" value={visibleCount.toLocaleString()} />
           </div>
         </div>
       </header>
 
-      <section className="rounded-2xl border border-border/70 bg-card p-5">
-        <div className="mb-4 flex items-center gap-2">
-          <ClipboardList className="size-4 text-primary" />
-          <h2 className="text-lg font-semibold">Analyst recommendation tasks</h2>
-        </div>
+      {sections.length === 0 ? (
+        <section className="rounded-2xl border border-border/70 bg-card p-8 text-center text-sm text-muted-foreground">
+          You don&apos;t have any task queues assigned to your roles.
+        </section>
+      ) : (
+        sections.map((section) => (
+          <BucketSection
+            key={section.bucket}
+            bucket={section.bucket}
+            data={section.data}
+            onPageChange={onPageChange}
+          />
+        ))
+      )}
+    </section>
+  )
+}
 
-        <div className="overflow-x-auto rounded-xl border border-border/70">
-          <table className="min-w-[860px] divide-y divide-border/70 text-sm">
-            <thead className="bg-muted/30 text-left text-xs uppercase tracking-[0.14em] text-muted-foreground">
+function BucketSection({
+  bucket,
+  data,
+  onPageChange,
+}: {
+  bucket: TaskBucketKey
+  data: PagedDecisionList
+  onPageChange: (page: number) => void
+}) {
+  const meta = BUCKET_LABELS[bucket]
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card p-5">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <ClipboardList className="size-4 text-primary" />
+            <h2 className="text-lg font-semibold">{meta.title}</h2>
+            <span className="rounded-full border border-border/70 bg-muted/30 px-2 py-0.5 text-xs text-muted-foreground">
+              {data.totalCount.toLocaleString()}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{meta.description}</p>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border/70">
+        <table className="min-w-[860px] divide-y divide-border/70 text-sm">
+          <thead className="bg-muted/30 text-left text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3">Software</th>
+              <th className="px-4 py-3">Task</th>
+              <th className="px-4 py-3">Exposure</th>
+              <th className="px-4 py-3">SLA</th>
+              <th className="px-4 py-3">Owner routing</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60 bg-background">
+            {data.items.length === 0 ? (
               <tr>
-                <th className="px-4 py-3">Software</th>
-                <th className="px-4 py-3">Task</th>
-                <th className="px-4 py-3">Exposure</th>
-                <th className="px-4 py-3">SLA</th>
-                <th className="px-4 py-3">Owner routing</th>
-                <th className="px-4 py-3" />
+                <td colSpan={6} className="px-4 py-8 text-sm text-muted-foreground">
+                  Nothing waiting in this queue.
+                </td>
               </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60 bg-background">
-              {data.items.length === 0 ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-sm text-muted-foreground">
-                    No analyst recommendation tasks are waiting right now.
-                  </td>
-                </tr>
-              ) : (
-                data.items.map((item) => (
-                  <tr key={item.remediationCaseId} className="align-top transition-colors hover:bg-muted/25">
-                    <td className="px-4 py-3">
-                      <div className="space-y-1">
-                        <div className="font-medium">{startCase(item.softwareName)}</div>
-                        <div className="flex flex-wrap gap-1.5">
-                          <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${toneBadge(severityTone(item.criticality))}`}>
-                            {item.criticality}
+            ) : (
+              data.items.map((item) => (
+                <tr key={item.remediationCaseId} className="align-top transition-colors hover:bg-muted/25">
+                  <td className="px-4 py-3">
+                    <div className="space-y-1">
+                      <div className="font-medium">{startCase(item.softwareName)}</div>
+                      <div className="flex flex-wrap gap-1.5">
+                        <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${toneBadge(severityTone(item.criticality))}`}>
+                          {item.criticality}
+                        </span>
+                        {item.riskBand ? (
+                          <span className="text-[10px] text-muted-foreground">
+                            {item.riskBand} risk
                           </span>
-                          {item.riskBand ? (
-                            <span className="text-[10px] text-muted-foreground">
-                              {item.riskBand} risk
-                            </span>
-                          ) : null}
-                        </div>
+                        ) : null}
                       </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium">
-                        <ShieldAlert className="size-3.5 text-primary" />
-                        Recommendation needed
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      <div>{item.totalVulnerabilities.toLocaleString()} open vulnerabilities</div>
-                      <div className="text-xs">{item.affectedDeviceCount.toLocaleString()} affected devices</div>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {item.slaDueDate ? (
-                        <>
-                          <div>{item.slaStatus ?? 'SLA tracked'}</div>
-                          <div className="text-xs">Due {formatDate(item.slaDueDate)}</div>
-                        </>
-                      ) : (
-                        'No due date'
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {formatSoftwareOwnerRoutingDetail(item.softwareOwnerTeamName, item.softwareOwnerAssignmentSource)}
-                    </td>
-                    <td className="px-4 py-3 text-right">
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium">
+                      <ShieldAlert className="size-3.5 text-primary" />
+                      {meta.title}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    <div>{item.totalVulnerabilities.toLocaleString()} open vulnerabilities</div>
+                    <div className="text-xs">{item.affectedDeviceCount.toLocaleString()} affected devices</div>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {item.slaDueDate ? (
+                      <>
+                        <div>{item.slaStatus ?? 'SLA tracked'}</div>
+                        <div className="text-xs">Due {formatDate(item.slaDueDate)}</div>
+                      </>
+                    ) : (
+                      'No due date'
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatSoftwareOwnerRoutingDetail(item.softwareOwnerTeamName, item.softwareOwnerAssignmentSource)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {bucket === 'recommendation' ? (
                       <Link
                         to="/workbenches/security-analyst/cases/$caseId"
                         params={{ caseId: item.remediationCaseId }}
                         className="inline-flex h-7 items-center justify-center rounded-lg bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground transition-colors hover:bg-primary/80"
                       >
-                        Open workbench
+                        {meta.cta}
                       </Link>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                    ) : (
+                      <Link
+                        to="/remediation/cases/$caseId"
+                        params={{ caseId: item.remediationCaseId }}
+                        className="inline-flex h-7 items-center justify-center rounded-lg bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+                      >
+                        {meta.cta}
+                      </Link>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
 
-        <div className="mt-4 flex items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">
-            Page {data.page} of {Math.max(data.totalPages, 1)}
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={data.page <= 1}
-              onClick={() => onPageChange(data.page - 1)}
-            >
-              Previous
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={data.page >= data.totalPages}
-              onClick={() => onPageChange(data.page + 1)}
-            >
-              Next
-            </Button>
-          </div>
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Page {data.page} of {Math.max(data.totalPages, 1)}
+        </p>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={data.page <= 1}
+            onClick={() => onPageChange(data.page - 1)}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={data.page >= data.totalPages}
+            onClick={() => onPageChange(data.page + 1)}
+          >
+            Next
+          </Button>
         </div>
-      </section>
+      </div>
     </section>
   )
 }

--- a/frontend/src/components/features/tasks/MyTasksPage.tsx
+++ b/frontend/src/components/features/tasks/MyTasksPage.tsx
@@ -1,0 +1,157 @@
+import { Link } from '@tanstack/react-router'
+import { ClipboardList, ShieldAlert } from 'lucide-react'
+import type { PagedDecisionList } from '@/api/remediation.schemas'
+import { Button } from '@/components/ui/button'
+import { formatDate, startCase } from '@/lib/formatting'
+import { toneBadge } from '@/lib/tone-classes'
+import {
+  formatSoftwareOwnerRoutingDetail,
+  severityTone,
+} from '@/components/features/remediation/remediation-utils'
+
+type MyTasksPageProps = {
+  data: PagedDecisionList
+  onPageChange: (page: number) => void
+}
+
+export function MyTasksPage({ data, onPageChange }: MyTasksPageProps) {
+  return (
+    <section className="space-y-5">
+      <header className="rounded-[28px] border border-border/70 bg-[linear-gradient(135deg,color-mix(in_oklab,var(--primary)_8%,transparent),transparent_50%),var(--color-card)] p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+              Work queue
+            </p>
+            <h1 className="text-3xl font-semibold tracking-[-0.04em]">
+              My tasks
+            </h1>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              Remediation cases that are waiting for security analysis before owners can choose the remediation path.
+            </p>
+          </div>
+          <div className="grid min-w-[220px] gap-3 rounded-xl border border-border/70 bg-background/50 p-4">
+            <Metric label="Recommendation needed" value={data.totalCount.toLocaleString()} />
+            <Metric label="Visible on page" value={data.items.length.toLocaleString()} />
+          </div>
+        </div>
+      </header>
+
+      <section className="rounded-2xl border border-border/70 bg-card p-5">
+        <div className="mb-4 flex items-center gap-2">
+          <ClipboardList className="size-4 text-primary" />
+          <h2 className="text-lg font-semibold">Analyst recommendation tasks</h2>
+        </div>
+
+        <div className="overflow-x-auto rounded-xl border border-border/70">
+          <table className="min-w-[860px] divide-y divide-border/70 text-sm">
+            <thead className="bg-muted/30 text-left text-xs uppercase tracking-[0.14em] text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">Software</th>
+                <th className="px-4 py-3">Task</th>
+                <th className="px-4 py-3">Exposure</th>
+                <th className="px-4 py-3">SLA</th>
+                <th className="px-4 py-3">Owner routing</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/60 bg-background">
+              {data.items.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-sm text-muted-foreground">
+                    No analyst recommendation tasks are waiting right now.
+                  </td>
+                </tr>
+              ) : (
+                data.items.map((item) => (
+                  <tr key={item.remediationCaseId} className="align-top transition-colors hover:bg-muted/25">
+                    <td className="px-4 py-3">
+                      <div className="space-y-1">
+                        <div className="font-medium">{startCase(item.softwareName)}</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${toneBadge(severityTone(item.criticality))}`}>
+                            {item.criticality}
+                          </span>
+                          {item.riskBand ? (
+                            <span className="text-[10px] text-muted-foreground">
+                              {item.riskBand} risk
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-xs font-medium">
+                        <ShieldAlert className="size-3.5 text-primary" />
+                        Recommendation needed
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      <div>{item.totalVulnerabilities.toLocaleString()} open vulnerabilities</div>
+                      <div className="text-xs">{item.affectedDeviceCount.toLocaleString()} affected devices</div>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {item.slaDueDate ? (
+                        <>
+                          <div>{item.slaStatus ?? 'SLA tracked'}</div>
+                          <div className="text-xs">Due {formatDate(item.slaDueDate)}</div>
+                        </>
+                      ) : (
+                        'No due date'
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatSoftwareOwnerRoutingDetail(item.softwareOwnerTeamName, item.softwareOwnerAssignmentSource)}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Link
+                        to="/workbenches/security-analyst/cases/$caseId"
+                        params={{ caseId: item.remediationCaseId }}
+                        className="inline-flex h-7 items-center justify-center rounded-lg bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+                      >
+                        Open workbench
+                      </Link>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            Page {data.page} of {Math.max(data.totalPages, 1)}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={data.page <= 1}
+              onClick={() => onPageChange(data.page - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={data.page >= data.totalPages}
+              onClick={() => onPageChange(data.page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      </section>
+    </section>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/features/tasks/my-tasks-buckets.ts
+++ b/frontend/src/components/features/tasks/my-tasks-buckets.ts
@@ -1,0 +1,36 @@
+export type TaskBucketKey = 'recommendation' | 'decision' | 'approval'
+
+export const BUCKET_FILTERS: Record<TaskBucketKey, Record<string, boolean>> = {
+  recommendation: { needsAnalystRecommendation: true },
+  decision: { needsRemediationDecision: true },
+  approval: { needsApproval: true },
+}
+
+export const BUCKET_LABELS: Record<TaskBucketKey, { title: string; description: string; cta: string }> = {
+  recommendation: {
+    title: 'Recommendation needed',
+    description: 'Cases waiting for security analysis before owners can choose a remediation path.',
+    cta: 'Open workbench',
+  },
+  decision: {
+    title: 'Decision needed',
+    description: 'Cases where the owning team needs to choose a remediation outcome.',
+    cta: 'Open case',
+  },
+  approval: {
+    title: 'Approval needed',
+    description: 'Decisions waiting for sign-off before remediation can move to execution.',
+    cta: 'Review approval',
+  },
+}
+
+export function bucketsForRoles(roles: readonly string[]): TaskBucketKey[] {
+  if (roles.includes('GlobalAdmin')) {
+    return ['recommendation', 'decision', 'approval']
+  }
+  const out: TaskBucketKey[] = []
+  if (roles.includes('SecurityAnalyst')) out.push('recommendation')
+  if (roles.includes('AssetOwner')) out.push('decision')
+  if (roles.includes('SecurityManager')) out.push('approval')
+  return out
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   BarChart3,
   Bug,
   ClipboardCheck,
+  ClipboardList,
   LayoutDashboard,
   ScrollText,
   Server,
@@ -64,6 +65,12 @@ type NavGroup = {
 
 const navItems: NavItem[] = [
   { to: "/dashboard", label: "Overview", icon: LayoutDashboard },
+  {
+    to: "/my-tasks",
+    label: "My Tasks",
+    icon: ClipboardList,
+    roles: ["SecurityManager", "SecurityAnalyst", "GlobalAdmin"],
+  },
   { to: "/vulnerabilities", label: "Vulnerabilities", icon: Bug },
   {
     to: "/remediation",

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -65,12 +65,7 @@ type NavGroup = {
 
 const navItems: NavItem[] = [
   { to: "/dashboard", label: "Overview", icon: LayoutDashboard },
-  {
-    to: "/my-tasks",
-    label: "My Tasks",
-    icon: ClipboardList,
-    roles: ["SecurityManager", "SecurityAnalyst", "GlobalAdmin"],
-  },
+  { to: "/my-tasks", label: "My Tasks", icon: ClipboardList },
   { to: "/vulnerabilities", label: "Vulnerabilities", icon: Bug },
   {
     to: "/remediation",

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -52,6 +52,7 @@ import { Route as AuthedAdminIntegrationsIndexRouteImport } from './routes/_auth
 import { Route as AuthedAdminDeviceRulesIndexRouteImport } from './routes/_authed/admin/device-rules/index'
 import { Route as AuthedRemediationTaskIdRouteImport } from './routes/_authed/remediation/task.$id'
 import { Route as AuthedRemediationCasesCaseIdRouteImport } from './routes/_authed/remediation/cases.$caseId'
+import { Route as AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport } from './routes/_authed/workbenches/security-analyst/cases.$caseId'
 import { Route as AuthedDashboardMyAssetsAttentionRouteImport } from './routes/_authed/dashboard/my-assets.attention'
 import { Route as AuthedAssetsApplicationsIdRouteImport } from './routes/_authed/assets/applications/$id'
 import { Route as AuthedAdminWorkflowsNewRouteImport } from './routes/_authed/admin/workflows/new'
@@ -298,6 +299,12 @@ const AuthedRemediationCasesCaseIdRoute =
     path: '/remediation/cases/$caseId',
     getParentRoute: () => AuthedRoute,
   } as any)
+const AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute =
+  AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport.update({
+    id: '/workbenches/security-analyst/cases/$caseId',
+    path: '/workbenches/security-analyst/cases/$caseId',
+    getParentRoute: () => AuthedRoute,
+  } as any)
 const AuthedDashboardMyAssetsAttentionRoute =
   AuthedDashboardMyAssetsAttentionRouteImport.update({
     id: '/attention',
@@ -455,6 +462,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/my-assets/attention': typeof AuthedDashboardMyAssetsAttentionRoute
   '/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
+  '/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/admin/device-rules/': typeof AuthedAdminDeviceRulesIndexRoute
   '/admin/integrations/': typeof AuthedAdminIntegrationsIndexRoute
   '/admin/teams/': typeof AuthedAdminTeamsIndexRoute
@@ -517,6 +525,7 @@ export interface FileRoutesByTo {
   '/dashboard/my-assets/attention': typeof AuthedDashboardMyAssetsAttentionRoute
   '/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
+  '/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/admin/device-rules': typeof AuthedAdminDeviceRulesIndexRoute
   '/admin/integrations': typeof AuthedAdminIntegrationsIndexRoute
   '/admin/teams': typeof AuthedAdminTeamsIndexRoute
@@ -581,6 +590,7 @@ export interface FileRoutesById {
   '/_authed/dashboard/my-assets/attention': typeof AuthedDashboardMyAssetsAttentionRoute
   '/_authed/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/_authed/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
+  '/_authed/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/_authed/admin/device-rules/': typeof AuthedAdminDeviceRulesIndexRoute
   '/_authed/admin/integrations/': typeof AuthedAdminIntegrationsIndexRoute
   '/_authed/admin/teams/': typeof AuthedAdminTeamsIndexRoute
@@ -645,6 +655,7 @@ export interface FileRouteTypes {
     | '/dashboard/my-assets/attention'
     | '/remediation/cases/$caseId'
     | '/remediation/task/$id'
+    | '/workbenches/security-analyst/cases/$caseId'
     | '/admin/device-rules/'
     | '/admin/integrations/'
     | '/admin/teams/'
@@ -707,6 +718,7 @@ export interface FileRouteTypes {
     | '/dashboard/my-assets/attention'
     | '/remediation/cases/$caseId'
     | '/remediation/task/$id'
+    | '/workbenches/security-analyst/cases/$caseId'
     | '/admin/device-rules'
     | '/admin/integrations'
     | '/admin/teams'
@@ -770,6 +782,7 @@ export interface FileRouteTypes {
     | '/_authed/dashboard/my-assets/attention'
     | '/_authed/remediation/cases/$caseId'
     | '/_authed/remediation/task/$id'
+    | '/_authed/workbenches/security-analyst/cases/$caseId'
     | '/_authed/admin/device-rules/'
     | '/_authed/admin/integrations/'
     | '/_authed/admin/teams/'
@@ -1095,6 +1108,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedRemediationCasesCaseIdRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/workbenches/security-analyst/cases/$caseId': {
+      id: '/_authed/workbenches/security-analyst/cases/$caseId'
+      path: '/workbenches/security-analyst/cases/$caseId'
+      fullPath: '/workbenches/security-analyst/cases/$caseId'
+      preLoaderRoute: typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/dashboard/my-assets/attention': {
       id: '/_authed/dashboard/my-assets/attention'
       path: '/attention'
@@ -1283,6 +1303,7 @@ interface AuthedRouteChildren {
   AuthedAssetsApplicationsIdRoute: typeof AuthedAssetsApplicationsIdRoute
   AuthedRemediationCasesCaseIdRoute: typeof AuthedRemediationCasesCaseIdRoute
   AuthedRemediationTaskIdRoute: typeof AuthedRemediationTaskIdRoute
+  AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute: typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   AuthedAdminDeviceRulesIndexRoute: typeof AuthedAdminDeviceRulesIndexRoute
   AuthedAdminIntegrationsIndexRoute: typeof AuthedAdminIntegrationsIndexRoute
   AuthedAdminTeamsIndexRoute: typeof AuthedAdminTeamsIndexRoute
@@ -1338,6 +1359,8 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAssetsApplicationsIdRoute: AuthedAssetsApplicationsIdRoute,
   AuthedRemediationCasesCaseIdRoute: AuthedRemediationCasesCaseIdRoute,
   AuthedRemediationTaskIdRoute: AuthedRemediationTaskIdRoute,
+  AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute:
+    AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute,
   AuthedAdminDeviceRulesIndexRoute: AuthedAdminDeviceRulesIndexRoute,
   AuthedAdminIntegrationsIndexRoute: AuthedAdminIntegrationsIndexRoute,
   AuthedAdminTeamsIndexRoute: AuthedAdminTeamsIndexRoute,

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as AuthedDashboardIndexRouteImport } from './routes/_authed/dashb
 import { Route as AuthedAuditLogIndexRouteImport } from './routes/_authed/audit-log/index'
 import { Route as AuthedApprovalsIndexRouteImport } from './routes/_authed/approvals/index'
 import { Route as AuthedAdminIndexRouteImport } from './routes/_authed/admin/index'
+import { Route as AuthedMyTasksRouteImport } from './routes/_authed/my-tasks'
 import { Route as AuthedActionsIndexRouteImport } from './routes/_authed/actions/index'
 import { Route as ApiInternalEventsRouteImport } from './routes/api/internal/events'
 import { Route as AuthedVulnerabilitiesChangesRouteImport } from './routes/_authed/vulnerabilities/changes'
@@ -150,6 +151,11 @@ const AuthedApprovalsIndexRoute = AuthedApprovalsIndexRouteImport.update({
 const AuthedAdminIndexRoute = AuthedAdminIndexRouteImport.update({
   id: '/admin/',
   path: '/admin/',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedMyTasksRoute = AuthedMyTasksRouteImport.update({
+  id: '/my-tasks',
+  path: '/my-tasks',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedActionsIndexRoute = AuthedActionsIndexRouteImport.update({
@@ -435,6 +441,7 @@ export interface FileRoutesByFullPath {
   '/vulnerabilities/$id': typeof AuthedVulnerabilitiesIdRoute
   '/vulnerabilities/changes': typeof AuthedVulnerabilitiesChangesRoute
   '/api/internal/events': typeof ApiInternalEventsRoute
+  '/my-tasks': typeof AuthedMyTasksRoute
   '/actions/': typeof AuthedActionsIndexRoute
   '/admin/': typeof AuthedAdminIndexRoute
   '/approvals/': typeof AuthedApprovalsIndexRoute
@@ -498,6 +505,7 @@ export interface FileRoutesByTo {
   '/vulnerabilities/$id': typeof AuthedVulnerabilitiesIdRoute
   '/vulnerabilities/changes': typeof AuthedVulnerabilitiesChangesRoute
   '/api/internal/events': typeof ApiInternalEventsRoute
+  '/my-tasks': typeof AuthedMyTasksRoute
   '/actions': typeof AuthedActionsIndexRoute
   '/admin': typeof AuthedAdminIndexRoute
   '/approvals': typeof AuthedApprovalsIndexRoute
@@ -563,6 +571,7 @@ export interface FileRoutesById {
   '/_authed/vulnerabilities/$id': typeof AuthedVulnerabilitiesIdRoute
   '/_authed/vulnerabilities/changes': typeof AuthedVulnerabilitiesChangesRoute
   '/api/internal/events': typeof ApiInternalEventsRoute
+  '/_authed/my-tasks': typeof AuthedMyTasksRoute
   '/_authed/actions/': typeof AuthedActionsIndexRoute
   '/_authed/admin/': typeof AuthedAdminIndexRoute
   '/_authed/approvals/': typeof AuthedApprovalsIndexRoute
@@ -628,6 +637,7 @@ export interface FileRouteTypes {
     | '/vulnerabilities/$id'
     | '/vulnerabilities/changes'
     | '/api/internal/events'
+    | '/my-tasks'
     | '/actions/'
     | '/admin/'
     | '/approvals/'
@@ -691,6 +701,7 @@ export interface FileRouteTypes {
     | '/vulnerabilities/$id'
     | '/vulnerabilities/changes'
     | '/api/internal/events'
+    | '/my-tasks'
     | '/actions'
     | '/admin'
     | '/approvals'
@@ -755,6 +766,7 @@ export interface FileRouteTypes {
     | '/_authed/vulnerabilities/$id'
     | '/_authed/vulnerabilities/changes'
     | '/api/internal/events'
+    | '/_authed/my-tasks'
     | '/_authed/actions/'
     | '/_authed/admin/'
     | '/_authed/approvals/'
@@ -924,6 +936,13 @@ declare module '@tanstack/react-router' {
       path: '/actions'
       fullPath: '/actions/'
       preLoaderRoute: typeof AuthedActionsIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/my-tasks': {
+      id: '/_authed/my-tasks'
+      path: '/my-tasks'
+      fullPath: '/my-tasks'
+      preLoaderRoute: typeof AuthedMyTasksRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/api/internal/events': {
@@ -1279,6 +1298,7 @@ interface AuthedRouteChildren {
   AuthedVulnerabilitiesChangesRoute: typeof AuthedVulnerabilitiesChangesRoute
   AuthedActionsIndexRoute: typeof AuthedActionsIndexRoute
   AuthedAdminIndexRoute: typeof AuthedAdminIndexRoute
+  AuthedMyTasksRoute: typeof AuthedMyTasksRoute
   AuthedApprovalsIndexRoute: typeof AuthedApprovalsIndexRoute
   AuthedAuditLogIndexRoute: typeof AuthedAuditLogIndexRoute
   AuthedDashboardIndexRoute: typeof AuthedDashboardIndexRoute
@@ -1334,6 +1354,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedVulnerabilitiesChangesRoute: AuthedVulnerabilitiesChangesRoute,
   AuthedActionsIndexRoute: AuthedActionsIndexRoute,
   AuthedAdminIndexRoute: AuthedAdminIndexRoute,
+  AuthedMyTasksRoute: AuthedMyTasksRoute,
   AuthedApprovalsIndexRoute: AuthedApprovalsIndexRoute,
   AuthedAuditLogIndexRoute: AuthedAuditLogIndexRoute,
   AuthedDashboardIndexRoute: AuthedDashboardIndexRoute,

--- a/frontend/src/routes/_authed/my-tasks.tsx
+++ b/frontend/src/routes/_authed/my-tasks.tsx
@@ -1,22 +1,38 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQueries } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { fetchDecisionList } from '@/api/remediation.functions'
 import { MyTasksPage } from '@/components/features/tasks/MyTasksPage'
+import {
+  bucketsForRoles,
+  BUCKET_FILTERS,
+  type TaskBucketKey,
+} from '@/components/features/tasks/my-tasks-buckets'
 import { useTenantScope } from '@/components/layout/tenant-scope'
 import { baseListSearchSchema } from '@/routes/-list-search'
 
 export const Route = createFileRoute('/_authed/my-tasks')({
   validateSearch: baseListSearchSchema,
   loaderDeps: ({ search }) => search,
-  loader: ({ deps }) =>
-    fetchDecisionList({
-      data: {
-        needsAnalystRecommendation: true,
-        page: deps.page,
-        pageSize: deps.pageSize,
-      },
-    }),
+  beforeLoad: ({ context }) => {
+    const buckets = bucketsForRoles(context.user?.activeRoles ?? [])
+    return { buckets }
+  },
+  loader: async ({ context, deps }) => {
+    const buckets = (context as { buckets: TaskBucketKey[] }).buckets
+    const results = await Promise.all(
+      buckets.map((bucket) =>
+        fetchDecisionList({
+          data: {
+            ...BUCKET_FILTERS[bucket],
+            page: deps.page,
+            pageSize: deps.pageSize,
+          },
+        }).then((data) => [bucket, data] as const),
+      ),
+    )
+    return Object.fromEntries(results) as Record<TaskBucketKey, Awaited<ReturnType<typeof fetchDecisionList>>>
+  },
   component: MyTasksRoute,
 })
 
@@ -24,37 +40,41 @@ function MyTasksRoute() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const initialData = Route.useLoaderData()
+  const { buckets } = Route.useRouteContext()
   const { selectedTenantId } = useTenantScope()
   const [initialTenantId] = useState(selectedTenantId)
   const canUseInitialData = initialTenantId === selectedTenantId
 
-  const query = useQuery({
-    queryKey: ['my-tasks', selectedTenantId, search],
-    queryFn: () =>
-      fetchDecisionList({
-        data: {
-          needsAnalystRecommendation: true,
-          page: search.page,
-          pageSize: search.pageSize,
-        },
-      }),
-    initialData: canUseInitialData ? initialData : undefined,
+  const queries = useQueries({
+    queries: buckets.map((bucket) => ({
+      queryKey: ['my-tasks', bucket, selectedTenantId, search],
+      queryFn: () =>
+        fetchDecisionList({
+          data: {
+            ...BUCKET_FILTERS[bucket],
+            page: search.page,
+            pageSize: search.pageSize,
+          },
+        }),
+      initialData: canUseInitialData ? initialData[bucket] : undefined,
+    })),
   })
 
-  const data = query.data ?? (canUseInitialData ? initialData : undefined)
-  if (!data) {
+  const sections = buckets.flatMap((bucket, index) => {
+    const data = queries[index].data
+    return data ? [{ bucket, data }] : []
+  })
+
+  if (sections.length === 0) {
     return null
   }
 
   return (
     <MyTasksPage
-      data={data}
+      sections={sections}
       onPageChange={(page) => {
         void navigate({
-          search: (prev) => ({
-            ...prev,
-            page,
-          }),
+          search: (prev) => ({ ...prev, page }),
         })
       }}
     />

--- a/frontend/src/routes/_authed/my-tasks.tsx
+++ b/frontend/src/routes/_authed/my-tasks.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchDecisionList } from '@/api/remediation.functions'
+import { MyTasksPage } from '@/components/features/tasks/MyTasksPage'
+import { useTenantScope } from '@/components/layout/tenant-scope'
+import { baseListSearchSchema } from '@/routes/-list-search'
+
+export const Route = createFileRoute('/_authed/my-tasks')({
+  validateSearch: baseListSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: ({ deps }) =>
+    fetchDecisionList({
+      data: {
+        needsAnalystRecommendation: true,
+        page: deps.page,
+        pageSize: deps.pageSize,
+      },
+    }),
+  component: MyTasksRoute,
+})
+
+function MyTasksRoute() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const initialData = Route.useLoaderData()
+  const { selectedTenantId } = useTenantScope()
+  const [initialTenantId] = useState(selectedTenantId)
+  const canUseInitialData = initialTenantId === selectedTenantId
+
+  const query = useQuery({
+    queryKey: ['my-tasks', selectedTenantId, search],
+    queryFn: () =>
+      fetchDecisionList({
+        data: {
+          needsAnalystRecommendation: true,
+          page: search.page,
+          pageSize: search.pageSize,
+        },
+      }),
+    initialData: canUseInitialData ? initialData : undefined,
+  })
+
+  const data = query.data ?? (canUseInitialData ? initialData : undefined)
+  if (!data) {
+    return null
+  }
+
+  return (
+    <MyTasksPage
+      data={data}
+      onPageChange={(page) => {
+        void navigate({
+          search: (prev) => ({
+            ...prev,
+            page,
+          }),
+        })
+      }}
+    />
+  )
+}

--- a/frontend/src/routes/_authed/my-tasks.tsx
+++ b/frontend/src/routes/_authed/my-tasks.tsx
@@ -65,10 +65,6 @@ function MyTasksRoute() {
     return data ? [{ bucket, data }] : []
   })
 
-  if (sections.length === 0) {
-    return null
-  }
-
   return (
     <MyTasksPage
       sections={sections}

--- a/frontend/src/routes/_authed/workbenches/security-analyst/cases.$caseId.tsx
+++ b/frontend/src/routes/_authed/workbenches/security-analyst/cases.$caseId.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchDecisionContext } from '@/api/remediation.functions'
+import { SecurityAnalystWorkbench } from '@/components/features/remediation/SecurityAnalystWorkbench'
+import { useTenantScope } from '@/components/layout/tenant-scope'
+
+export const Route = createFileRoute('/_authed/workbenches/security-analyst/cases/$caseId')({
+  loader: ({ params }) => fetchDecisionContext({ data: { caseId: params.caseId } }),
+  component: SecurityAnalystWorkbenchRoute,
+})
+
+function SecurityAnalystWorkbenchRoute() {
+  const initialData = Route.useLoaderData()
+  const { caseId } = Route.useParams()
+  const { selectedTenantId } = useTenantScope()
+  const [initialTenantId] = useState(selectedTenantId)
+  const canUseInitialData = initialTenantId === selectedTenantId
+  const queryKey = ['security-analyst-workbench', selectedTenantId, caseId] as const
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => fetchDecisionContext({ data: { caseId } }),
+    initialData: canUseInitialData ? initialData : undefined,
+    refetchInterval: (currentQuery) => {
+      const status = currentQuery.state.data?.aiSummary.status
+      return status === 'Queued' || status === 'Generating' ? 8000 : false
+    },
+    refetchIntervalInBackground: false,
+  })
+
+  const data = query.data ?? (canUseInitialData ? initialData : undefined)
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24 text-muted-foreground">
+        Loading analyst workbench...
+      </div>
+    )
+  }
+
+  return <SecurityAnalystWorkbench data={data} caseId={caseId} queryKey={queryKey} />
+}

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -4,10 +4,14 @@ public record DecisionContextDto(
     Guid RemediationCaseId,
     Guid? TenantSoftwareId,
     string SoftwareName,
+    string? SoftwareVendor,
+    string? SoftwareCategory,
+    string? SoftwareDescription,
     Guid? SoftwareOwnerTeamId,
     string? SoftwareOwnerTeamName,
     string SoftwareOwnerAssignmentSource,
     string Criticality,
+    List<DecisionBusinessLabelDto> BusinessLabels,
     DecisionSummaryDto Summary,
     DecisionWorkflowSummaryDto Workflow,
     DecisionWorkflowStateDto WorkflowState,
@@ -16,9 +20,19 @@ public record DecisionContextDto(
     DecisionApprovalResolutionDto? LatestApprovalResolution,
     List<AnalystRecommendationDto> Recommendations,
     List<DecisionVulnDto> TopVulnerabilities,
+    List<DecisionVulnDto> OpenVulnerabilities,
     DecisionRiskDto? RiskScore,
     DecisionSlaDto? Sla,
     DecisionAiSummaryDto AiSummary
+);
+
+public record DecisionBusinessLabelDto(
+    Guid Id,
+    string Name,
+    string? Color,
+    string WeightCategory,
+    double RiskWeight,
+    int AffectedDeviceCount
 );
 
 public record DecisionApprovalResolutionDto(
@@ -139,11 +153,15 @@ public record DecisionVulnDto(
     Guid VulnerabilityDefinitionId,
     string ExternalId,
     string Title,
+    string? Description,
     string VendorSeverity,
     double? VendorScore,
     string? EffectiveSeverity,
     double? EffectiveScore,
     string? CvssVector,
+    DateTimeOffset? FirstSeenAt,
+    int AffectedDeviceCount,
+    int AffectedVersionCount,
     bool KnownExploited,
     bool PublicExploit,
     bool ActiveAlert,

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionListItemDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionListItemDto.cs
@@ -50,5 +50,6 @@ public record RemediationDecisionFilterQuery(
     string? Outcome = null,
     string? ApprovalStatus = null,
     string? DecisionState = null,
-    bool? MissedMaintenanceWindow = null
+    bool? MissedMaintenanceWindow = null,
+    bool? NeedsAnalystRecommendation = null
 );

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionListItemDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionListItemDto.cs
@@ -51,5 +51,7 @@ public record RemediationDecisionFilterQuery(
     string? ApprovalStatus = null,
     string? DecisionState = null,
     bool? MissedMaintenanceWindow = null,
-    bool? NeedsAnalystRecommendation = null
+    bool? NeedsAnalystRecommendation = null,
+    bool? NeedsRemediationDecision = null,
+    bool? NeedsApproval = null
 );

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -320,6 +320,26 @@ public class RemediationDecisionQueryService(
                 }
             }
 
+            if (filter.NeedsRemediationDecision == true)
+            {
+                if (!activeWorkflowsByCase.TryGetValue(rc.Id, out var activeWorkflow)
+                    || activeWorkflow.CurrentStage != RemediationWorkflowStage.RemediationDecision
+                    || decision is not null)
+                {
+                    continue;
+                }
+            }
+
+            if (filter.NeedsApproval == true)
+            {
+                if (!activeWorkflowsByCase.TryGetValue(rc.Id, out var activeWorkflow)
+                    || activeWorkflow.CurrentStage != RemediationWorkflowStage.Approval
+                    || decision?.ApprovalStatus != DecisionApprovalStatus.PendingApproval)
+                {
+                    continue;
+                }
+            }
+
             string? riskBand = null;
             double? riskScore = null;
             if (riskScoresByCaseId.TryGetValue(rc.Id, out var risk))

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -572,7 +572,11 @@ public class RemediationDecisionQueryService(
                 g.First().Vulnerability.CvssVector,
                 FirstSeenAt = g.Min(e => e.FirstObservedAt),
                 AffectedDeviceCount = g.Select(e => e.DeviceId).Distinct().Count(),
-                AffectedVersionCount = g.Select(e => e.MatchedVersion).Distinct().Count(),
+                AffectedVersionCount = g
+                    .Select(e => e.MatchedVersion == null ? null : e.MatchedVersion.Trim().ToLower())
+                    .Where(v => !string.IsNullOrEmpty(v))
+                    .Distinct()
+                    .Count(),
             })
             .ToListAsync(ct);
 

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -397,6 +397,8 @@ public class RemediationDecisionQueryService(
                 c.SoftwareProductId,
                 Name = c.SoftwareProduct.Name,
                 Vendor = c.SoftwareProduct.Vendor,
+                Category = c.SoftwareProduct.Category,
+                ProductDescription = c.SoftwareProduct.Description,
             })
             .FirstOrDefaultAsync(ct);
 
@@ -405,6 +407,14 @@ public class RemediationDecisionQueryService(
 
         var softwareName = ResolveDisplaySoftwareName(caseMeta.Name, null);
         var softwareProductId = caseMeta.SoftwareProductId;
+
+        var tenantSoftwareInsight = await dbContext.TenantSoftwareProductInsights.AsNoTracking()
+            .Where(insight => insight.TenantId == tenantId && insight.SoftwareProductId == softwareProductId)
+            .Select(insight => new { insight.Description })
+            .FirstOrDefaultAsync(ct);
+        var softwareDescription = !string.IsNullOrWhiteSpace(tenantSoftwareInsight?.Description)
+            ? tenantSoftwareInsight.Description
+            : caseMeta.ProductDescription;
 
         var scopedDeviceAssetIds = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
             .Where(e => e.TenantId == tenantId
@@ -455,18 +465,39 @@ public class RemediationDecisionQueryService(
                 .Select(team => team.Name)
                 .Take(5)
                 .ToListAsync(ct);
-        var businessLabelSummary = scopedDeviceAssetIds.Count == 0
+        var businessLabelRows = scopedDeviceAssetIds.Count == 0
             ? []
             : await dbContext.DeviceBusinessLabels.AsNoTracking()
-                .Where(link => scopedDeviceAssetIds.Contains(link.DeviceId))
-                .Select(link => new { link.DeviceId, link.BusinessLabel.Name })
+                .Where(link => scopedDeviceAssetIds.Contains(link.DeviceId) && link.BusinessLabel.IsActive)
+                .Select(link => new
+                {
+                    link.DeviceId,
+                    link.BusinessLabel.Id,
+                    link.BusinessLabel.Name,
+                    link.BusinessLabel.Color,
+                    link.BusinessLabel.WeightCategory,
+                })
                 .Distinct()
-                .GroupBy(item => item.Name)
-                .OrderByDescending(group => group.Count())
-                .ThenBy(group => group.Key)
-                .Select(group => $"{group.Key} ({group.Count()})")
-                .Take(3)
                 .ToListAsync(ct);
+        var businessLabelDtos = businessLabelRows
+            .GroupBy(item => new { item.Id, item.Name, item.Color, item.WeightCategory })
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key.Name)
+            .Select(group => new DecisionBusinessLabelDto(
+                group.Key.Id,
+                group.Key.Name,
+                group.Key.Color,
+                group.Key.WeightCategory.ToString(),
+                (double)BusinessLabel.CategoryWeights[group.Key.WeightCategory],
+                group.Count()
+            ))
+            .ToList();
+        var businessLabelSummary = businessLabelDtos.Count == 0
+            ? []
+            : businessLabelDtos
+                .Take(3)
+                .Select(label => $"{label.Name} ({label.AffectedDeviceCount})")
+                .ToList();
         var patchingTaskCounts = await dbContext.PatchingTasks.AsNoTracking()
             .Where(task => task.TenantId == tenantId && task.RemediationCaseId == remediationCaseId)
             .GroupBy(_ => 1)
@@ -492,10 +523,13 @@ public class RemediationDecisionQueryService(
                 Id = g.Key,
                 g.First().Vulnerability.ExternalId,
                 g.First().Vulnerability.Title,
+                g.First().Vulnerability.Description,
                 VendorSeverity = g.First().Vulnerability.VendorSeverity,
                 VendorScore = g.First().Vulnerability.CvssScore,
                 g.First().Vulnerability.CvssVector,
                 FirstSeenAt = g.Min(e => e.FirstObservedAt),
+                AffectedDeviceCount = g.Select(e => e.DeviceId).Distinct().Count(),
+                AffectedVersionCount = g.Select(e => e.MatchedVersion).Distinct().Count(),
             })
             .ToListAsync(ct);
 
@@ -641,11 +675,15 @@ public class RemediationDecisionQueryService(
                     m.Id,
                     m.ExternalId,
                     m.Title,
+                    m.Description,
                     m.VendorSeverity.ToString(),
                     m.VendorScore.HasValue ? (double?)((double)m.VendorScore.Value) : null,
                     effectiveSeverity,
                     effectiveScore,
                     m.CvssVector,
+                    m.FirstSeenAt,
+                    m.AffectedDeviceCount,
+                    m.AffectedVersionCount,
                     threat?.KnownExploited ?? false,
                     threat?.PublicExploit ?? false,
                     threat?.ActiveAlert ?? false,
@@ -858,10 +896,14 @@ public class RemediationDecisionQueryService(
             remediationCaseId,
             tenantSoftware?.Id,
             softwareName,
+            caseMeta.Vendor,
+            caseMeta.Category,
+            softwareDescription,
             softwareOwnerTeamId,
             softwareOwnerTeamName,
             softwareOwnerAssignmentSource,
             assetCriticality.ToString(),
+            businessLabelDtos,
             summary,
             new DecisionWorkflowSummaryDto(
                 scopedDeviceAssetIds.Count,
@@ -883,6 +925,7 @@ public class RemediationDecisionQueryService(
                 ),
             recommendationDtos,
             topVulns.Take(5).ToList(),
+            topVulns,
             riskDto,
             slaDto,
             aiSummary

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -183,11 +183,24 @@ public class RemediationDecisionQueryService(
             .Where(w => w.TenantId == tenantId
                 && caseIds.Contains(w.RemediationCaseId)
                 && w.Status == RemediationWorkflowStatus.Active)
-            .Select(w => new { w.RemediationCaseId, w.CurrentStage, w.UpdatedAt })
+            .Select(w => new { w.Id, w.RemediationCaseId, w.CurrentStage, w.UpdatedAt })
             .ToListAsync(ct);
-        var activeWorkflowStages = activeWorkflowRows
+        var activeWorkflowsByCase = activeWorkflowRows
             .GroupBy(w => w.RemediationCaseId)
-            .ToDictionary(g => g.Key, g => g.OrderByDescending(w => w.UpdatedAt).First().CurrentStage);
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(w => w.UpdatedAt).First());
+        var activeWorkflowStages = activeWorkflowsByCase
+            .ToDictionary(pair => pair.Key, pair => pair.Value.CurrentStage);
+        var activeWorkflowIds = activeWorkflowsByCase.Values.Select(w => w.Id).ToHashSet();
+        var workflowsWithRecommendations = activeWorkflowIds.Count == 0
+            ? []
+            : await dbContext.AnalystRecommendations.AsNoTracking()
+                .Where(r => r.TenantId == tenantId
+                    && r.RemediationWorkflowId != null
+                    && activeWorkflowIds.Contains(r.RemediationWorkflowId.Value))
+                .Select(r => r.RemediationWorkflowId!.Value)
+                .Distinct()
+                .ToListAsync(ct);
+        var workflowRecommendationSet = workflowsWithRecommendations.ToHashSet();
         var activeWorkflowOwnerTeams = await dbContext.RemediationWorkflows.AsNoTracking()
             .Where(w => w.TenantId == tenantId
                 && caseIds.Contains(w.RemediationCaseId)
@@ -292,6 +305,16 @@ public class RemediationDecisionQueryService(
             {
                 if (decision?.MaintenanceWindowDate is not DateTimeOffset maintenanceWindowDate
                     || maintenanceWindowDate >= DateTimeOffset.UtcNow)
+                {
+                    continue;
+                }
+            }
+
+            if (filter.NeedsAnalystRecommendation == true)
+            {
+                if (!activeWorkflowsByCase.TryGetValue(rc.Id, out var activeWorkflow)
+                    || activeWorkflow.CurrentStage != RemediationWorkflowStage.SecurityAnalysis
+                    || workflowRecommendationSet.Contains(activeWorkflow.Id))
                 {
                     continue;
                 }

--- a/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
@@ -281,6 +281,110 @@ public class RemediationDecisionListTests : IDisposable
         item.WorkflowStage.Should().Be(nameof(RemediationWorkflowStage.SecurityAnalysis));
     }
 
+    [Fact]
+    public async Task ListAsync_WhenNeedsRemediationDecision_ReturnsRemediationDecisionStageCasesWithoutDecision()
+    {
+        // Case at RemediationDecision stage with no decision → matches.
+        var pendingProduct = SoftwareProduct.Create("Contoso", "Awaiting Decision", null);
+        var pendingCase = RemediationCase.Create(_tenantId, pendingProduct.Id);
+        var pendingWorkflow = RemediationWorkflow.Create(_tenantId, pendingCase.Id, Guid.NewGuid());
+        pendingWorkflow.MoveToStage(RemediationWorkflowStage.RemediationDecision);
+
+        // Case at RemediationDecision stage WITH a decision → excluded.
+        var decidedProduct = SoftwareProduct.Create("Contoso", "Already Decided", null);
+        var decidedCase = RemediationCase.Create(_tenantId, decidedProduct.Id);
+        var decidedWorkflow = RemediationWorkflow.Create(_tenantId, decidedCase.Id, Guid.NewGuid());
+        decidedWorkflow.MoveToStage(RemediationWorkflowStage.RemediationDecision);
+        var decidedDecision = RemediationDecision.Create(
+            _tenantId,
+            decidedCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Accepted",
+            _userId
+        );
+
+        // Case at SecurityAnalysis stage → excluded (wrong stage).
+        var earlyProduct = SoftwareProduct.Create("Contoso", "Still Analyzing", null);
+        var earlyCase = RemediationCase.Create(_tenantId, earlyProduct.Id);
+        var earlyWorkflow = RemediationWorkflow.Create(_tenantId, earlyCase.Id, Guid.NewGuid());
+
+        await _dbContext.AddRangeAsync(
+            pendingProduct, pendingCase, pendingWorkflow,
+            decidedProduct, decidedCase, decidedWorkflow, decidedDecision,
+            earlyProduct, earlyCase, earlyWorkflow
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ListAsync(
+            _tenantId,
+            new PatchHound.Api.Models.Decisions.RemediationDecisionFilterQuery(NeedsRemediationDecision: true),
+            new PaginationQuery(),
+            CancellationToken.None
+        );
+
+        var item = result.Items.Should().ContainSingle().Subject;
+        item.RemediationCaseId.Should().Be(pendingCase.Id);
+        item.WorkflowStage.Should().Be(nameof(RemediationWorkflowStage.RemediationDecision));
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenNeedsApproval_ReturnsApprovalStageCasesWithPendingApproval()
+    {
+        // Case at Approval stage with PendingApproval decision → matches.
+        var pendingApprovalProduct = SoftwareProduct.Create("Contoso", "Awaiting Approval", null);
+        var pendingApprovalCase = RemediationCase.Create(_tenantId, pendingApprovalProduct.Id);
+        var pendingApprovalWorkflow = RemediationWorkflow.Create(_tenantId, pendingApprovalCase.Id, Guid.NewGuid());
+        pendingApprovalWorkflow.MoveToStage(RemediationWorkflowStage.RemediationDecision);
+        pendingApprovalWorkflow.MoveToStage(RemediationWorkflowStage.Approval);
+        var pendingApprovalDecision = RemediationDecision.Create(
+            _tenantId,
+            pendingApprovalCase.Id,
+            RemediationOutcome.ApprovedForPatching,
+            "Patch ready",
+            _userId,
+            initialApprovalStatus: DecisionApprovalStatus.PendingApproval
+        );
+
+        // Case at Approval stage with already-approved decision → excluded.
+        var approvedProduct = SoftwareProduct.Create("Contoso", "Already Approved", null);
+        var approvedCase = RemediationCase.Create(_tenantId, approvedProduct.Id);
+        var approvedWorkflow = RemediationWorkflow.Create(_tenantId, approvedCase.Id, Guid.NewGuid());
+        approvedWorkflow.MoveToStage(RemediationWorkflowStage.RemediationDecision);
+        approvedWorkflow.MoveToStage(RemediationWorkflowStage.Approval);
+        var approvedDecision = RemediationDecision.Create(
+            _tenantId,
+            approvedCase.Id,
+            RemediationOutcome.ApprovedForPatching,
+            "Approved",
+            _userId,
+            initialApprovalStatus: DecisionApprovalStatus.Approved
+        );
+
+        // Case at RemediationDecision stage → excluded (wrong stage).
+        var decisionProduct = SoftwareProduct.Create("Contoso", "Still Deciding", null);
+        var decisionCase = RemediationCase.Create(_tenantId, decisionProduct.Id);
+        var decisionWorkflow = RemediationWorkflow.Create(_tenantId, decisionCase.Id, Guid.NewGuid());
+        decisionWorkflow.MoveToStage(RemediationWorkflowStage.RemediationDecision);
+
+        await _dbContext.AddRangeAsync(
+            pendingApprovalProduct, pendingApprovalCase, pendingApprovalWorkflow, pendingApprovalDecision,
+            approvedProduct, approvedCase, approvedWorkflow, approvedDecision,
+            decisionProduct, decisionCase, decisionWorkflow
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ListAsync(
+            _tenantId,
+            new PatchHound.Api.Models.Decisions.RemediationDecisionFilterQuery(NeedsApproval: true),
+            new PaginationQuery(),
+            CancellationToken.None
+        );
+
+        var item = result.Items.Should().ContainSingle().Subject;
+        item.RemediationCaseId.Should().Be(pendingApprovalCase.Id);
+        item.WorkflowStage.Should().Be(nameof(RemediationWorkflowStage.Approval));
+    }
+
     public void Dispose()
     {
         _dbContext.Dispose();

--- a/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
@@ -97,6 +97,109 @@ public class RemediationDecisionListTests : IDisposable
     }
 
     [Fact]
+    public async Task BuildByCaseIdAsync_ReturnsAnalystWorkbenchMetadata()
+    {
+        var sourceSystemId = Guid.NewGuid();
+        var product = SoftwareProduct.Create("Contoso", "Contoso Agent", null);
+        product.UpdateIdentity("Endpoint agent", null, SoftwareNormalizationMethod.Heuristic, SoftwareNormalizationConfidence.High, DateTimeOffset.UtcNow);
+        var insight = TenantSoftwareProductInsight.Create(_tenantId, product.Id);
+        insight.UpdateDescription("Tenant-specific description for analysts.");
+        var tenantSoftware = SoftwareTenantRecord.Create(
+            _tenantId,
+            null,
+            product.Id,
+            DateTimeOffset.UtcNow.AddDays(-10),
+            DateTimeOffset.UtcNow.AddDays(-1)
+        );
+        var remediationCase = RemediationCase.Create(_tenantId, product.Id);
+        var device = Device.Create(_tenantId, sourceSystemId, "device-1", "Device 1", Criticality.High);
+        var label = BusinessLabel.Create(_tenantId, "Revenue", null, "#22c55e", BusinessLabelWeightCategory.Critical);
+        var installedSoftware = InstalledSoftware.Observe(
+            _tenantId,
+            device.Id,
+            product.Id,
+            sourceSystemId,
+            "1.2.3",
+            DateTimeOffset.UtcNow.AddDays(-2)
+        );
+        var vulnerability = Vulnerability.Create(
+            "nvd",
+            "CVE-2026-4242",
+            "Remote code execution",
+            "A remotely exploitable vulnerability.",
+            Severity.Critical,
+            9.8m,
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            DateTimeOffset.UtcNow.AddDays(-30)
+        );
+        var exposure = DeviceVulnerabilityExposure.Observe(
+            _tenantId,
+            device.Id,
+            vulnerability.Id,
+            product.Id,
+            installedSoftware.Id,
+            "1.2.3",
+            ExposureMatchSource.Product,
+            DateTimeOffset.UtcNow.AddDays(-2)
+        );
+        var threat = ThreatAssessment.Create(
+            vulnerability.Id,
+            threatScore: 95m,
+            technicalScore: 98m,
+            exploitLikelihoodScore: 90m,
+            threatActivityScore: 90m,
+            epssScore: 0.42m,
+            knownExploited: true,
+            publicExploit: true,
+            activeAlert: false,
+            hasRansomwareAssociation: false,
+            hasMalwareAssociation: false,
+            factorsJson: "[]",
+            calculationVersion: "test"
+        );
+
+        await _dbContext.AddRangeAsync(
+            product,
+            insight,
+            tenantSoftware,
+            remediationCase,
+            device,
+            label,
+            DeviceBusinessLabel.Create(_tenantId, device.Id, label.Id),
+            installedSoftware,
+            vulnerability,
+            exposure,
+            threat
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.BuildByCaseIdAsync(
+            _tenantId,
+            remediationCase.Id,
+            forceAiSummaryRefresh: false,
+            CancellationToken.None
+        );
+
+        result.Should().NotBeNull();
+        result!.SoftwareVendor.Should().Be("Contoso");
+        result.SoftwareCategory.Should().Be("Endpoint agent");
+        result.SoftwareDescription.Should().Be("Tenant-specific description for analysts.");
+        result.BusinessLabels.Should().ContainSingle().Which.Name.Should().Be("Revenue");
+        result.BusinessLabels.Single().AffectedDeviceCount.Should().Be(1);
+        result.BusinessLabels.Single().WeightCategory.Should().Be(nameof(BusinessLabelWeightCategory.Critical));
+        result.OpenVulnerabilities.Should().ContainSingle();
+        var vuln = result.OpenVulnerabilities.Single();
+        vuln.ExternalId.Should().Be("CVE-2026-4242");
+        vuln.Description.Should().Be("A remotely exploitable vulnerability.");
+        vuln.FirstSeenAt.Should().NotBeNull();
+        vuln.AffectedDeviceCount.Should().Be(1);
+        vuln.AffectedVersionCount.Should().Be(1);
+        vuln.KnownExploited.Should().BeTrue();
+        vuln.PublicExploit.Should().BeTrue();
+        vuln.EpssScore.Should().Be(0.42);
+    }
+
+    [Fact]
     public async Task ListAsync_ReturnsSoftwareOwnerRoutingFields()
     {
         var ownerTeam = Team.Create(_tenantId, "Platform Engineering");

--- a/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
@@ -231,6 +231,56 @@ public class RemediationDecisionListTests : IDisposable
         item.SoftwareOwnerAssignmentSource.Should().Be("Rule");
     }
 
+    [Fact]
+    public async Task ListAsync_WhenNeedsAnalystRecommendation_ReturnsSecurityAnalysisCasesWithoutRecommendations()
+    {
+        var needsRecommendationProduct = SoftwareProduct.Create("Contoso", "Needs Recommendation", null);
+        var needsRecommendationCase = RemediationCase.Create(_tenantId, needsRecommendationProduct.Id);
+        var needsRecommendationWorkflow = RemediationWorkflow.Create(_tenantId, needsRecommendationCase.Id, Guid.NewGuid());
+
+        var alreadyRecommendedProduct = SoftwareProduct.Create("Contoso", "Already Recommended", null);
+        var alreadyRecommendedCase = RemediationCase.Create(_tenantId, alreadyRecommendedProduct.Id);
+        var alreadyRecommendedWorkflow = RemediationWorkflow.Create(_tenantId, alreadyRecommendedCase.Id, Guid.NewGuid());
+        var recommendation = AnalystRecommendation.Create(
+            _tenantId,
+            alreadyRecommendedCase.Id,
+            RemediationOutcome.ApprovedForPatching,
+            "Patch this software.",
+            _userId
+        );
+        recommendation.AttachToWorkflow(alreadyRecommendedWorkflow.Id);
+
+        var decisionStageProduct = SoftwareProduct.Create("Contoso", "Decision Stage", null);
+        var decisionStageCase = RemediationCase.Create(_tenantId, decisionStageProduct.Id);
+        var decisionStageWorkflow = RemediationWorkflow.Create(_tenantId, decisionStageCase.Id, Guid.NewGuid());
+        decisionStageWorkflow.MoveToStage(RemediationWorkflowStage.RemediationDecision);
+
+        await _dbContext.AddRangeAsync(
+            needsRecommendationProduct,
+            needsRecommendationCase,
+            needsRecommendationWorkflow,
+            alreadyRecommendedProduct,
+            alreadyRecommendedCase,
+            alreadyRecommendedWorkflow,
+            recommendation,
+            decisionStageProduct,
+            decisionStageCase,
+            decisionStageWorkflow
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ListAsync(
+            _tenantId,
+            new PatchHound.Api.Models.Decisions.RemediationDecisionFilterQuery(NeedsAnalystRecommendation: true),
+            new PaginationQuery(),
+            CancellationToken.None
+        );
+
+        var item = result.Items.Should().ContainSingle().Subject;
+        item.RemediationCaseId.Should().Be(needsRecommendationCase.Id);
+        item.WorkflowStage.Should().Be(nameof(RemediationWorkflowStage.SecurityAnalysis));
+    }
+
     public void Dispose()
     {
         _dbContext.Dispose();


### PR DESCRIPTION
Closes #62.

## Summary

Adds a focused security analyst workbench for a single remediation case and a role-aware "My Tasks" queue that surfaces the next action each role owns.

### Security analyst workbench
- New route `/workbenches/security-analyst/cases/$caseId`.
- Shows software identity (vendor, name, category, description), workflow stage, SLA / risk badges, business-label metadata, owner/team context, and open-vulnerability count.
- Compact open-vulnerabilities list with a slide-over for essentials (description, CVSS vector, exploit/EPSS signals, first-seen, affected device/version counts).
- AI critical-risk summary surfaces queued / generating / unavailable states cleanly.
- Recommendation form lets the analyst pick a remediation action and save through the existing analysis endpoint.
- Backend extends decision context with software description / vendor / category, structured business-label DTOs (id, name, color, weight category, weight, affected-device count), and richer per-vulnerability fields.

### My Tasks queue
- New route `/my-tasks` always visible in the sidebar.
- `beforeLoad` derives task buckets from the user's active roles:
  - `SecurityAnalyst` → recommendations needed
  - `AssetOwner` → decisions needed
  - `SecurityManager` → approvals pending
  - `GlobalAdmin` → all three
- Loader fans out one fetch per bucket in parallel; the page renders a section per bucket with its own table, count, pagination, and CTA (workbench for recommendations, case page for decisions/approvals).
- Empty state when the user has no relevant roles.
- Backend adds `NeedsRemediationDecision` and `NeedsApproval` filters alongside the existing `NeedsAnalystRecommendation` filter on `RemediationDecisionFilterQuery`.

## Test plan

- [x] Backend: `dotnet test` — 687 / 687 passing. New `RemediationDecisionListTests` cover analyst workbench metadata projection and each of the three task-bucket filters.
- [x] Frontend: `npm test` — 10 / 10 passing. Tests cover bucket-to-role mapping plus rendering for one bucket, multiple buckets, empty bucket, and no-roles cases.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [ ] Manual: as a `SecurityAnalyst`, open `/my-tasks`, click into a recommendation case, save a recommendation, confirm it disappears from the queue.
- [ ] Manual: as an `AssetOwner`, only the "Decision needed" section is visible; CTA navigates to the case page.
- [ ] Manual: as a `GlobalAdmin`, all three sections render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)