### PR TITLE
Build asset owner workbench for remediation decisions

### DIFF
--- a/frontend/src/api/remediation.functions.ts
+++ b/frontend/src/api/remediation.functions.ts
@@ -38,6 +38,7 @@ export const createDecision = createServerFn({ method: 'POST' })
       maintenanceWindowDate: z.string().optional(),
       expiryDate: z.string().optional(),
       reEvaluationDate: z.string().optional(),
+      deadlineMode: z.enum(['forever', 'date']).optional(),
     })
   )
   .handler(async ({ context, data: { caseId, ...body } }) => {

--- a/frontend/src/components/features/remediation/AssetOwnerWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/AssetOwnerWorkbench.test.tsx
@@ -162,8 +162,17 @@ describe('AssetOwnerWorkbench', () => {
 
     expect(screen.queryByText('CVE-2026-4242')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Show vulnerabilities/i }))
+    const toggle = screen.getByRole('button', { name: /Show vulnerabilities/i })
+    const controlledRegionId = toggle.getAttribute('aria-controls')
 
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(controlledRegionId).toBeTruthy()
+    expect(document.getElementById(controlledRegionId!)).not.toBeInTheDocument()
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(document.getElementById(controlledRegionId!)).toBeInTheDocument()
     expect(screen.getByText('CVE-2026-4242')).toBeInTheDocument()
     expect(screen.getByText('Remote code execution')).toBeInTheDocument()
   })

