### PR TITLE
feat(threat-intel): AI-powered threat intelligence in analyst workbench

### DIFF
--- a/frontend/src/api/remediation.functions.ts
+++ b/frontend/src/api/remediation.functions.ts
@@ -8,6 +8,7 @@ import {
   decisionContextSchema,
   pagedDecisionListSchema,
   remediationDecisionSchema,
+  threatIntelSchema,
   vulnerabilityOverrideSchema,
 } from './remediation.schemas'
 import { buildFilterParams } from './utils'
@@ -124,6 +125,14 @@ export const generateRemediationAiSummary = createServerFn({ method: 'POST' })
   .handler(async ({ context, data: { caseId } }) => {
     const data = await apiPost(`/remediation/cases/${caseId}/ai-summary`, context, {})
     return decisionAiSummarySchema.parse(data)
+  })
+
+export const generateThreatIntel = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ caseId: z.string().uuid() }))
+  .handler(async ({ context, data: { caseId } }) => {
+    const data = await apiPost(`/remediation/cases/${caseId}/threat-intel`, context, {})
+    return threatIntelSchema.parse(data)
   })
 
 export const reviewRemediationAiSummary = createServerFn({ method: 'POST' })

--- a/frontend/src/api/remediation.schemas.ts
+++ b/frontend/src/api/remediation.schemas.ts
@@ -160,6 +160,14 @@ export const decisionApprovalResolutionSchema = z.object({
   resolvedByDisplayName: z.string().nullable(),
 })
 