--- a/frontend/src/components/features/remediation/AssetOwnerWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/AssetOwnerWorkbench.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AnchorHTMLAttributes } from 'react'
+import type { DecisionContext } from '@/api/remediation.schemas'
+import { AssetOwnerWorkbench } from './AssetOwnerWorkbench'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('./DecisionForm', () => ({
+  DecisionForm: ({ submitLabel }: { submitLabel: string }) => (
+    <form aria-label="owner decision form">
+      <button type="button">{submitLabel}</button>
+    </form>
+  ),
+}))
+
+const dataFixture: DecisionContext = {
+  remediationCaseId: '11111111-1111-1111-1111-111111111111',
+  tenantSoftwareId: '22222222-2222-2222-2222-222222222222',
+  softwareName: 'Contoso Agent',
+  softwareVendor: 'Contoso',
+  softwareCategory: 'Endpoint agent',
+  softwareDescription: 'Endpoint security agent installed on managed workstations.',
+  softwareOwnerTeamId: '33333333-3333-3333-3333-333333333333',
+  softwareOwnerTeamName: 'Platform Engineering',
+  softwareOwnerAssignmentSource: 'Rule',
+  criticality: 'High',
+  businessLabels: [],
+  summary: {
+    totalVulnerabilities: 1,
+    criticalCount: 1,
+    highCount: 0,
+    mediumCount: 0,
+    lowCount: 0,
+    withKnownExploit: 1,
+    withActiveAlert: 0,
+  },
+  workflow: {
+    affectedDeviceCount: 5,
+    affectedOwnerTeamCount: 1,
+    openPatchingTaskCount: 0,
+    completedPatchingTaskCount: 0,
+    openEpisodeTrend: [],
+  },
+  workflowState: {
+    workflowId: '55555555-5555-5555-5555-555555555555',
+    currentStage: 'RemediationDecision',
+    currentStageLabel: 'Remediation Decision',
+    currentStageDescription: 'Owner team records the remediation decision.',
+    currentActorSummary: 'Asset owner',
+    canActOnCurrentStage: true,
+    currentUserRoles: ['AssetOwner'],
+    currentUserTeams: ['Platform Engineering'],
+    expectedRoles: ['AssetOwner'],
+    expectedTeamName: 'Platform Engineering',
+    isInExpectedTeam: true,
+    isRecurrence: false,
+    hasActiveWorkflow: true,
+    stages: [],
+  },
+  currentDecision: null,
+  previousDecision: null,
+  latestApprovalResolution: {
+    status: 'Rejected',
+    justification: 'The proposed date is too far out.',
+    resolvedAt: '2026-05-03T00:00:00Z',
+    resolvedByDisplayName: 'Sam Security',
+  },
+  recommendations: [
+    {
+      id: '77777777-7777-7777-7777-777777777777',
+      vulnerabilityId: null,
+      recommendedOutcome: 'ApprovedForPatching',
+      rationale: 'Patch this endpoint agent because exploitation is likely.',
+      priorityOverride: 'Critical',
+      analystId: '88888888-8888-8888-8888-888888888888',
+      analystDisplayName: 'Casey Analyst',
+      createdAt: '2026-05-02T01:00:00Z',
+    },
+  ],
+  topVulnerabilities: [],
+  openVulnerabilities: [
+    {
+      vulnerabilityId: '66666666-6666-6666-6666-666666666666',
+      vulnerabilityDefinitionId: '66666666-6666-6666-6666-666666666666',
+      externalId: 'CVE-2026-4242',
+      title: 'Remote code execution',
+      description: 'A remotely exploitable vulnerability.',
+      vendorSeverity: 'Critical',
+      vendorScore: 9.8,
+      effectiveSeverity: 'Critical',
+      effectiveScore: 9.8,
+      cvssVector: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
+      firstSeenAt: '2026-05-01T00:00:00Z',
+      affectedDeviceCount: 5,
+      affectedVersionCount: 1,
+      knownExploited: true,
+      publicExploit: true,
+      activeAlert: false,
+      epssScore: 0.42,
+      episodeRiskScore: null,
+      overrideOutcome: null,
+    },
+  ],
+  riskScore: null,
+  sla: null,
+  aiSummary: {
+    content: null,
+    ownerRecommendation: 'Approve patching in the next maintenance window.',
+    analystAssessment: null,
+    exceptionRecommendation: null,
+    recommendedOutcome: 'ApprovedForPatching',
+    recommendedPriority: 'Critical',
+    status: 'Completed',
+    isStale: false,
+    reviewStatus: null,
+    reviewedAt: null,
+    reviewedByDisplayName: null,
+    generatedAt: '2026-05-02T00:00:00Z',
+    requestedAt: null,
+    completedAt: null,
+    providerType: null,
+    profileName: null,
+    model: null,
+    canGenerate: true,
+    isGenerating: false,
+    lastError: null,
+    unavailableMessage: null,
+  },
+}
+
+describe('AssetOwnerWorkbench', () => {
+  it('promotes analyst recommendation and owner decision before vulnerability details', () => {
+    render(
+      <AssetOwnerWorkbench
+        data={dataFixture}
+        caseId={dataFixture.remediationCaseId}
+        queryKey={['asset-owner-workbench', dataFixture.remediationCaseId]}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: /Contoso Agent/i })).toBeInTheDocument()
+    expect(screen.getByText('Patch this endpoint agent because exploitation is likely.')).toBeInTheDocument()
+    expect(screen.getByText(/Casey Analyst/i)).toBeInTheDocument()
+    expect(screen.getByText(/Critical priority/i)).toBeInTheDocument()
+    expect(screen.getByRole('form', { name: /owner decision form/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Submit owner decision/i })).toBeInTheDocument()
+  })
+
+  it('keeps technical vulnerability details hidden until requested', () => {
+    render(
+      <AssetOwnerWorkbench
+        data={dataFixture}
+        caseId={dataFixture.remediationCaseId}
+        queryKey={['asset-owner-workbench', dataFixture.remediationCaseId]}
+      />,
+    )
+
+    expect(screen.queryByText('CVE-2026-4242')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Show vulnerabilities/i }))
+
+    expect(screen.getByText('CVE-2026-4242')).toBeInTheDocument()
+    expect(screen.getByText('Remote code execution')).toBeInTheDocument()
+  })
+
+  it('shows rejection feedback when a previous approval was returned', () => {
+    render(
+      <AssetOwnerWorkbench
+        data={dataFixture}
+        caseId={dataFixture.remediationCaseId}
+        queryKey={['asset-owner-workbench', dataFixture.remediationCaseId]}
+      />,
+    )
+
+    expect(screen.getByText('The proposed date is too far out.')).toBeInTheDocument()
+    expect(screen.getByText(/Sam Security/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/features/remediation/AssetOwnerWorkbench.tsx
+++ b/frontend/src/components/features/remediation/AssetOwnerWorkbench.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useId, useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Bot, ChevronDown, ChevronUp, ExternalLink, SearchCheck, ShieldAlert, TriangleAlert } from 'lucide-react'
 import type { DecisionContext, DecisionVuln } from '@/api/remediation.schemas'
@@ -23,6 +23,7 @@ type AssetOwnerWorkbenchProps = {
 }
 
 export function AssetOwnerWorkbench({ data, caseId, queryKey }: AssetOwnerWorkbenchProps) {
+  const vulnerabilityDetailsId = useId()
   const [showVulnerabilities, setShowVulnerabilities] = useState(false)
   const recommendation = data.recommendations[0] ?? null
   const vulnerabilities = data.openVulnerabilities.length > 0 ? data.openVulnerabilities : data.topVulnerabilities
@@ -166,6 +167,8 @@ export function AssetOwnerWorkbench({ data, caseId, queryKey }: AssetOwnerWorkbe
           <Button
             type="button"
             variant="outline"
+            aria-controls={vulnerabilityDetailsId}
+            aria-expanded={showVulnerabilities}
             onClick={() => setShowVulnerabilities((value) => !value)}
           >
             {showVulnerabilities ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
@@ -173,7 +176,7 @@ export function AssetOwnerWorkbench({ data, caseId, queryKey }: AssetOwnerWorkbe
           </Button>
         </div>
         {showVulnerabilities ? (
-          <div className="overflow-x-auto border-t border-border/70">
+          <div id={vulnerabilityDetailsId} className="overflow-x-auto border-t border-border/70">
             <table className="min-w-[760px] divide-y divide-border/70 text-sm">
               <thead className="bg-muted/35 text-left text-xs uppercase tracking-[0.12em] text-muted-foreground">
                 <tr>

--- a/frontend/src/components/features/remediation/AssetOwnerWorkbench.tsx
+++ b/frontend/src/components/features/remediation/AssetOwnerWorkbench.tsx
@@ -1,0 +1,241 @@
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { Bot, ChevronDown, ChevronUp, ExternalLink, SearchCheck, ShieldAlert, TriangleAlert } from 'lucide-react'
+import type { DecisionContext, DecisionVuln } from '@/api/remediation.schemas'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatDateTime, formatNullableDateTime, startCase } from '@/lib/formatting'
+import { toneBadge } from '@/lib/tone-classes'
+import { cn } from '@/lib/utils'
+import {
+  formatSoftwareOwnerRoutingDetail,
+  outcomeLabel,
+  outcomeTone,
+  severityTone,
+} from './remediation-utils'
+import { DecisionForm } from './DecisionForm'
+
+type AssetOwnerWorkbenchProps = {
+  data: DecisionContext
+  caseId: string
+  queryKey: readonly unknown[]
+}
+
+export function AssetOwnerWorkbench({ data, caseId, queryKey }: AssetOwnerWorkbenchProps) {
+  const [showVulnerabilities, setShowVulnerabilities] = useState(false)
+  const recommendation = data.recommendations[0] ?? null
+  const vulnerabilities = data.openVulnerabilities.length > 0 ? data.openVulnerabilities : data.topVulnerabilities
+  const visibleVulnerabilities = useMemo(() => vulnerabilities.slice(0, 8), [vulnerabilities])
+  const rejection = data.latestApprovalResolution?.status === 'Rejected'
+    ? data.latestApprovalResolution
+    : null
+  const displaySoftwareName = startCase(data.softwareName)
+  const softwareIdentity = data.softwareVendor
+    && !displaySoftwareName.toLowerCase().startsWith(data.softwareVendor.toLowerCase())
+    ? `${data.softwareVendor} ${displaySoftwareName}`
+    : displaySoftwareName
+
+  return (
+    <section className="space-y-5">
+      <header className="rounded-lg border border-border/70 bg-card px-5 py-4">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0 space-y-2">
+            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+              Asset owner workbench
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold leading-tight">{softwareIdentity}</h1>
+              {data.softwareCategory ? <Badge variant="outline">{data.softwareCategory}</Badge> : null}
+              <Badge variant="outline">{data.workflowState.currentStageLabel}</Badge>
+            </div>
+            <p className="max-w-4xl text-sm leading-relaxed text-muted-foreground">
+              {data.softwareDescription
+                ?? 'Review the analyst recommendation, choose the remediation posture, and send the decision into the existing approval workflow.'}
+            </p>
+          </div>
+          <Link
+            to="/remediation/cases/$caseId"
+            params={{ caseId }}
+            className="inline-flex h-9 items-center gap-2 self-start rounded-md border border-border bg-background px-3 text-sm font-medium hover:bg-muted"
+          >
+            Full case
+            <ExternalLink className="size-3.5" />
+          </Link>
+        </div>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <WorkbenchMetric label="Open vulnerabilities" value={data.summary.totalVulnerabilities.toLocaleString()} detail={`${data.summary.criticalCount} critical, ${data.summary.highCount} high`} />
+        <WorkbenchMetric label="Affected devices" value={data.workflow.affectedDeviceCount.toLocaleString()} detail={`${data.workflow.affectedOwnerTeamCount} owner teams`} />
+        <WorkbenchMetric label="Owner routing" value={data.softwareOwnerTeamName ?? 'Default Team'} detail={formatSoftwareOwnerRoutingDetail(data.softwareOwnerTeamName, data.softwareOwnerAssignmentSource)} />
+        <WorkbenchMetric label="SLA" value={data.sla?.slaStatus ?? 'Not set'} detail={data.sla?.dueDate ? `Due ${formatNullableDateTime(data.sla.dueDate)}` : 'No due date'} />
+      </div>
+
+      {rejection ? (
+        <div className="rounded-lg border border-destructive/35 bg-destructive/8 px-4 py-3">
+          <div className="flex items-start gap-3">
+            <TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Previous decision was returned</p>
+              <p className="text-sm text-muted-foreground">{rejection.justification ?? 'No rejection note was provided.'}</p>
+              <p className="text-xs text-muted-foreground">
+                {rejection.resolvedByDisplayName ? `${rejection.resolvedByDisplayName}, ` : ''}
+                {formatNullableDateTime(rejection.resolvedAt)}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(420px,1.05fr)]">
+        <Card className="shadow-none">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <SearchCheck className="size-4 text-primary" />
+              Analyst recommendation
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {recommendation ? (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-xs font-medium', toneBadge(outcomeTone(recommendation.recommendedOutcome)))}>
+                    {outcomeLabel(recommendation.recommendedOutcome)}
+                  </span>
+                  {recommendation.priorityOverride ? (
+                    <span className="text-xs text-muted-foreground">{recommendation.priorityOverride} priority</span>
+                  ) : null}
+                </div>
+                <p className="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+                  {recommendation.rationale}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {recommendation.analystDisplayName ? `${recommendation.analystDisplayName}, ` : ''}
+                  {formatDateTime(recommendation.createdAt)}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No analyst recommendation has been captured yet. Use the full case if the workflow should go back to security analysis.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="shadow-none">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldAlert className="size-4 text-primary" />
+              Owner decision
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DecisionForm
+              caseId={caseId}
+              queryKey={queryKey}
+              initialOutcome={recommendation?.recommendedOutcome ?? data.aiSummary.recommendedOutcome}
+              submitLabel="Submit owner decision"
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      {data.aiSummary.ownerRecommendation ? (
+        <Card className="shadow-none">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bot className="size-4 text-primary" />
+              AI owner guidance
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm leading-relaxed text-muted-foreground">{data.aiSummary.ownerRecommendation}</p>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <section className="rounded-lg border border-border/70 bg-card">
+        <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-base font-semibold">Technical vulnerability details</h2>
+            <p className="text-sm text-muted-foreground">
+              Hidden by default. Open only when you need to inspect the detailed exposure drivers.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setShowVulnerabilities((value) => !value)}
+          >
+            {showVulnerabilities ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+            {showVulnerabilities ? 'Hide vulnerabilities' : 'Show vulnerabilities'}
+          </Button>
+        </div>
+        {showVulnerabilities ? (
+          <div className="overflow-x-auto border-t border-border/70">
+            <table className="min-w-[760px] divide-y divide-border/70 text-sm">
+              <thead className="bg-muted/35 text-left text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3">Vulnerability</th>
+                  <th className="px-4 py-3">Severity</th>
+                  <th className="px-4 py-3">Threats</th>
+                  <th className="px-4 py-3">Scope</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {visibleVulnerabilities.map((vulnerability) => (
+                  <VulnerabilityRow key={vulnerability.vulnerabilityId} vulnerability={vulnerability} />
+                ))}
+                {visibleVulnerabilities.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">
+                      No open vulnerabilities are linked to this remediation case.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+    </section>
+  )
+}
+
+function WorkbenchMetric({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-card px-4 py-3">
+      <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate text-lg font-semibold">{value}</p>
+      <p className="mt-1 truncate text-xs text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function VulnerabilityRow({ vulnerability }: { vulnerability: DecisionVuln }) {
+  return (
+    <tr className="align-top transition-colors hover:bg-muted/25">
+      <td className="px-4 py-3">
+        <div className="font-medium">{vulnerability.externalId}</div>
+        <div className="line-clamp-1 max-w-xl text-xs text-muted-foreground">{vulnerability.title}</div>
+      </td>
+      <td className="px-4 py-3">
+        <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-xs font-medium', toneBadge(severityTone(vulnerability.effectiveSeverity ?? vulnerability.vendorSeverity)))}>
+          {vulnerability.effectiveSeverity ?? vulnerability.vendorSeverity}
+          {vulnerability.effectiveScore != null ? ` ${vulnerability.effectiveScore.toFixed(1)}` : ''}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-xs text-muted-foreground">
+        {[
+          vulnerability.knownExploited ? 'KEV' : null,
+          vulnerability.publicExploit ? 'Exploit' : null,
+          vulnerability.activeAlert ? 'Alert' : null,
+        ].filter(Boolean).join(', ') || 'None'}
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {vulnerability.affectedDeviceCount.toLocaleString()} devices
+      </td>
+    </tr>
+  )
+}

--- a/frontend/src/components/features/remediation/DecisionForm.tsx
+++ b/frontend/src/components/features/remediation/DecisionForm.tsx
@@ -66,8 +66,9 @@ export function DecisionForm({
   const [outcome, setOutcome] = useState(initialOutcome ?? '')
   const [justification, setJustification] = useState(initialJustification ?? '')
   const [expiryDate, setExpiryDate] = useState(toDateInputValue(initialExpiryDate))
-  const [expiryMode, setExpiryMode] = useState<'permanent' | 'expires'>('permanent')
+  const [expiryMode, setExpiryMode] = useState<'forever' | 'date'>('forever')
   const [reEvaluationDate, setReEvaluationDate] = useState(toDateInputValue(initialReEvaluationDate))
+  const [deferralMode, setDeferralMode] = useState<'forever' | 'date'>('forever')
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -80,6 +81,8 @@ export function DecisionForm({
     setJustification(initialJustification ?? '')
     setExpiryDate(toDateInputValue(initialExpiryDate))
     setReEvaluationDate(toDateInputValue(initialReEvaluationDate))
+    setExpiryMode(initialExpiryDate ? 'date' : 'forever')
+    setDeferralMode(initialReEvaluationDate ? 'date' : 'forever')
   }, [initialOutcome, initialJustification, initialMaintenanceWindowDate, initialExpiryDate, initialReEvaluationDate])
 
   useEffect(() => {
@@ -91,26 +94,35 @@ export function DecisionForm({
     setJustification(decisionSeed.justification ?? initialJustification ?? '')
     setExpiryDate(toDateInputValue(decisionSeed.expiryDate ?? initialExpiryDate))
     setReEvaluationDate(toDateInputValue(decisionSeed.reEvaluationDate ?? initialReEvaluationDate))
-    setExpiryMode(decisionSeed.expiryDate || initialExpiryDate ? 'expires' : 'permanent')
+    setExpiryMode(decisionSeed.expiryDate || initialExpiryDate ? 'date' : 'forever')
+    setDeferralMode(decisionSeed.reEvaluationDate || initialReEvaluationDate ? 'date' : 'forever')
   }, [decisionSeed?.token, decisionSeed, initialExpiryDate, initialJustification, initialMaintenanceWindowDate, initialOutcome, initialReEvaluationDate])
 
   useEffect(() => {
     if (!needsExpiry) {
-      setExpiryMode('permanent')
+      setExpiryMode('forever')
       setExpiryDate('')
     }
   }, [needsExpiry])
 
   useEffect(() => {
     if (needsExpiry) {
-      setExpiryMode(initialExpiryDate ? 'expires' : 'permanent')
+      setExpiryMode(initialExpiryDate ? 'date' : 'forever')
     }
   }, [initialExpiryDate, needsExpiry])
+
+  useEffect(() => {
+    if (!needsReEvaluation) {
+      setDeferralMode('forever')
+      setReEvaluationDate('')
+    }
+  }, [needsReEvaluation])
 
   const canSubmit =
     outcome !== '' &&
     (!needsJustification || justification.trim().length > 0) &&
-    (!needsReEvaluation || reEvaluationDate !== '')
+    (!needsExpiry || expiryMode === 'forever' || expiryDate !== '') &&
+    (!needsReEvaluation || deferralMode === 'forever' || reEvaluationDate !== '')
 
   async function handleSubmit() {
     if (!canSubmit) return
@@ -123,16 +135,18 @@ export function DecisionForm({
           outcome,
           justification: justification || undefined,
           maintenanceWindowDate: undefined,
-          expiryDate: needsExpiry && expiryMode === 'expires' ? toIsoDateBoundary(expiryDate) : undefined,
-          reEvaluationDate: toIsoDateBoundary(reEvaluationDate),
+          expiryDate: needsExpiry && expiryMode === 'date' ? toIsoDateBoundary(expiryDate) : undefined,
+          reEvaluationDate: needsReEvaluation && deferralMode === 'date' ? toIsoDateBoundary(reEvaluationDate) : undefined,
+          deadlineMode: needsExpiry ? expiryMode : needsReEvaluation ? deferralMode : undefined,
         },
       })
       await queryClient.invalidateQueries({ queryKey })
       setOutcome('')
       setJustification('')
       setExpiryDate('')
-      setExpiryMode('permanent')
+      setExpiryMode('forever')
       setReEvaluationDate('')
+      setDeferralMode('forever')
     } catch (error) {
       setSubmitError(getApiErrorMessage(error, 'Unable to save the remediation decision.'))
     } finally {
@@ -183,27 +197,27 @@ export function DecisionForm({
           <div className="flex flex-wrap gap-2">
             <Button
               type="button"
-              variant={expiryMode === 'permanent' ? 'default' : 'outline'}
+              variant={expiryMode === 'forever' ? 'default' : 'outline'}
               size="sm"
               disabled={readOnly}
               onClick={() => {
-                setExpiryMode('permanent')
+                setExpiryMode('forever')
                 setExpiryDate('')
               }}
             >
-              Permanent or until cancelled
+              Forever / no fixed deadline
             </Button>
             <Button
               type="button"
-              variant={expiryMode === 'expires' ? 'default' : 'outline'}
+              variant={expiryMode === 'date' ? 'default' : 'outline'}
               size="sm"
               disabled={readOnly}
-              onClick={() => setExpiryMode('expires')}
+              onClick={() => setExpiryMode('date')}
             >
               Expires on date
             </Button>
           </div>
-          {expiryMode === 'expires' ? (
+          {expiryMode === 'date' ? (
             <Input
               type="date"
               value={expiryDate}
@@ -219,17 +233,40 @@ export function DecisionForm({
 
       {needsReEvaluation ? (
         <div className="space-y-2">
-          <label className="text-sm font-medium">
-            Deferral review date <span className="text-tone-danger-foreground">*</span>
-          </label>
-          <Input
-            type="date"
-            value={reEvaluationDate}
-            onChange={(e) => setReEvaluationDate(e.target.value)}
-            disabled={readOnly}
-          />
+          <label className="text-sm font-medium">Deferral review</label>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant={deferralMode === 'forever' ? 'default' : 'outline'}
+              size="sm"
+              disabled={readOnly}
+              onClick={() => {
+                setDeferralMode('forever')
+                setReEvaluationDate('')
+              }}
+            >
+              Forever / no fixed deadline
+            </Button>
+            <Button
+              type="button"
+              variant={deferralMode === 'date' ? 'default' : 'outline'}
+              size="sm"
+              disabled={readOnly}
+              onClick={() => setDeferralMode('date')}
+            >
+              Review on date
+            </Button>
+          </div>
+          {deferralMode === 'date' ? (
+            <Input
+              type="date"
+              value={reEvaluationDate}
+              onChange={(e) => setReEvaluationDate(e.target.value)}
+              disabled={readOnly}
+            />
+          ) : null}
           <p className="text-xs text-muted-foreground">
-            When this deferred patch decision must be revisited.
+            Choose no fixed deadline or set the date this deferred patch decision must be revisited.
           </p>
         </div>
       ) : null}

--- a/frontend/src/components/features/tasks/MyTasksPage.test.tsx
+++ b/frontend/src/components/features/tasks/MyTasksPage.test.tsx
@@ -83,7 +83,10 @@ describe('MyTasksPage', () => {
     expect(screen.getByRole('heading', { name: /Decision needed/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Approval needed/i })).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /Open workbench/i }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /Open case/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /Open decision workbench/i })[0]).toHaveAttribute(
+      'href',
+      '/workbenches/asset-owner/cases/$caseId',
+    )
     expect(screen.getAllByRole('link', { name: /Review approval/i }).length).toBeGreaterThan(0)
   })
 

--- a/frontend/src/components/features/tasks/MyTasksPage.tsx
+++ b/frontend/src/components/features/tasks/MyTasksPage.tsx
@@ -157,7 +157,7 @@ function BucketSection({
                       </Link>
                     ) : (
                       <Link
-                        to="/remediation/cases/$caseId"
+                        to="/workbenches/asset-owner/cases/$caseId"
                         params={{ caseId: item.remediationCaseId }}
                         className="inline-flex h-7 items-center justify-center rounded-lg bg-primary px-2.5 text-[0.8rem] font-medium text-primary-foreground transition-colors hover:bg-primary/80"
                       >

--- a/frontend/src/components/features/tasks/my-tasks-buckets.ts
+++ b/frontend/src/components/features/tasks/my-tasks-buckets.ts
@@ -15,7 +15,7 @@ export const BUCKET_LABELS: Record<TaskBucketKey, { title: string; description: 
   decision: {
     title: 'Decision needed',
     description: 'Cases where the owning team needs to choose a remediation outcome.',
-    cta: 'Open case',
+    cta: 'Open decision workbench',
   },
   approval: {
     title: 'Approval needed',

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AuthLoginRouteImport } from './routes/auth/login'
 import { Route as AuthCallbackRouteImport } from './routes/auth/callback'
 import { Route as ApiIngestionRunEventsRouteImport } from './routes/api/ingestion-run-events'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
+import { Route as AuthedMyTasksRouteImport } from './routes/_authed/my-tasks'
 import { Route as AuthedVulnerabilitiesIndexRouteImport } from './routes/_authed/vulnerabilities/index'
 import { Route as AuthedSoftwareIndexRouteImport } from './routes/_authed/software/index'
 import { Route as AuthedRemediationIndexRouteImport } from './routes/_authed/remediation/index'
@@ -25,7 +26,6 @@ import { Route as AuthedDashboardIndexRouteImport } from './routes/_authed/dashb
 import { Route as AuthedAuditLogIndexRouteImport } from './routes/_authed/audit-log/index'
 import { Route as AuthedApprovalsIndexRouteImport } from './routes/_authed/approvals/index'
 import { Route as AuthedAdminIndexRouteImport } from './routes/_authed/admin/index'
-import { Route as AuthedMyTasksRouteImport } from './routes/_authed/my-tasks'
 import { Route as AuthedActionsIndexRouteImport } from './routes/_authed/actions/index'
 import { Route as ApiInternalEventsRouteImport } from './routes/api/internal/events'
 import { Route as AuthedVulnerabilitiesChangesRouteImport } from './routes/_authed/vulnerabilities/changes'
@@ -53,7 +53,6 @@ import { Route as AuthedAdminIntegrationsIndexRouteImport } from './routes/_auth
 import { Route as AuthedAdminDeviceRulesIndexRouteImport } from './routes/_authed/admin/device-rules/index'
 import { Route as AuthedRemediationTaskIdRouteImport } from './routes/_authed/remediation/task.$id'
 import { Route as AuthedRemediationCasesCaseIdRouteImport } from './routes/_authed/remediation/cases.$caseId'
-import { Route as AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport } from './routes/_authed/workbenches/security-analyst/cases.$caseId'
 import { Route as AuthedDashboardMyAssetsAttentionRouteImport } from './routes/_authed/dashboard/my-assets.attention'
 import { Route as AuthedAssetsApplicationsIdRouteImport } from './routes/_authed/assets/applications/$id'
 import { Route as AuthedAdminWorkflowsNewRouteImport } from './routes/_authed/admin/workflows/new'
@@ -71,6 +70,8 @@ import { Route as AuthedAdminPlatformAdvancedToolsRouteImport } from './routes/_
 import { Route as AuthedAdminDeviceRulesNewRouteImport } from './routes/_authed/admin/device-rules/new'
 import { Route as AuthedAdminDeviceRulesIdRouteImport } from './routes/_authed/admin/device-rules/$id'
 import { Route as AuthedAdminPlatformAccessIndexRouteImport } from './routes/_authed/admin/platform/access/index'
+import { Route as AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport } from './routes/_authed/workbenches/security-analyst/cases.$caseId'
+import { Route as AuthedWorkbenchesAssetOwnerCasesCaseIdRouteImport } from './routes/_authed/workbenches/asset-owner/cases.$caseId'
 import { Route as AuthedAdminPlatformAccessUserIdRouteImport } from './routes/_authed/admin/platform/access/$userId'
 
 const AuthedRoute = AuthedRouteImport.update({
@@ -112,6 +113,11 @@ const ApiEventsRoute = ApiEventsRouteImport.update({
   path: '/api/events',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthedMyTasksRoute = AuthedMyTasksRouteImport.update({
+  id: '/my-tasks',
+  path: '/my-tasks',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedVulnerabilitiesIndexRoute =
   AuthedVulnerabilitiesIndexRouteImport.update({
     id: '/vulnerabilities/',
@@ -151,11 +157,6 @@ const AuthedApprovalsIndexRoute = AuthedApprovalsIndexRouteImport.update({
 const AuthedAdminIndexRoute = AuthedAdminIndexRouteImport.update({
   id: '/admin/',
   path: '/admin/',
-  getParentRoute: () => AuthedRoute,
-} as any)
-const AuthedMyTasksRoute = AuthedMyTasksRouteImport.update({
-  id: '/my-tasks',
-  path: '/my-tasks',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedActionsIndexRoute = AuthedActionsIndexRouteImport.update({
@@ -305,12 +306,6 @@ const AuthedRemediationCasesCaseIdRoute =
     path: '/remediation/cases/$caseId',
     getParentRoute: () => AuthedRoute,
   } as any)
-const AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute =
-  AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport.update({
-    id: '/workbenches/security-analyst/cases/$caseId',
-    path: '/workbenches/security-analyst/cases/$caseId',
-    getParentRoute: () => AuthedRoute,
-  } as any)
 const AuthedDashboardMyAssetsAttentionRoute =
   AuthedDashboardMyAssetsAttentionRouteImport.update({
     id: '/attention',
@@ -408,6 +403,18 @@ const AuthedAdminPlatformAccessIndexRoute =
     path: '/admin/platform/access/',
     getParentRoute: () => AuthedRoute,
   } as any)
+const AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute =
+  AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport.update({
+    id: '/workbenches/security-analyst/cases/$caseId',
+    path: '/workbenches/security-analyst/cases/$caseId',
+    getParentRoute: () => AuthedRoute,
+  } as any)
+const AuthedWorkbenchesAssetOwnerCasesCaseIdRoute =
+  AuthedWorkbenchesAssetOwnerCasesCaseIdRouteImport.update({
+    id: '/workbenches/asset-owner/cases/$caseId',
+    path: '/workbenches/asset-owner/cases/$caseId',
+    getParentRoute: () => AuthedRoute,
+  } as any)
 const AuthedAdminPlatformAccessUserIdRoute =
   AuthedAdminPlatformAccessUserIdRouteImport.update({
     id: '/admin/platform/access/$userId',
@@ -417,6 +424,7 @@ const AuthedAdminPlatformAccessUserIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/my-tasks': typeof AuthedMyTasksRoute
   '/api/events': typeof ApiEventsRoute
   '/api/ingestion-run-events': typeof ApiIngestionRunEventsRoute
   '/auth/callback': typeof AuthCallbackRoute
@@ -441,7 +449,6 @@ export interface FileRoutesByFullPath {
   '/vulnerabilities/$id': typeof AuthedVulnerabilitiesIdRoute
   '/vulnerabilities/changes': typeof AuthedVulnerabilitiesChangesRoute
   '/api/internal/events': typeof ApiInternalEventsRoute
-  '/my-tasks': typeof AuthedMyTasksRoute
   '/actions/': typeof AuthedActionsIndexRoute
   '/admin/': typeof AuthedAdminIndexRoute
   '/approvals/': typeof AuthedApprovalsIndexRoute
@@ -469,7 +476,6 @@ export interface FileRoutesByFullPath {
   '/dashboard/my-assets/attention': typeof AuthedDashboardMyAssetsAttentionRoute
   '/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
-  '/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/admin/device-rules/': typeof AuthedAdminDeviceRulesIndexRoute
   '/admin/integrations/': typeof AuthedAdminIntegrationsIndexRoute
   '/admin/teams/': typeof AuthedAdminTeamsIndexRoute
@@ -477,10 +483,13 @@ export interface FileRoutesByFullPath {
   '/admin/workflows/': typeof AuthedAdminWorkflowsIndexRoute
   '/assets/applications/': typeof AuthedAssetsApplicationsIndexRoute
   '/admin/platform/access/$userId': typeof AuthedAdminPlatformAccessUserIdRoute
+  '/workbenches/asset-owner/cases/$caseId': typeof AuthedWorkbenchesAssetOwnerCasesCaseIdRoute
+  '/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/admin/platform/access/': typeof AuthedAdminPlatformAccessIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/my-tasks': typeof AuthedMyTasksRoute
   '/api/events': typeof ApiEventsRoute
   '/api/ingestion-run-events': typeof ApiIngestionRunEventsRoute
   '/auth/callback': typeof AuthCallbackRoute
@@ -505,7 +514,6 @@ export interface FileRoutesByTo {
   '/vulnerabilities/$id': typeof AuthedVulnerabilitiesIdRoute
   '/vulnerabilities/changes': typeof AuthedVulnerabilitiesChangesRoute
   '/api/internal/events': typeof ApiInternalEventsRoute
-  '/my-tasks': typeof AuthedMyTasksRoute
   '/actions': typeof AuthedActionsIndexRoute
   '/admin': typeof AuthedAdminIndexRoute
   '/approvals': typeof AuthedApprovalsIndexRoute
@@ -533,7 +541,6 @@ export interface FileRoutesByTo {
   '/dashboard/my-assets/attention': typeof AuthedDashboardMyAssetsAttentionRoute
   '/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
-  '/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/admin/device-rules': typeof AuthedAdminDeviceRulesIndexRoute
   '/admin/integrations': typeof AuthedAdminIntegrationsIndexRoute
   '/admin/teams': typeof AuthedAdminTeamsIndexRoute
@@ -541,12 +548,15 @@ export interface FileRoutesByTo {
   '/admin/workflows': typeof AuthedAdminWorkflowsIndexRoute
   '/assets/applications': typeof AuthedAssetsApplicationsIndexRoute
   '/admin/platform/access/$userId': typeof AuthedAdminPlatformAccessUserIdRoute
+  '/workbenches/asset-owner/cases/$caseId': typeof AuthedWorkbenchesAssetOwnerCasesCaseIdRoute
+  '/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/admin/platform/access': typeof AuthedAdminPlatformAccessIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authed': typeof AuthedRouteWithChildren
+  '/_authed/my-tasks': typeof AuthedMyTasksRoute
   '/api/events': typeof ApiEventsRoute
   '/api/ingestion-run-events': typeof ApiIngestionRunEventsRoute
   '/auth/callback': typeof AuthCallbackRoute
@@ -571,7 +581,6 @@ export interface FileRoutesById {
   '/_authed/vulnerabilities/$id': typeof AuthedVulnerabilitiesIdRoute
   '/_authed/vulnerabilities/changes': typeof AuthedVulnerabilitiesChangesRoute
   '/api/internal/events': typeof ApiInternalEventsRoute
-  '/_authed/my-tasks': typeof AuthedMyTasksRoute
   '/_authed/actions/': typeof AuthedActionsIndexRoute
   '/_authed/admin/': typeof AuthedAdminIndexRoute
   '/_authed/approvals/': typeof AuthedApprovalsIndexRoute
@@ -599,7 +608,6 @@ export interface FileRoutesById {
   '/_authed/dashboard/my-assets/attention': typeof AuthedDashboardMyAssetsAttentionRoute
   '/_authed/remediation/cases/$caseId': typeof AuthedRemediationCasesCaseIdRoute
   '/_authed/remediation/task/$id': typeof AuthedRemediationTaskIdRoute
-  '/_authed/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/_authed/admin/device-rules/': typeof AuthedAdminDeviceRulesIndexRoute
   '/_authed/admin/integrations/': typeof AuthedAdminIntegrationsIndexRoute
   '/_authed/admin/teams/': typeof AuthedAdminTeamsIndexRoute
@@ -607,12 +615,15 @@ export interface FileRoutesById {
   '/_authed/admin/workflows/': typeof AuthedAdminWorkflowsIndexRoute
   '/_authed/assets/applications/': typeof AuthedAssetsApplicationsIndexRoute
   '/_authed/admin/platform/access/$userId': typeof AuthedAdminPlatformAccessUserIdRoute
+  '/_authed/workbenches/asset-owner/cases/$caseId': typeof AuthedWorkbenchesAssetOwnerCasesCaseIdRoute
+  '/_authed/workbenches/security-analyst/cases/$caseId': typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   '/_authed/admin/platform/access/': typeof AuthedAdminPlatformAccessIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/my-tasks'
     | '/api/events'
     | '/api/ingestion-run-events'
     | '/auth/callback'
@@ -637,7 +648,6 @@ export interface FileRouteTypes {
     | '/vulnerabilities/$id'
     | '/vulnerabilities/changes'
     | '/api/internal/events'
-    | '/my-tasks'
     | '/actions/'
     | '/admin/'
     | '/approvals/'
@@ -665,7 +675,6 @@ export interface FileRouteTypes {
     | '/dashboard/my-assets/attention'
     | '/remediation/cases/$caseId'
     | '/remediation/task/$id'
-    | '/workbenches/security-analyst/cases/$caseId'
     | '/admin/device-rules/'
     | '/admin/integrations/'
     | '/admin/teams/'
@@ -673,10 +682,13 @@ export interface FileRouteTypes {
     | '/admin/workflows/'
     | '/assets/applications/'
     | '/admin/platform/access/$userId'
+    | '/workbenches/asset-owner/cases/$caseId'
+    | '/workbenches/security-analyst/cases/$caseId'
     | '/admin/platform/access/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/my-tasks'
     | '/api/events'
     | '/api/ingestion-run-events'
     | '/auth/callback'
@@ -701,7 +713,6 @@ export interface FileRouteTypes {
     | '/vulnerabilities/$id'
     | '/vulnerabilities/changes'
     | '/api/internal/events'
-    | '/my-tasks'
     | '/actions'
     | '/admin'
     | '/approvals'
@@ -729,7 +740,6 @@ export interface FileRouteTypes {
     | '/dashboard/my-assets/attention'
     | '/remediation/cases/$caseId'
     | '/remediation/task/$id'
-    | '/workbenches/security-analyst/cases/$caseId'
     | '/admin/device-rules'
     | '/admin/integrations'
     | '/admin/teams'
@@ -737,11 +747,14 @@ export interface FileRouteTypes {
     | '/admin/workflows'
     | '/assets/applications'
     | '/admin/platform/access/$userId'
+    | '/workbenches/asset-owner/cases/$caseId'
+    | '/workbenches/security-analyst/cases/$caseId'
     | '/admin/platform/access'
   id:
     | '__root__'
     | '/'
     | '/_authed'
+    | '/_authed/my-tasks'
     | '/api/events'
     | '/api/ingestion-run-events'
     | '/auth/callback'
@@ -766,7 +779,6 @@ export interface FileRouteTypes {
     | '/_authed/vulnerabilities/$id'
     | '/_authed/vulnerabilities/changes'
     | '/api/internal/events'
-    | '/_authed/my-tasks'
     | '/_authed/actions/'
     | '/_authed/admin/'
     | '/_authed/approvals/'
@@ -794,7 +806,6 @@ export interface FileRouteTypes {
     | '/_authed/dashboard/my-assets/attention'
     | '/_authed/remediation/cases/$caseId'
     | '/_authed/remediation/task/$id'
-    | '/_authed/workbenches/security-analyst/cases/$caseId'
     | '/_authed/admin/device-rules/'
     | '/_authed/admin/integrations/'
     | '/_authed/admin/teams/'
@@ -802,6 +813,8 @@ export interface FileRouteTypes {
     | '/_authed/admin/workflows/'
     | '/_authed/assets/applications/'
     | '/_authed/admin/platform/access/$userId'
+    | '/_authed/workbenches/asset-owner/cases/$caseId'
+    | '/_authed/workbenches/security-analyst/cases/$caseId'
     | '/_authed/admin/platform/access/'
   fileRoutesById: FileRoutesById
 }
@@ -875,6 +888,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiEventsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authed/my-tasks': {
+      id: '/_authed/my-tasks'
+      path: '/my-tasks'
+      fullPath: '/my-tasks'
+      preLoaderRoute: typeof AuthedMyTasksRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/vulnerabilities/': {
       id: '/_authed/vulnerabilities/'
       path: '/vulnerabilities'
@@ -936,13 +956,6 @@ declare module '@tanstack/react-router' {
       path: '/actions'
       fullPath: '/actions/'
       preLoaderRoute: typeof AuthedActionsIndexRouteImport
-      parentRoute: typeof AuthedRoute
-    }
-    '/_authed/my-tasks': {
-      id: '/_authed/my-tasks'
-      path: '/my-tasks'
-      fullPath: '/my-tasks'
-      preLoaderRoute: typeof AuthedMyTasksRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/api/internal/events': {
@@ -1127,13 +1140,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedRemediationCasesCaseIdRouteImport
       parentRoute: typeof AuthedRoute
     }
-    '/_authed/workbenches/security-analyst/cases/$caseId': {
-      id: '/_authed/workbenches/security-analyst/cases/$caseId'
-      path: '/workbenches/security-analyst/cases/$caseId'
-      fullPath: '/workbenches/security-analyst/cases/$caseId'
-      preLoaderRoute: typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport
-      parentRoute: typeof AuthedRoute
-    }
     '/_authed/dashboard/my-assets/attention': {
       id: '/_authed/dashboard/my-assets/attention'
       path: '/attention'
@@ -1253,6 +1259,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAdminPlatformAccessIndexRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/workbenches/security-analyst/cases/$caseId': {
+      id: '/_authed/workbenches/security-analyst/cases/$caseId'
+      path: '/workbenches/security-analyst/cases/$caseId'
+      fullPath: '/workbenches/security-analyst/cases/$caseId'
+      preLoaderRoute: typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/workbenches/asset-owner/cases/$caseId': {
+      id: '/_authed/workbenches/asset-owner/cases/$caseId'
+      path: '/workbenches/asset-owner/cases/$caseId'
+      fullPath: '/workbenches/asset-owner/cases/$caseId'
+      preLoaderRoute: typeof AuthedWorkbenchesAssetOwnerCasesCaseIdRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/admin/platform/access/$userId': {
       id: '/_authed/admin/platform/access/$userId'
       path: '/admin/platform/access/$userId'
@@ -1279,6 +1299,7 @@ const AuthedDashboardMyAssetsRouteWithChildren =
   )
 
 interface AuthedRouteChildren {
+  AuthedMyTasksRoute: typeof AuthedMyTasksRoute
   AuthedAdminAdvancedToolsRoute: typeof AuthedAdminAdvancedToolsRoute
   AuthedAdminAuthenticatedScansRoute: typeof AuthedAdminAuthenticatedScansRoute
   AuthedAdminBusinessLabelsRoute: typeof AuthedAdminBusinessLabelsRoute
@@ -1298,7 +1319,6 @@ interface AuthedRouteChildren {
   AuthedVulnerabilitiesChangesRoute: typeof AuthedVulnerabilitiesChangesRoute
   AuthedActionsIndexRoute: typeof AuthedActionsIndexRoute
   AuthedAdminIndexRoute: typeof AuthedAdminIndexRoute
-  AuthedMyTasksRoute: typeof AuthedMyTasksRoute
   AuthedApprovalsIndexRoute: typeof AuthedApprovalsIndexRoute
   AuthedAuditLogIndexRoute: typeof AuthedAuditLogIndexRoute
   AuthedDashboardIndexRoute: typeof AuthedDashboardIndexRoute
@@ -1323,7 +1343,6 @@ interface AuthedRouteChildren {
   AuthedAssetsApplicationsIdRoute: typeof AuthedAssetsApplicationsIdRoute
   AuthedRemediationCasesCaseIdRoute: typeof AuthedRemediationCasesCaseIdRoute
   AuthedRemediationTaskIdRoute: typeof AuthedRemediationTaskIdRoute
-  AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute: typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   AuthedAdminDeviceRulesIndexRoute: typeof AuthedAdminDeviceRulesIndexRoute
   AuthedAdminIntegrationsIndexRoute: typeof AuthedAdminIntegrationsIndexRoute
   AuthedAdminTeamsIndexRoute: typeof AuthedAdminTeamsIndexRoute
@@ -1331,10 +1350,13 @@ interface AuthedRouteChildren {
   AuthedAdminWorkflowsIndexRoute: typeof AuthedAdminWorkflowsIndexRoute
   AuthedAssetsApplicationsIndexRoute: typeof AuthedAssetsApplicationsIndexRoute
   AuthedAdminPlatformAccessUserIdRoute: typeof AuthedAdminPlatformAccessUserIdRoute
+  AuthedWorkbenchesAssetOwnerCasesCaseIdRoute: typeof AuthedWorkbenchesAssetOwnerCasesCaseIdRoute
+  AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute: typeof AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute
   AuthedAdminPlatformAccessIndexRoute: typeof AuthedAdminPlatformAccessIndexRoute
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
+  AuthedMyTasksRoute: AuthedMyTasksRoute,
   AuthedAdminAdvancedToolsRoute: AuthedAdminAdvancedToolsRoute,
   AuthedAdminAuthenticatedScansRoute: AuthedAdminAuthenticatedScansRoute,
   AuthedAdminBusinessLabelsRoute: AuthedAdminBusinessLabelsRoute,
@@ -1354,7 +1376,6 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedVulnerabilitiesChangesRoute: AuthedVulnerabilitiesChangesRoute,
   AuthedActionsIndexRoute: AuthedActionsIndexRoute,
   AuthedAdminIndexRoute: AuthedAdminIndexRoute,
-  AuthedMyTasksRoute: AuthedMyTasksRoute,
   AuthedApprovalsIndexRoute: AuthedApprovalsIndexRoute,
   AuthedAuditLogIndexRoute: AuthedAuditLogIndexRoute,
   AuthedDashboardIndexRoute: AuthedDashboardIndexRoute,
@@ -1380,8 +1401,6 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAssetsApplicationsIdRoute: AuthedAssetsApplicationsIdRoute,
   AuthedRemediationCasesCaseIdRoute: AuthedRemediationCasesCaseIdRoute,
   AuthedRemediationTaskIdRoute: AuthedRemediationTaskIdRoute,
-  AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute:
-    AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute,
   AuthedAdminDeviceRulesIndexRoute: AuthedAdminDeviceRulesIndexRoute,
   AuthedAdminIntegrationsIndexRoute: AuthedAdminIntegrationsIndexRoute,
   AuthedAdminTeamsIndexRoute: AuthedAdminTeamsIndexRoute,
@@ -1389,6 +1408,10 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAdminWorkflowsIndexRoute: AuthedAdminWorkflowsIndexRoute,
   AuthedAssetsApplicationsIndexRoute: AuthedAssetsApplicationsIndexRoute,
   AuthedAdminPlatformAccessUserIdRoute: AuthedAdminPlatformAccessUserIdRoute,
+  AuthedWorkbenchesAssetOwnerCasesCaseIdRoute:
+    AuthedWorkbenchesAssetOwnerCasesCaseIdRoute,
+  AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute:
+    AuthedWorkbenchesSecurityAnalystCasesCaseIdRoute,
   AuthedAdminPlatformAccessIndexRoute: AuthedAdminPlatformAccessIndexRoute,
 }
 

--- a/frontend/src/routes/_authed/workbenches/asset-owner/cases.$caseId.tsx
+++ b/frontend/src/routes/_authed/workbenches/asset-owner/cases.$caseId.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchDecisionContext } from '@/api/remediation.functions'
+import { AssetOwnerWorkbench } from '@/components/features/remediation/AssetOwnerWorkbench'
+import { useTenantScope } from '@/components/layout/tenant-scope'
+
+export const Route = createFileRoute('/_authed/workbenches/asset-owner/cases/$caseId')({
+  loader: ({ params }) => fetchDecisionContext({ data: { caseId: params.caseId } }),
+  component: AssetOwnerWorkbenchRoute,
+})
+
+function AssetOwnerWorkbenchRoute() {
+  const initialData = Route.useLoaderData()
+  const { caseId } = Route.useParams()
+  const { selectedTenantId } = useTenantScope()
+  const [initialTenantId] = useState(selectedTenantId)
+  const canUseInitialData = initialTenantId === selectedTenantId
+  const queryKey = ['asset-owner-workbench', selectedTenantId, caseId] as const
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => fetchDecisionContext({ data: { caseId } }),
+    initialData: canUseInitialData ? initialData : undefined,
+    refetchInterval: (currentQuery) => {
+      const status = currentQuery.state.data?.aiSummary.status
+      return status === 'Queued' || status === 'Generating' ? 8000 : false
+    },
+    refetchIntervalInBackground: false,
+  })
+
+  const data = query.data ?? (canUseInitialData ? initialData : undefined)
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24 text-muted-foreground">
+        Loading asset owner workbench...
+      </div>
+    )
+  }
+
+  return <AssetOwnerWorkbench data={data} caseId={caseId} queryKey={queryKey} />
+}

--- a/frontend/src/routes/api/ingestion-run-events.ts
+++ b/frontend/src/routes/api/ingestion-run-events.ts
@@ -23,7 +23,7 @@ type IngestionRunProgressDto = {
   lastCheckpointCommittedAt: string | null
 }
 
-export const Route = createFileRoute('/api/ingestion-run-events' as never)({
+export const Route = createFileRoute('/api/ingestion-run-events')({
   server: {
     handlers: {
       GET: async ({ request }) => {

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -258,7 +258,8 @@ public class RemediationDecisionsController(
         RemediationDecisionDeadlineMode? deadlineMode = null;
         if (!string.IsNullOrWhiteSpace(request.DeadlineMode))
         {
-            if (!Enum.TryParse<RemediationDecisionDeadlineMode>(request.DeadlineMode, true, out var parsedDeadlineMode))
+            if (!Enum.TryParse<RemediationDecisionDeadlineMode>(request.DeadlineMode, true, out var parsedDeadlineMode)
+                || !IsSupportedDeadlineMode(parsedDeadlineMode))
                 return BadRequest(new ProblemDetails { Title = "Invalid deadline mode value." });
 
             deadlineMode = parsedDeadlineMode;
@@ -290,6 +291,9 @@ public class RemediationDecisionsController(
             []
         ));
     }
+
+    private static bool IsSupportedDeadlineMode(RemediationDecisionDeadlineMode deadlineMode) =>
+        deadlineMode is RemediationDecisionDeadlineMode.Forever or RemediationDecisionDeadlineMode.Date;
 
     [HttpPost("approval")]
     [Authorize(Policy = Policies.ResolveApprovalTask)]

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -255,6 +255,14 @@ public class RemediationDecisionsController(
 
         if (!Enum.TryParse<RemediationOutcome>(request.Outcome, true, out var outcome))
             return BadRequest(new ProblemDetails { Title = "Invalid outcome value." });
+        RemediationDecisionDeadlineMode? deadlineMode = null;
+        if (!string.IsNullOrWhiteSpace(request.DeadlineMode))
+        {
+            if (!Enum.TryParse<RemediationDecisionDeadlineMode>(request.DeadlineMode, true, out var parsedDeadlineMode))
+                return BadRequest(new ProblemDetails { Title = "Invalid deadline mode value." });
+
+            deadlineMode = parsedDeadlineMode;
+        }
 
         var result = await decisionService.CreateDecisionForCaseAsync(
             tenantId,
@@ -265,7 +273,8 @@ public class RemediationDecisionsController(
             request.ExpiryDate,
             request.ReEvaluationDate,
             ct,
-            request.MaintenanceWindowDate
+            request.MaintenanceWindowDate,
+            deadlineMode
         );
 
         if (!result.IsSuccess)

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -190,7 +190,8 @@ public record CreateDecisionRequest(
     string? Justification,
     DateTimeOffset? MaintenanceWindowDate,
     DateTimeOffset? ExpiryDate,
-    DateTimeOffset? ReEvaluationDate
+    DateTimeOffset? ReEvaluationDate,
+    string? DeadlineMode
 );
 
 public record CreateOverrideRequest(

--- a/src/PatchHound.Api/PatchHound.Api.csproj
+++ b/src/PatchHound.Api/PatchHound.Api.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.8.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PatchHound.Api/PatchHound.Api.csproj
+++ b/src/PatchHound.Api/PatchHound.Api.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PatchHound.Core/Entities/ApprovalTask.cs
+++ b/src/PatchHound.Core/Entities/ApprovalTask.cs
@@ -52,8 +52,8 @@ public class ApprovalTask
                     new[] { RoleName.GlobalAdmin, RoleName.TechnicalManager }, false),
 
             RemediationOutcome.PatchingDeferred =>
-                (ApprovalTaskType.PatchingDeferred, ApprovalTaskStatus.AutoApproved,
-                    new[] { RoleName.GlobalAdmin, RoleName.TechnicalManager }, false),
+                (ApprovalTaskType.PatchingDeferred, ApprovalTaskStatus.Pending,
+                    new[] { RoleName.GlobalAdmin, RoleName.SecurityManager }, true),
 
             _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unsupported outcome for approval task."),
         };

--- a/src/PatchHound.Core/Entities/RemediationDecision.cs
+++ b/src/PatchHound.Core/Entities/RemediationDecision.cs
@@ -30,6 +30,7 @@ public class RemediationDecision
     [
         RemediationOutcome.RiskAcceptance,
         RemediationOutcome.AlternateMitigation,
+        RemediationOutcome.PatchingDeferred,
     ];
 
     private static readonly RemediationOutcome[] OutcomesRequiringJustification =
@@ -59,9 +60,6 @@ public class RemediationDecision
 
         if (OutcomesRequiringJustification.Contains(outcome) && string.IsNullOrWhiteSpace(justification))
             throw new ArgumentException($"Justification is required for {outcome}.");
-
-        if (outcome == RemediationOutcome.PatchingDeferred && !reEvaluationDate.HasValue)
-            throw new ArgumentException("Re-evaluation date is required for PatchingDeferred.");
 
         var now = DateTimeOffset.UtcNow;
         var requiresApproval = initialApprovalStatus.HasValue

--- a/src/PatchHound.Core/Enums/RemediationDecisionDeadlineMode.cs
+++ b/src/PatchHound.Core/Enums/RemediationDecisionDeadlineMode.cs
@@ -1,0 +1,7 @@
+namespace PatchHound.Core.Enums;
+
+public enum RemediationDecisionDeadlineMode
+{
+    Forever = 1,
+    Date = 2,
+}

--- a/src/PatchHound.Infrastructure/PatchHound.Infrastructure.csproj
+++ b/src/PatchHound.Infrastructure/PatchHound.Infrastructure.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Cronos" Version="0.12.0" />
+    <PackageReference Include="Cronos" Version="0.13.0" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/PatchHound.Infrastructure/PatchHound.Infrastructure.csproj
+++ b/src/PatchHound.Infrastructure/PatchHound.Infrastructure.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Cronos" Version="0.13.0" />
+    <PackageReference Include="Cronos" Version="0.12.0" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
@@ -25,7 +25,8 @@ public class RemediationDecisionService(
         DateTimeOffset? expiryDate,
         DateTimeOffset? reEvaluationDate,
         CancellationToken ct,
-        DateTimeOffset? maintenanceWindowDate = null
+        DateTimeOffset? maintenanceWindowDate = null,
+        RemediationDecisionDeadlineMode? deadlineMode = null
     )
     {
         var caseExists = await dbContext.RemediationCases
@@ -63,6 +64,15 @@ public class RemediationDecisionService(
         var initialApprovalStatus = approvalMode is RemediationWorkflowApprovalMode.SecurityApproval or RemediationWorkflowApprovalMode.TechnicalApproval
             ? DecisionApprovalStatus.PendingApproval
             : DecisionApprovalStatus.Approved;
+        var validation = ValidateDecisionInput(outcome, justification, expiryDate, reEvaluationDate, deadlineMode);
+        if (!validation.IsSuccess)
+            return Result<RemediationDecision>.Failure(validation.Error ?? "Decision input is invalid.");
+
+        if (deadlineMode == RemediationDecisionDeadlineMode.Forever)
+        {
+            expiryDate = null;
+            reEvaluationDate = null;
+        }
 
         var decision = RemediationDecision.Create(
             tenantId,
@@ -157,6 +167,40 @@ public class RemediationDecisionService(
             ? approvalExpiryHours.Value
             : DefaultApprovalExpiryHours;
     }
+
+    private static Result<bool> ValidateDecisionInput(
+        RemediationOutcome outcome,
+        string? justification,
+        DateTimeOffset? expiryDate,
+        DateTimeOffset? reEvaluationDate,
+        RemediationDecisionDeadlineMode? deadlineMode
+    )
+    {
+        if (RequiresJustification(outcome) && string.IsNullOrWhiteSpace(justification))
+            return Result<bool>.Failure($"Justification is required for {outcome}.");
+
+        if (outcome is not (RemediationOutcome.RiskAcceptance or RemediationOutcome.PatchingDeferred))
+            return Result<bool>.Success(true);
+
+        if (!deadlineMode.HasValue)
+            return Result<bool>.Failure("Risk acceptance and patch deferral decisions require a deadline mode.");
+
+        if (deadlineMode == RemediationDecisionDeadlineMode.Date)
+        {
+            if (outcome == RemediationOutcome.RiskAcceptance && !expiryDate.HasValue)
+                return Result<bool>.Failure("Risk acceptance with a date deadline requires an expiry date.");
+
+            if (outcome == RemediationOutcome.PatchingDeferred && !reEvaluationDate.HasValue)
+                return Result<bool>.Failure("Patch deferral with a date deadline requires a review date.");
+        }
+
+        return Result<bool>.Success(true);
+    }
+
+    private static bool RequiresJustification(RemediationOutcome outcome) =>
+        outcome is RemediationOutcome.RiskAcceptance
+            or RemediationOutcome.AlternateMitigation
+            or RemediationOutcome.PatchingDeferred;
 
     public async Task<Result<bool>> VerifyAndRequireNewDecisionAsync(
         Guid tenantId,

--- a/src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationDecisionService.cs
@@ -185,6 +185,9 @@ public class RemediationDecisionService(
         if (!deadlineMode.HasValue)
             return Result<bool>.Failure("Risk acceptance and patch deferral decisions require a deadline mode.");
 
+        if (deadlineMode.Value is not (RemediationDecisionDeadlineMode.Forever or RemediationDecisionDeadlineMode.Date))
+            return Result<bool>.Failure("Invalid deadline mode.");
+
         if (deadlineMode == RemediationDecisionDeadlineMode.Date)
         {
             if (outcome == RemediationOutcome.RiskAcceptance && !expiryDate.HasValue)

--- a/src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
+++ b/src/PatchHound.Infrastructure/Services/RemediationWorkflowService.cs
@@ -631,14 +631,12 @@ public class RemediationWorkflowService(PatchHoundDbContext dbContext)
     ) =>
         outcome switch
         {
-            RemediationOutcome.RiskAcceptance or RemediationOutcome.AlternateMitigation =>
+            RemediationOutcome.RiskAcceptance
+                or RemediationOutcome.AlternateMitigation
+                or RemediationOutcome.PatchingDeferred =>
                 RemediationWorkflowApprovalMode.SecurityApproval,
             RemediationOutcome.ApprovedForPatching =>
                 RemediationWorkflowApprovalMode.TechnicalApproval,
-            RemediationOutcome.PatchingDeferred when priority == RemediationWorkflowPriority.Emergency =>
-                RemediationWorkflowApprovalMode.TechnicalApproval,
-            RemediationOutcome.PatchingDeferred =>
-                RemediationWorkflowApprovalMode.TechnicalAutoApproved,
             _ => RemediationWorkflowApprovalMode.None,
         };
 

--- a/src/PatchHound.Puppy/PatchHound.Puppy.csproj
+++ b/src/PatchHound.Puppy/PatchHound.Puppy.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
-    <PackageReference Include="YamlDotNet" Version="17.0.1" />
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="runner.yaml" CopyToOutputDirectory="PreserveNewest" />

--- a/src/PatchHound.Puppy/PatchHound.Puppy.csproj
+++ b/src/PatchHound.Puppy/PatchHound.Puppy.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
-    <PackageReference Include="YamlDotNet" Version="17.1.0" />
+    <PackageReference Include="YamlDotNet" Version="17.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="runner.yaml" CopyToOutputDirectory="PreserveNewest" />

--- a/src/PatchHound.Worker/PatchHound.Worker.csproj
+++ b/src/PatchHound.Worker/PatchHound.Worker.csproj
@@ -6,10 +6,10 @@
     <InternalsVisibleTo Include="PatchHound.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cronos" Version="0.13.0" />
+    <PackageReference Include="Cronos" Version="0.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.8.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />

--- a/src/PatchHound.Worker/PatchHound.Worker.csproj
+++ b/src/PatchHound.Worker/PatchHound.Worker.csproj
@@ -6,10 +6,10 @@
     <InternalsVisibleTo Include="PatchHound.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cronos" Version="0.12.0" />
+    <PackageReference Include="Cronos" Version="0.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />

--- a/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
@@ -4,10 +4,13 @@ using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using PatchHound.Api.Controllers;
 using PatchHound.Api.Models.ApprovalTasks;
+using PatchHound.Api.Models.Decisions;
+using PatchHound.Api.Services;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
 using PatchHound.Tests.TestData;
 
 namespace PatchHound.Tests.Api;
@@ -25,6 +28,7 @@ public class RemediationDecisionsControllerTests : IDisposable
         _tenantContext.CurrentTenantId.Returns(_tenantId);
         _tenantContext.CurrentUserId.Returns(_userId);
         _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+        _tenantContext.GetRolesForTenant(_tenantId).Returns([RoleName.GlobalAdmin.ToString()]);
 
         var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -81,18 +85,62 @@ public class RemediationDecisionsControllerTests : IDisposable
             && entry.Justification == "Approved for Saturday window");
     }
 
-    private RemediationDecisionsController CreateController() =>
+    [Fact]
+    public async Task CreateDecision_RejectsNumericDeadlineMode()
+    {
+        var caseId = await SeedActiveDecisionWorkflowAsync();
+        var controller = CreateController(
+            workflowAuthorizationService: new RemediationWorkflowAuthorizationService(_dbContext, _tenantContext)
+        );
+
+        var result = await controller.CreateDecision(
+            caseId,
+            new CreateDecisionRequest(
+                Outcome: RemediationOutcome.RiskAcceptance.ToString(),
+                Justification: "Risk accepted with invalid deadline mode.",
+                MaintenanceWindowDate: null,
+                ExpiryDate: null,
+                ReEvaluationDate: null,
+                DeadlineMode: "999"
+            ),
+            CancellationToken.None
+        );
+
+        var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problem = badRequest.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Title.Should().Be("Invalid deadline mode value.");
+    }
+
+    private RemediationDecisionsController CreateController(
+        RemediationWorkflowAuthorizationService? workflowAuthorizationService = null
+    ) =>
         new(
             queryService: null!,
             decisionService: null!,
             approvalTaskService: null!,
             recommendationService: null!,
-            workflowAuthorizationService: null!,
+            workflowAuthorizationService: workflowAuthorizationService!,
             workflowService: null!,
             remediationAiJobService: null!,
             dbContext: _dbContext,
             tenantContext: _tenantContext
         );
+
+    private async Task<Guid> SeedActiveDecisionWorkflowAsync()
+    {
+        var product = SoftwareProduct.Create("Contoso", "Contoso Agent", null);
+        var remediationCase = RemediationCase.Create(_tenantId, product.Id);
+        var workflow = RemediationWorkflow.Create(
+            _tenantId,
+            remediationCase.Id,
+            Guid.NewGuid(),
+            RemediationWorkflowStage.RemediationDecision
+        );
+
+        await _dbContext.AddRangeAsync(product, remediationCase, workflow);
+        await _dbContext.SaveChangesAsync();
+        return remediationCase.Id;
+    }
 
     public void Dispose() => _dbContext.Dispose();
 }

--- a/tests/PatchHound.Tests/Core/ApprovalTaskTests.cs
+++ b/tests/PatchHound.Tests/Core/ApprovalTaskTests.cs
@@ -41,14 +41,14 @@ public class ApprovalTaskTests
     }
 
     [Fact]
-    public void Create_PatchingDeferred_SetsAutoApproved()
+    public void Create_PatchingDeferred_RoutesToSecurityApproval()
     {
         var task = ApprovalTask.Create(TenantId, CaseId, DecisionId, RemediationOutcome.PatchingDeferred, null, Expiry);
 
         task.Type.Should().Be(ApprovalTaskType.PatchingDeferred);
-        task.Status.Should().Be(ApprovalTaskStatus.AutoApproved);
-        task.RequiresJustification.Should().BeFalse();
-        task.VisibleToRoles.Should().BeEquivalentTo(new[] { RoleName.GlobalAdmin, RoleName.TechnicalManager });
+        task.Status.Should().Be(ApprovalTaskStatus.Pending);
+        task.RequiresJustification.Should().BeTrue();
+        task.VisibleToRoles.Should().BeEquivalentTo(new[] { RoleName.GlobalAdmin, RoleName.SecurityManager });
     }
 
     [Fact]

--- a/tests/PatchHound.Tests/Infrastructure/RemediationDecisionServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/RemediationDecisionServiceTests.cs
@@ -80,6 +80,91 @@ public class RemediationDecisionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateDecisionForCaseAsync_RiskAcceptanceForeverModeAllowsOmittedExpiryDate()
+    {
+        var remediationCase = await SeedCaseAsync();
+
+        var result = await _service.CreateDecisionForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Risk accepted permanently.",
+            _userId,
+            expiryDate: null,
+            reEvaluationDate: null,
+            CancellationToken.None,
+            deadlineMode: RemediationDecisionDeadlineMode.Forever
+        );
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExpiryDate.Should().BeNull();
+        result.Value.ReEvaluationDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateDecisionForCaseAsync_RiskAcceptanceDateModeRequiresExpiryDate()
+    {
+        var remediationCase = await SeedCaseAsync();
+
+        var result = await _service.CreateDecisionForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Risk accepted until a specific date.",
+            _userId,
+            expiryDate: null,
+            reEvaluationDate: null,
+            CancellationToken.None,
+            deadlineMode: RemediationDecisionDeadlineMode.Date
+        );
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("expiry date");
+    }
+
+    [Fact]
+    public async Task CreateDecisionForCaseAsync_PatchingDeferredDateModeRequiresReviewDate()
+    {
+        var remediationCase = await SeedCaseAsync();
+
+        var result = await _service.CreateDecisionForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.PatchingDeferred,
+            "Defer until the next release window.",
+            _userId,
+            expiryDate: null,
+            reEvaluationDate: null,
+            CancellationToken.None,
+            deadlineMode: RemediationDecisionDeadlineMode.Date
+        );
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("review date");
+    }
+
+    [Fact]
+    public async Task CreateDecisionForCaseAsync_RejectsUndefinedDeadlineMode()
+    {
+        var remediationCase = await SeedCaseAsync();
+
+        var result = await _service.CreateDecisionForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Risk accepted with invalid deadline mode.",
+            _userId,
+            expiryDate: null,
+            reEvaluationDate: null,
+            CancellationToken.None,
+            deadlineMode: (RemediationDecisionDeadlineMode)999
+        );
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("deadline mode");
+    }
+
+    [Fact]
     public async Task CreateDecisionForCaseAsync_PatchingDeferredRoutesToSecurityApproval()
     {
         var remediationCase = await SeedCaseAsync();

--- a/tests/PatchHound.Tests/Infrastructure/RemediationDecisionServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/RemediationDecisionServiceTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Services;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Infrastructure;
+
+public class RemediationDecisionServiceTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly ITenantContext _tenantContext;
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly RemediationDecisionService _service;
+
+    public RemediationDecisionServiceTests()
+    {
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.CurrentTenantId.Returns(_tenantId);
+        _tenantContext.CurrentUserId.Returns(_userId);
+        _tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(_tenantContext)
+        );
+
+        var workflowService = new RemediationWorkflowService(_dbContext);
+        var notificationService = Substitute.For<INotificationService>();
+        var patchingTaskService = new PatchingTaskService(
+            _dbContext,
+            new SlaService(),
+            workflowService,
+            notificationService
+        );
+        var approvalTaskService = new ApprovalTaskService(
+            _dbContext,
+            notificationService,
+            Substitute.For<IRealTimeNotifier>(),
+            workflowService,
+            patchingTaskService
+        );
+
+        _service = new RemediationDecisionService(
+            _dbContext,
+            approvalTaskService,
+            workflowService,
+            patchingTaskService
+        );
+    }
+
+    [Fact]
+    public async Task CreateDecisionForCaseAsync_RiskAcceptanceRequiresExplicitDeadlineMode()
+    {
+        var remediationCase = await SeedCaseAsync();
+
+        var result = await _service.CreateDecisionForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.RiskAcceptance,
+            "Risk accepted by asset owner.",
+            _userId,
+            expiryDate: null,
+            reEvaluationDate: null,
+            CancellationToken.None
+        );
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("deadline");
+    }
+
+    [Fact]
+    public async Task CreateDecisionForCaseAsync_PatchingDeferredRoutesToSecurityApproval()
+    {
+        var remediationCase = await SeedCaseAsync();
+
+        var result = await _service.CreateDecisionForCaseAsync(
+            _tenantId,
+            remediationCase.Id,
+            RemediationOutcome.PatchingDeferred,
+            "Defer until the next release window.",
+            _userId,
+            expiryDate: null,
+            reEvaluationDate: DateTimeOffset.UtcNow.AddDays(30),
+            CancellationToken.None,
+            deadlineMode: RemediationDecisionDeadlineMode.Date
+        );
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ApprovalStatus.Should().Be(DecisionApprovalStatus.PendingApproval);
+
+        var workflow = await _dbContext.RemediationWorkflows.SingleAsync();
+        workflow.CurrentStage.Should().Be(RemediationWorkflowStage.Approval);
+        workflow.ApprovalMode.Should().Be(RemediationWorkflowApprovalMode.SecurityApproval);
+    }
+
+    private async Task<RemediationCase> SeedCaseAsync()
+    {
+        var product = SoftwareProduct.Create("Contoso", "Contoso Agent", null);
+        var remediationCase = RemediationCase.Create(_tenantId, product.Id);
+        await _dbContext.AddRangeAsync(product, remediationCase);
+        await _dbContext.SaveChangesAsync();
+        return remediationCase;
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/tests/PatchHound.Tests/PatchHound.Tests.csproj
+++ b/tests/PatchHound.Tests/PatchHound.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/PatchHound.Tests/PatchHound.Tests.csproj
+++ b/tests/PatchHound.Tests/PatchHound.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
Summary:
- add an asset-owner remediation decision workbench and route
- route My Tasks decision items to the new workbench
- require explicit forever/date deadline mode for risk acceptance and patch deferral decisions
- route patch deferrals to Security Manager approval and show rejection feedback in the owner workbench

Verification:
- dotnet test focused RemediationDecisionServiceTests, ApprovalTaskTests, ApprovalTaskServiceTests
- dotnet build PatchHound.slnx
- npm test focused AssetOwnerWorkbench.test.tsx and MyTasksPage.test.tsx
- npm run typecheck
- npm run lint
- npm run build

Closes #63