+export const threatIntelSchema = z.object({
+  summary: z.string().nullable(),
+  generatedAt: z.string().nullable(),
+  profileName: z.string().nullable(),
+  canGenerate: z.boolean(),
+  unavailableMessage: z.string().nullable(),
+})
+
 export const decisionContextSchema = z.object({
   remediationCaseId: z.string().uuid(),
   tenantSoftwareId: z.string().uuid().nullable(),
@@ -184,6 +192,7 @@ export const decisionContextSchema = z.object({
   riskScore: decisionRiskSchema.nullable(),
   sla: decisionSlaSchema.nullable(),
   aiSummary: decisionAiSummarySchema,
+  threatIntel: threatIntelSchema,
 })
 
 export const decisionListItemSchema = z.object({
@@ -242,6 +251,7 @@ export type DecisionSla = z.infer<typeof decisionSlaSchema>
 export type DecisionAiSummary = z.infer<typeof decisionAiSummarySchema>
 export type DecisionApprovalResolution = z.infer<typeof decisionApprovalResolutionSchema>
 export type VulnerabilityOverride = z.infer<typeof vulnerabilityOverrideSchema>
+export type ThreatIntel = z.infer<typeof threatIntelSchema>
 export type DecisionListItem = z.infer<typeof decisionListItemSchema>
 export type DecisionListSummary = z.infer<typeof decisionListSummarySchema>
 export type PagedDecisionList = z.infer<typeof pagedDecisionListSchema>

--- a/frontend/src/components/features/remediation/AssetOwnerWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/AssetOwnerWorkbench.test.tsx
@@ -131,6 +131,13 @@ const dataFixture: DecisionContext = {
     lastError: null,
     unavailableMessage: null,
   },
+  threatIntel: {
+    summary: null,
+    generatedAt: null,
+    profileName: null,
+    canGenerate: true,
+    unavailableMessage: null,
+  },
 }
 
 describe('AssetOwnerWorkbench', () => {

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
@@ -131,6 +131,13 @@ const dataFixture: DecisionContext = {
     lastError: null,
     unavailableMessage: null,
   },
+  threatIntel: {
+    summary: null,
+    generatedAt: null,
+    profileName: null,
+    canGenerate: true,
+    unavailableMessage: null,
+  },
 }
 
 function renderWorkbench(data: DecisionContext = dataFixture) {

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
@@ -21,6 +21,17 @@ vi.mock('@/api/work-notes.functions', () => ({
   deleteWorkNote: vi.fn(),
 }))
 
+vi.mock('@/components/layout/tenant-scope', () => ({
+  useTenantScope: () => ({
+    selectedTenantId: 'test-tenant-id',
+    tenants: [],
+    isLoadingTenants: false,
+    setSelectedTenantId: vi.fn(),
+    tenantPendingDeletion: false,
+    clearTenantPendingDeletion: vi.fn(),
+  }),
+}))
+
 vi.mock('@/components/ui/textarea', () => ({
   Textarea: (props: TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
 }))

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('@/api/remediation.functions', () => ({
   addRecommendation: vi.fn(),
-  generateRemediationAiSummary: vi.fn(),
+  generateThreatIntel: vi.fn(),
 }))
 
 vi.mock('@/components/ui/textarea', () => ({

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.test.tsx
@@ -14,6 +14,13 @@ vi.mock('@/api/remediation.functions', () => ({
   generateThreatIntel: vi.fn(),
 }))
 
+vi.mock('@/api/work-notes.functions', () => ({
+  fetchWorkNotes: vi.fn().mockResolvedValue([]),
+  createWorkNote: vi.fn(),
+  updateWorkNote: vi.fn(),
+  deleteWorkNote: vi.fn(),
+}))
+
 vi.mock('@/components/ui/textarea', () => ({
   Textarea: (props: TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
 }))

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
@@ -2,8 +2,8 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { Bot, ExternalLink, LoaderCircle, NotebookPen, Pencil, Save, SearchCheck, ShieldAlert, Sparkles, Trash2, TriangleAlert } from 'lucide-react'
-import type { DecisionContext, DecisionVuln } from '@/api/remediation.schemas'
-import { addRecommendation, generateRemediationAiSummary } from '@/api/remediation.functions'
+import type { DecisionContext, DecisionVuln, ThreatIntel } from '@/api/remediation.schemas'
+import { addRecommendation, generateThreatIntel } from '@/api/remediation.functions'
 import { createWorkNote, deleteWorkNote, fetchWorkNotes, updateWorkNote } from '@/api/work-notes.functions'
 import type { WorkNote } from '@/api/work-notes.schemas'
 import { Button } from '@/components/ui/button'
@@ -52,7 +52,7 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
   const [rationale, setRationale] = useState(currentRecommendation?.rationale ?? data.aiSummary.analystAssessment ?? '')
   const [priorityOverride, setPriorityOverride] = useState(currentRecommendation?.priorityOverride ?? data.aiSummary.recommendedPriority ?? '')
   const [isSaving, setIsSaving] = useState(false)
-  const [isGeneratingAi, setIsGeneratingAi] = useState(false)
+  const [isGeneratingThreatIntel, setIsGeneratingThreatIntel] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const vulnerabilities = data.openVulnerabilities.length > 0 ? data.openVulnerabilities : data.topVulnerabilities
@@ -106,16 +106,16 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
     }
   }
 
-  async function handleGenerateAiSummary() {
-    setIsGeneratingAi(true)
+  async function handleGenerateThreatIntel() {
+    setIsGeneratingThreatIntel(true)
     setError(null)
     try {
-      await generateRemediationAiSummary({ data: { caseId } })
+      await generateThreatIntel({ data: { caseId } })
       await queryClient.invalidateQueries({ queryKey })
     } catch (err) {
-      setError(getApiErrorMessage(err, 'Unable to request AI risk guidance.'))
+      setError(getApiErrorMessage(err, 'Unable to generate threat intel.'))
     } finally {
-      setIsGeneratingAi(false)
+      setIsGeneratingThreatIntel(false)
     }
   }
 
@@ -396,10 +396,10 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
           </CardContent>
         </Card>
 
-        <AiRiskBrief
-          data={data}
-          isGenerating={isGeneratingAi}
-          onGenerate={() => void handleGenerateAiSummary()}
+        <ThreatIntelBrief
+          threatIntel={data.threatIntel}
+          isGenerating={isGeneratingThreatIntel}
+          onGenerate={() => void handleGenerateThreatIntel()}
         />
       </div>
 
@@ -552,66 +552,62 @@ function formatSeverityScore(severity: string, score: number | null | undefined)
   return score == null ? severity : `${severity} ${score.toFixed(1)}`
 }
 
-function AiRiskBrief({
-  data,
+function ThreatIntelBrief({
+  threatIntel,
   isGenerating,
   onGenerate,
 }: {
-  data: DecisionContext
+  threatIntel: ThreatIntel
   isGenerating: boolean
   onGenerate: () => void
 }) {
-  const hasAnalystGuidance = Boolean(data.aiSummary.analystAssessment || data.aiSummary.recommendedOutcome || data.aiSummary.recommendedPriority)
-  const isWorking = data.aiSummary.status === 'Queued' || data.aiSummary.status === 'Generating'
-
   return (
     <Card className="shadow-none">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          {isWorking ? <LoaderCircle className="size-4 animate-spin text-primary" /> : <Bot className="size-4 text-primary" />}
-          AI risk brief
-        </CardTitle>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2">
+            {isGenerating ? <LoaderCircle className="size-4 animate-spin text-primary" /> : <Bot className="size-4 text-primary" />}
+            Threat intelligence
+          </CardTitle>
+          {threatIntel.summary && threatIntel.canGenerate ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onGenerate}
+              disabled={isGenerating}
+              className="text-xs text-muted-foreground"
+            >
+              {isGenerating ? 'Updating...' : 'Update threat intel'}
+            </Button>
+          ) : null}
+        </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        {hasAnalystGuidance ? (
+        {threatIntel.summary ? (
           <>
-            {data.aiSummary.recommendedPriority ? (
-              <div>
-                <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Suggested priority</p>
-                <p className="mt-1 text-sm font-medium">{data.aiSummary.recommendedPriority}</p>
-              </div>
-            ) : null}
-            {data.aiSummary.recommendedOutcome ? (
-              <div>
-                <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Suggested action</p>
-                <p className="mt-1 text-sm font-medium">{outcomeLabel(data.aiSummary.recommendedOutcome)}</p>
-              </div>
-            ) : null}
-            {data.aiSummary.analystAssessment ? (
-              <p className="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
-                {data.aiSummary.analystAssessment}
-              </p>
-            ) : null}
+            <MarkdownViewer content={threatIntel.summary} />
             <p className="text-xs text-muted-foreground">
-              Generated {formatNullableDateTime(data.aiSummary.generatedAt)}
+              Generated {formatNullableDateTime(threatIntel.generatedAt)}
+              {threatIntel.profileName ? ` · ${threatIntel.profileName}` : null}
             </p>
           </>
-        ) : isWorking ? (
+        ) : isGenerating ? (
           <p className="text-sm text-muted-foreground">
-            AI guidance is queued or generating. You can continue the analysis while it runs.
+            Retrieving threat intelligence. This may take a moment.
           </p>
-        ) : data.aiSummary.canGenerate ? (
+        ) : threatIntel.canGenerate ? (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              Ask AI for a concise analyst-oriented summary of the highest-risk open vulnerabilities.
+              Generate a threat intelligence summary for the top vulnerabilities — covering active exploitation, attack vectors, and mitigations.
             </p>
             <Button type="button" variant="outline" onClick={onGenerate} disabled={isGenerating}>
-              {isGenerating ? 'Asking AI...' : 'Ask AI'}
+              Retrieve threat intel
             </Button>
           </div>
         ) : (
           <p className="text-sm text-muted-foreground">
-            {data.aiSummary.unavailableMessage ?? 'AI guidance is not available for this tenant.'}
+            {threatIntel.unavailableMessage ?? 'AI is not configured for this tenant.'}
           </p>
         )}
       </CardContent>

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -443,7 +443,11 @@ public class RemediationDecisionsController(
 
         var result = await threatIntelService.GenerateAsync(tenantId, caseId, ct);
         if (!result.IsSuccess)
+        {
+            if (result.Error == "Remediation case not found.")
+                return NotFound(new ProblemDetails { Title = result.Error });
             return BadRequest(new ProblemDetails { Title = result.Error });
+        }
 
         return Ok(result.Value);
     }

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -25,6 +25,7 @@ public class RemediationDecisionsController(
     RemediationWorkflowAuthorizationService workflowAuthorizationService,
     RemediationWorkflowService workflowService,
     RemediationAiJobService remediationAiJobService,
+    ThreatIntelGenerationService threatIntelService,
     PatchHoundDbContext dbContext,
     ITenantContext tenantContext
 ) : ControllerBase
@@ -422,6 +423,29 @@ public class RemediationDecisionsController(
         }
 
         return Ok(context.AiSummary);
+    }
+
+    [HttpPost("threat-intel")]
+    [Authorize(Policy = Policies.GenerateAiReports)]
+    public async Task<ActionResult<ThreatIntelDto>> GenerateThreatIntel(
+        Guid caseId,
+        CancellationToken ct
+    )
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        if (!await threatIntelService.CanGenerateAsync(tenantId, ct))
+            return BadRequest(new ProblemDetails
+            {
+                Title = "No enabled default AI profile is configured for this tenant."
+            });
+
+        var result = await threatIntelService.GenerateAsync(tenantId, caseId, ct);
+        if (!result.IsSuccess)
+            return BadRequest(new ProblemDetails { Title = result.Error });
+
+        return Ok(result.Value);
     }
 
     [HttpPost("ai-summary/review")]

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -23,7 +23,8 @@ public record DecisionContextDto(
     List<DecisionVulnDto> OpenVulnerabilities,
     DecisionRiskDto? RiskScore,
     DecisionSlaDto? Sla,
-    DecisionAiSummaryDto AiSummary
+    DecisionAiSummaryDto AiSummary,
+    ThreatIntelDto ThreatIntel
 );
 
 public record DecisionBusinessLabelDto(
@@ -63,6 +64,14 @@ public record DecisionAiSummaryDto(
     bool CanGenerate,
     bool IsGenerating,
     string? LastError,
+    string? UnavailableMessage
+);
+
+public record ThreatIntelDto(
+    string? Summary,
+    DateTimeOffset? GeneratedAt,
+    string? ProfileName,
+    bool CanGenerate,
     string? UnavailableMessage
 );
 

--- a/src/PatchHound.Api/Program.cs
+++ b/src/PatchHound.Api/Program.cs
@@ -417,6 +417,7 @@ builder.Services.AddScoped<PatchHound.Api.Services.DashboardQueryService>();
 builder.Services.AddScoped<PatchHound.Api.Services.VulnerabilityDetailQueryService>();
 builder.Services.AddScoped<PatchHound.Api.Services.DeviceDetailQueryService>();
 builder.Services.AddScoped<PatchHound.Api.Services.RemediationDecisionQueryService>();
+builder.Services.AddScoped<PatchHound.Api.Services.ThreatIntelGenerationService>();
 builder.Services.AddScoped<PatchHound.Api.Services.RemediationWorkflowAuthorizationService>();
 builder.Services.AddScoped<PatchHound.Api.Services.BlockedTenantAccessLogger>();
 builder.Services.AddScoped<PatchHound.Api.Services.ApprovalTaskQueryService>();

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -19,6 +19,7 @@ public class RemediationDecisionQueryService(
     PatchHoundDbContext dbContext,
     SlaService slaService,
     TenantAiTextGenerationService aiTextGenerationService,
+    ITenantAiConfigurationResolver aiConfigurationResolver,
     ITenantContext tenantContext
 )
 {
@@ -458,6 +459,9 @@ public class RemediationDecisionQueryService(
                 Vendor = c.SoftwareProduct.Vendor,
                 Category = c.SoftwareProduct.Category,
                 ProductDescription = c.SoftwareProduct.Description,
+                c.ThreatIntelSummary,
+                c.ThreatIntelGeneratedAt,
+                c.ThreatIntelProfileName,
             })
             .FirstOrDefaultAsync(ct);
 
@@ -955,6 +959,17 @@ public class RemediationDecisionQueryService(
 
         var aiSummary = await ResolveAiSummaryAsync(ct);
 
+        var aiProfileAvailable = (await aiConfigurationResolver.ResolveDefaultAsync(tenantId, ct)).IsSuccess;
+        var threatIntel = new ThreatIntelDto(
+            caseMeta.ThreatIntelSummary,
+            caseMeta.ThreatIntelGeneratedAt,
+            caseMeta.ThreatIntelProfileName,
+            CanGenerate: aiProfileAvailable,
+            UnavailableMessage: aiProfileAvailable
+                ? null
+                : "Set up and enable a default AI profile for this tenant to retrieve threat intelligence."
+        );
+
         return new DecisionContextDto(
             remediationCaseId,
             tenantSoftware?.Id,
@@ -991,7 +1006,8 @@ public class RemediationDecisionQueryService(
             topVulns,
             riskDto,
             slaDto,
-            aiSummary
+            aiSummary,
+            threatIntel
         );
     }
 

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -957,9 +957,10 @@ public class RemediationDecisionQueryService(
             decision
         );
 
+        var aiProfileAvailable = (await aiConfigurationResolver.ResolveDefaultAsync(tenantId, ct)).IsSuccess;
+
         var aiSummary = await ResolveAiSummaryAsync(ct);
 
-        var aiProfileAvailable = (await aiConfigurationResolver.ResolveDefaultAsync(tenantId, ct)).IsSuccess;
         var threatIntel = new ThreatIntelDto(
             caseMeta.ThreatIntelSummary,
             caseMeta.ThreatIntelGeneratedAt,

--- a/src/PatchHound.Api/Services/ThreatIntelGenerationService.cs
+++ b/src/PatchHound.Api/Services/ThreatIntelGenerationService.cs
@@ -1,0 +1,118 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Api.Models.Decisions;
+using PatchHound.Core.Common;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Core.Services;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Api.Services;
+
+public class ThreatIntelGenerationService(
+    PatchHoundDbContext dbContext,
+    TenantAiTextGenerationService aiTextGenerationService,
+    ITenantAiConfigurationResolver aiConfigurationResolver
+)
+{
+    private const string SystemPrompt =
+        "You are a security analyst. You will receive a list of CVE vulnerabilities affecting a software product. " +
+        "Use web research to retrieve current threat intelligence data for each vulnerability. " +
+        "Write a concise threat intelligence summary in markdown covering: active exploitation status, " +
+        "attack vectors and techniques (referencing MITRE ATT&CK where applicable), " +
+        "available proof-of-concept or exploit availability, affected versions, " +
+        "relevant threat actor activity, and recommended detection or mitigation strategies. " +
+        "Include direct links to relevant advisories, NVD entries, vendor bulletins, PoC repositories, " +
+        "or threat reports you find. Use clear markdown headings and bullet lists. " +
+        "Do not invent facts — only report what you can verify via web research.";
+
+    public async Task<bool> CanGenerateAsync(Guid tenantId, CancellationToken ct)
+    {
+        var result = await aiConfigurationResolver.ResolveDefaultAsync(tenantId, ct);
+        return result.IsSuccess;
+    }
+
+    public async Task<Result<ThreatIntelDto>> GenerateAsync(
+        Guid tenantId,
+        Guid caseId,
+        CancellationToken ct)
+    {
+        var case_ = await dbContext.RemediationCases
+            .FirstOrDefaultAsync(c => c.TenantId == tenantId && c.Id == caseId, ct);
+        if (case_ is null)
+            return Result<ThreatIntelDto>.Failure("Remediation case not found.");
+
+        var softwareProductId = case_.SoftwareProductId;
+
+        var softwareName = await dbContext.SoftwareProducts.AsNoTracking()
+            .Where(p => p.Id == softwareProductId)
+            .Select(p => $"{p.Vendor} {p.Name}".Trim())
+            .FirstOrDefaultAsync(ct) ?? "Unknown software";
+
+        var topVulns = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+            .Where(e => e.TenantId == tenantId
+                && e.SoftwareProductId == softwareProductId
+                && e.Status == ExposureStatus.Open)
+            .GroupBy(e => new
+            {
+                e.VulnerabilityId,
+                e.Vulnerability.ExternalId,
+                e.Vulnerability.Title,
+                VendorSeverity = e.Vulnerability.VendorSeverity,
+                e.Vulnerability.CvssScore,
+                e.Vulnerability.Description,
+            })
+            .Select(g => new
+            {
+                g.Key.ExternalId,
+                g.Key.Title,
+                g.Key.VendorSeverity,
+                g.Key.CvssScore,
+                g.Key.Description,
+            })
+            .OrderByDescending(v => v.VendorSeverity)
+            .ThenByDescending(v => v.CvssScore)
+            .Take(5)
+            .ToListAsync(ct);
+
+        if (topVulns.Count == 0)
+            return Result<ThreatIntelDto>.Failure("No open vulnerabilities found for this remediation case.");
+
+        var vulnList = new StringBuilder();
+        foreach (var v in topVulns)
+        {
+            vulnList.AppendLine($"- {v.ExternalId} ({v.VendorSeverity}, CVSS {v.CvssScore?.ToString("F1") ?? "N/A"}): {v.Title}");
+            if (!string.IsNullOrWhiteSpace(v.Description))
+                vulnList.AppendLine($"  {v.Description.Trim()}");
+        }
+
+        var userPrompt = $"Software product: {softwareName}\n\nTop vulnerabilities (by severity):\n{vulnList}";
+
+        var request = new AiTextGenerationRequest(
+            SystemPrompt,
+            userPrompt,
+            ExternalContext: null,
+            UseProviderNativeWebResearch: true,
+            MaxResearchSources: 10,
+            IncludeCitations: true
+        );
+
+        var generated = await aiTextGenerationService.GenerateAsync(tenantId, null, request, ct);
+        if (!generated.IsSuccess)
+            return Result<ThreatIntelDto>.Failure(generated.Error ?? "AI generation failed.");
+
+        var result = generated.Value;
+        case_.SetThreatIntel(result.Content, result.ProfileName);
+        await dbContext.SaveChangesAsync(ct);
+
+        return Result<ThreatIntelDto>.Success(new ThreatIntelDto(
+            result.Content,
+            case_.ThreatIntelGeneratedAt,
+            result.ProfileName,
+            CanGenerate: true,
+            UnavailableMessage: null
+        ));
+    }
+}

--- a/src/PatchHound.Api/Services/ThreatIntelGenerationService.cs
+++ b/src/PatchHound.Api/Services/ThreatIntelGenerationService.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Models.Decisions;
 using PatchHound.Core.Common;
@@ -51,26 +50,22 @@ public class ThreatIntelGenerationService(
             .Select(p => $"{p.Vendor} {p.Name}".Trim())
             .FirstOrDefaultAsync(ct) ?? "Unknown software";
 
-        var topVulns = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+        var openVulnIds = dbContext.DeviceVulnerabilityExposures.AsNoTracking()
             .Where(e => e.TenantId == tenantId
                 && e.SoftwareProductId == softwareProductId
                 && e.Status == ExposureStatus.Open)
-            .GroupBy(e => new
+            .Select(e => e.VulnerabilityId)
+            .Distinct();
+
+        var topVulns = await dbContext.Vulnerabilities.AsNoTracking()
+            .Where(v => openVulnIds.Contains(v.Id))
+            .Select(v => new
             {
-                e.VulnerabilityId,
-                e.Vulnerability.ExternalId,
-                e.Vulnerability.Title,
-                VendorSeverity = e.Vulnerability.VendorSeverity,
-                e.Vulnerability.CvssScore,
-                e.Vulnerability.Description,
-            })
-            .Select(g => new
-            {
-                g.Key.ExternalId,
-                g.Key.Title,
-                g.Key.VendorSeverity,
-                g.Key.CvssScore,
-                g.Key.Description,
+                v.ExternalId,
+                v.Title,
+                VendorSeverity = v.VendorSeverity,
+                v.CvssScore,
+                v.Description,
             })
             .OrderByDescending(v => v.VendorSeverity)
             .ThenByDescending(v => v.CvssScore)

--- a/src/PatchHound.Core/Entities/RemediationCase.cs
+++ b/src/PatchHound.Core/Entities/RemediationCase.cs
@@ -12,6 +12,10 @@ public class RemediationCase
     public DateTimeOffset UpdatedAt { get; private set; }
     public DateTimeOffset? ClosedAt { get; private set; }
 
+    public string? ThreatIntelSummary { get; private set; }
+    public DateTimeOffset? ThreatIntelGeneratedAt { get; private set; }
+    public string? ThreatIntelProfileName { get; private set; }
+
     public SoftwareProduct SoftwareProduct { get; private set; } = null!;
 
     private RemediationCase() { }
@@ -42,6 +46,14 @@ public class RemediationCase
         Status = RemediationCaseStatus.Closed;
         ClosedAt = DateTimeOffset.UtcNow;
         UpdatedAt = ClosedAt.Value;
+    }
+
+    public void SetThreatIntel(string summary, string? profileName)
+    {
+        ThreatIntelSummary = summary;
+        ThreatIntelGeneratedAt = DateTimeOffset.UtcNow;
+        ThreatIntelProfileName = profileName;
+        UpdatedAt = ThreatIntelGeneratedAt.Value;
     }
 
     public void Reopen()

--- a/src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RemediationCaseConfiguration.cs
@@ -16,6 +16,7 @@ public class RemediationCaseConfiguration : IEntityTypeConfiguration<Remediation
         builder.Property(c => c.Status).HasConversion<string>().HasMaxLength(32);
         builder.Property(c => c.CreatedAt).IsRequired();
         builder.Property(c => c.UpdatedAt).IsRequired();
+        builder.Property(c => c.ThreatIntelProfileName).HasMaxLength(256);
 
         builder.HasIndex(c => new { c.TenantId, c.SoftwareProductId }).IsUnique();
         builder.HasIndex(c => c.TenantId);

--- a/src/PatchHound.Infrastructure/Migrations/20260507053250_AddThreatIntelToRemediationCase.Designer.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260507053250_AddThreatIntelToRemediationCase.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507053250_AddThreatIntelToRemediationCase")]
+    partial class AddThreatIntelToRemediationCase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Migrations/20260507053250_AddThreatIntelToRemediationCase.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260507053250_AddThreatIntelToRemediationCase.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddThreatIntelToRemediationCase : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ThreatIntelGeneratedAt",
+                table: "RemediationCases",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ThreatIntelProfileName",
+                table: "RemediationCases",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ThreatIntelSummary",
+                table: "RemediationCases",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ThreatIntelGeneratedAt",
+                table: "RemediationCases");
+
+            migrationBuilder.DropColumn(
+                name: "ThreatIntelProfileName",
+                table: "RemediationCases");
+
+            migrationBuilder.DropColumn(
+                name: "ThreatIntelSummary",
+                table: "RemediationCases");
+        }
+    }
+}

--- a/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionListTests.cs
@@ -5,7 +5,9 @@ using PatchHound.Api.Models;
 using PatchHound.Api.Services;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
+using PatchHound.Core.Common;
 using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
 using PatchHound.Core.Services;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
@@ -38,10 +40,14 @@ public class RemediationDecisionListTests : IDisposable
         );
 
         var aiConfigurationResolver = Substitute.For<ITenantAiConfigurationResolver>();
+        aiConfigurationResolver
+            .ResolveDefaultAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result<TenantAiProfileResolved>.Failure("No AI profile configured."));
         _service = new RemediationDecisionQueryService(
             _dbContext,
             new SlaService(),
             new TenantAiTextGenerationService([], aiConfigurationResolver),
+            aiConfigurationResolver,
             _tenantContext
         );
     }

--- a/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
@@ -6,9 +6,12 @@ using PatchHound.Api.Controllers;
 using PatchHound.Api.Models.ApprovalTasks;
 using PatchHound.Api.Models.Decisions;
 using PatchHound.Api.Services;
+using PatchHound.Core.Common;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Core.Services;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Tests.TestData;
@@ -109,6 +112,97 @@ public class RemediationDecisionsControllerTests : IDisposable
         var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
         var problem = badRequest.Value.Should().BeOfType<ProblemDetails>().Subject;
         problem.Title.Should().Be("Invalid deadline mode value.");
+    }
+
+    [Fact]
+    public async Task GenerateThreatIntel_ReturnsBadRequest_WhenNoTenantSelected()
+    {
+        var noTenantContext = Substitute.For<ITenantContext>();
+        noTenantContext.CurrentTenantId.Returns((Guid?)null);
+
+        var controller = new RemediationDecisionsController(
+            queryService: null!,
+            decisionService: null!,
+            approvalTaskService: null!,
+            recommendationService: null!,
+            workflowAuthorizationService: null!,
+            workflowService: null!,
+            remediationAiJobService: null!,
+            threatIntelService: null!,
+            dbContext: _dbContext,
+            tenantContext: noTenantContext
+        );
+
+        var result = await controller.GenerateThreatIntel(Guid.NewGuid(), CancellationToken.None);
+
+        var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().BeOfType<ProblemDetails>().Which.Title.Should().Be("No active tenant is selected.");
+    }
+
+    [Fact]
+    public async Task GenerateThreatIntel_ReturnsBadRequest_WhenNoAiProfileConfigured()
+    {
+        var aiResolver = Substitute.For<ITenantAiConfigurationResolver>();
+        aiResolver.ResolveDefaultAsync(_tenantId, Arg.Any<CancellationToken>())
+            .Returns(Result<TenantAiProfileResolved>.Failure("No profile."));
+
+        var threatIntelService = new ThreatIntelGenerationService(
+            _dbContext,
+            new TenantAiTextGenerationService([], aiResolver),
+            aiResolver
+        );
+
+        var controller = new RemediationDecisionsController(
+            queryService: null!,
+            decisionService: null!,
+            approvalTaskService: null!,
+            recommendationService: null!,
+            workflowAuthorizationService: null!,
+            workflowService: null!,
+            remediationAiJobService: null!,
+            threatIntelService: threatIntelService,
+            dbContext: _dbContext,
+            tenantContext: _tenantContext
+        );
+
+        var result = await controller.GenerateThreatIntel(Guid.NewGuid(), CancellationToken.None);
+
+        var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().BeOfType<ProblemDetails>().Which.Title.Should()
+            .Be("No enabled default AI profile is configured for this tenant.");
+    }
+
+    [Fact]
+    public async Task GenerateThreatIntel_ReturnsNotFound_WhenCaseDoesNotExist()
+    {
+        var aiResolver = Substitute.For<ITenantAiConfigurationResolver>();
+        aiResolver.ResolveDefaultAsync(_tenantId, Arg.Any<CancellationToken>())
+            .Returns(Result<TenantAiProfileResolved>.Success(null!));
+
+        var threatIntelService = new ThreatIntelGenerationService(
+            _dbContext,
+            new TenantAiTextGenerationService([], aiResolver),
+            aiResolver
+        );
+
+        var controller = new RemediationDecisionsController(
+            queryService: null!,
+            decisionService: null!,
+            approvalTaskService: null!,
+            recommendationService: null!,
+            workflowAuthorizationService: null!,
+            workflowService: null!,
+            remediationAiJobService: null!,
+            threatIntelService: threatIntelService,
+            dbContext: _dbContext,
+            tenantContext: _tenantContext
+        );
+
+        var result = await controller.GenerateThreatIntel(Guid.NewGuid(), CancellationToken.None);
+
+        var notFound = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFound.Value.Should().BeOfType<ProblemDetails>().Which.Title.Should()
+            .Be("Remediation case not found.");
     }
 
     private RemediationDecisionsController CreateController(

--- a/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
@@ -122,6 +122,7 @@ public class RemediationDecisionsControllerTests : IDisposable
             workflowAuthorizationService: workflowAuthorizationService!,
             workflowService: null!,
             remediationAiJobService: null!,
+            threatIntelService: null!,
             dbContext: _dbContext,
             tenantContext: _tenantContext
         );


### PR DESCRIPTION
## Summary

- Adds a **Threat Intelligence** card to the Security Analyst Workbench, replacing the broken AI risk brief placeholder
- Clicking **Retrieve threat intel** generates a web-researched summary for the top 5 vulnerabilities by severity — covering active exploitation, attack vectors (MITRE ATT&CK), PoC availability, threat actor activity, and mitigations with direct citations
- Result is stored on the remediation case (`ThreatIntelSummary`) and rendered as markdown; an **Update threat intel** button refreshes it at any time
- Gated on the same `canGenerate` check as other AI features (requires an active AI profile for the tenant)

## Changes

- **Entity**: `ThreatIntelSummary`, `ThreatIntelGeneratedAt`, `ThreatIntelProfileName` fields + `SetThreatIntel()` on `RemediationCase`
- **Migration**: `AddThreatIntelToRemediationCase`
- **Service**: `ThreatIntelGenerationService` — queries top-5 open vulns, calls AI with `UseProviderNativeWebResearch: true`, max 10 sources, citations enabled
- **Endpoint**: `POST /api/remediation/cases/{caseId}/threat-intel` (requires `GenerateAiReports` policy)
- **DTO**: `ThreatIntelDto` added to `DecisionContextDto`; `canGenerate` resolved from default AI profile
- **Frontend**: `threatIntelSchema`, `generateThreatIntel` server fn, `ThreatIntelBrief` component with markdown rendering

## Test plan

- [ ] Tenant with no AI profile configured: card shows unavailable message, no button
- [ ] Tenant with AI profile: card shows **Retrieve threat intel** button
- [ ] Click button: spinner appears, summary renders as markdown with links after generation
- [ ] Re-open workbench: summary persists, **Update threat intel** button visible in card header
- [ ] Click update: summary refreshes with new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)