### PR TITLE
refactor: decompose IngestionService monolith and fix pipeline correctness issues

### DIFF
--- a/docs/superpowers/plans/2026-05-13-ingestion-pipeline-refactor.md
+++ b/docs/superpowers/plans/2026-05-13-ingestion-pipeline-refactor.md
@@ -1,0 +1,1367 @@
+# Ingestion Pipeline Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `IngestionService.cs` (3121 lines) and its collaborators to eliminate magic strings, consolidate in-memory workarounds, split the monolith into focused classes, and fix several correctness bugs — without breaking existing functionality.
+
+**Architecture:** `IngestionService` is decomposed into four focused collaborators (`IngestionLeaseManager`, `IngestionCheckpointWriter`, `IngestionStagingPipeline`, `IngestionSnapshotLifecycle`), reducing it to a pure orchestrator. An `IIngestionBulkWriter` adapter replaces 12 `IsInMemoryProvider()` branches. All checkpoint/status string literals are replaced with typed constants.
+
+**Tech Stack:** .NET 10 / C#, EF Core 9 (PostgreSQL + InMemory), xunit + FluentAssertions + NSubstitute, Testcontainers.PostgreSql
+
+**Branch:** `refactor/ingestion-pipeline`
+
+---
+
+## Progress Tracker
+
+| Phase | Status |
+|-------|--------|
+| Phase 0: Constants | ☐ Not started |
+| Phase 1: Decompose IngestionService | ☐ Not started |
+| Phase 2: Collapse constructors + IIngestionBulkWriter | ☐ Not started |
+| Phase 3: Critical fixes | ☐ Not started |
+| Phase 4: Important fixes | ☐ Not started |
+| Phase 5: Minor fixes | ☐ Not started |
+
+---
+
+## File Map
+
+**Create:**
+- `src/PatchHound.Infrastructure/Services/CheckpointConstants.cs` — `CheckpointPhases` and `CheckpointStatuses` static classes
+- `src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs` — lease acquire/release/abort, run status updates (~350 lines)
+- `src/PatchHound.Infrastructure/Services/IngestionCheckpointWriter.cs` — checkpoint read/commit, artifact cleanup (~150 lines)
+- `src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs` — asset + vulnerability staging, progress tracking (~600 lines)
+- `src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs` — snapshot get-or-create, publish, discard, cleanup (~300 lines)
+- `src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs` — interface for ExecuteUpdate/ExecuteDelete wrappers
+- `src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs` — real implementation using `ExecuteUpdateAsync`/`ExecuteDeleteAsync`
+- `src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs` — in-memory workaround implementation
+- `tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs`
+- `tests/PatchHound.Tests/Infrastructure/Services/IngestionCheckpointWriterTests.cs`
+- `tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs`
+
+**Modify:**
+- `src/PatchHound.Infrastructure/Services/IngestionService.cs` — shrink to orchestrator; collapse constructors; remove dead code
+- `src/PatchHound.Worker/IngestionWorker.cs` — remove duplicate `IsDue`, fix hardcoded `"Failed"` string
+- `src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs` — create real `IngestionRun`, delete staged rows after merge
+- `src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs` — fix N+1 SELECT (device pre-load + installed software pre-load)
+- `src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs` — already bounded; verify
+- `src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs` — add overload accepting primitive fields for IngestionWorker use
+- `src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs` — remove unused `FetchCanonicalVulnerabilitiesAsync`
+- `src/PatchHound.Infrastructure/DependencyInjection.cs` — register new collaborator classes
+
+---
+
+## Phase 0: Extract Checkpoint Constants
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/CheckpointConstants.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+- Modify: `src/PatchHound.Worker/IngestionWorker.cs`
+
+### Task 0.1: Create constants file
+
+- [ ] **Step 1: Create `CheckpointConstants.cs`**
+
+```csharp
+namespace PatchHound.Infrastructure.Services;
+
+internal static class CheckpointPhases
+{
+    public const string AssetStaging = "asset-staging";
+    public const string AssetMerge = "asset-merge";
+    public const string VulnerabilityStaging = "vulnerability-staging";
+    public const string VulnerabilityMerge = "vulnerability-merge";
+    public const string CloudAppStaging = "cloud-app-staging";
+}
+
+internal static class CheckpointStatuses
+{
+    public const string Running = "Running";
+    public const string Staged = "Staged";
+    public const string Completed = "Completed";
+}
+```
+
+- [ ] **Step 2: Replace magic strings in `IngestionService.cs`**
+
+Find all occurrences with: `grep -n '"asset-staging"\|"asset-merge"\|"vulnerability-staging"\|"vulnerability-merge"\|"Completed"\|"Staged"\|"Running"' src/PatchHound.Infrastructure/Services/IngestionService.cs`
+
+Replace each:
+- `"asset-staging"` → `CheckpointPhases.AssetStaging` (lines ~253, ~2546)
+- `"asset-merge"` → `CheckpointPhases.AssetMerge` (lines ~257, ~2597)
+- `"vulnerability-staging"` → `CheckpointPhases.VulnerabilityStaging` (lines ~261, ~1974)
+- `"vulnerability-merge"` → `CheckpointPhases.VulnerabilityMerge` (lines ~265, ~2089)
+- `item.Status == "Completed"` → `item.Status == CheckpointStatuses.Completed` (line ~1800)
+- `status: "Completed"` → `status: CheckpointStatuses.Completed` (all call-sites in CommitCheckpointAsync)
+- `status: "Running"` → `status: CheckpointStatuses.Running`
+- `status: "Staged"` → `status: CheckpointStatuses.Staged`
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+dotnet build PatchHound.slnx
+```
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+dotnet test PatchHound.slnx -v minimal
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/CheckpointConstants.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        src/PatchHound.Worker/IngestionWorker.cs
+git commit -m "refactor: replace checkpoint phase/status magic strings with typed constants"
+```
+
+---
+
+## Phase 1: Decompose IngestionService
+
+**Context:** `IngestionService.cs` is 3121 lines. The goal is to extract four collaborators. `IngestionService` becomes an orchestrator that holds references to these collaborators and calls them. Each collaborator takes `PatchHoundDbContext` directly (already scoped). All four are registered as `AddScoped` in DI.
+
+### Task 1.1: Extract `IngestionLeaseManager`
+
+Lease manager owns: `TryAcquireIngestionRunAsync`, `ReleaseIngestionLeaseAsync`, `FinalizeAbortedRunIfPendingAsync`, `UpdateRuntimeStateAsync`, `UpdateIngestionRunStatusAsync`, `CompleteIngestionRunAsync`, `CleanupExpiredIngestionArtifactsAsync`, `ThrowIfAbortRequestedAsync`.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+
+- [ ] **Step 1: Write a failing test for `IngestionLeaseManager`**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs`:
+
+```csharp
+using FluentAssertions;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class IngestionLeaseManagerTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public IngestionLeaseManagerTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    private IngestionLeaseManager CreateSut() => new(_db);
+
+    [Fact]
+    public async Task TryAcquireIngestionRunAsync_WhenNoActiveRun_ReturnsRun()
+    {
+        var sut = CreateSut();
+        var result = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        result.Should().NotBeNull();
+        result!.Run.TenantId.Should().Be(_tenantId);
+        result.Resumed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireIngestionRunAsync_WhenAlreadyActive_ReturnsNull()
+    {
+        var sut = CreateSut();
+        var first = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        first.Should().NotBeNull();
+
+        var second = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        second.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+dotnet test --filter "FullyQualifiedName~IngestionLeaseManagerTests" -v minimal
+```
+Expected: FAIL — `IngestionLeaseManager` does not exist yet.
+
+- [ ] **Step 3: Create `IngestionLeaseManager.cs`**
+
+Extract the following private methods from `IngestionService.cs` into `IngestionLeaseManager`. The class takes `PatchHoundDbContext` and `ILogger<IngestionLeaseManager>` via constructor.
+
+Methods to move (check exact lines in file before moving):
+- `TryAcquireIngestionRunAsync` (lines ~1096–1270)
+- `ReleaseIngestionLeaseAsync` (lines ~1698–1739)
+- `FinalizeAbortedRunIfPendingAsync` (lines ~1272–1354)
+- `UpdateRuntimeStateAsync` (lines ~965–1055)
+- `UpdateIngestionRunStatusAsync` (lines ~1073–1094)
+- `CompleteIngestionRunAsync` (lines ~1371–1590)
+- `CleanupExpiredIngestionArtifactsAsync` (lines ~1592–1696)
+- `ThrowIfAbortRequestedAsync` (lines ~1356–1369)
+- Private record `AcquiredIngestionRun` (line 41: `sealed record AcquiredIngestionRun(IngestionRun Run, bool Resumed)`)
+- Constants: `LeaseDuration`, `IngestionArtifactRetention`, `FailedIngestionRetention`, `MaxPersistenceAttempts`
+
+Skeleton:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class IngestionLeaseManager(
+    PatchHoundDbContext dbContext,
+    ILogger<IngestionLeaseManager> logger)
+{
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan IngestionArtifactRetention = TimeSpan.FromDays(7);
+    private static readonly TimeSpan FailedIngestionRetention = TimeSpan.FromHours(24);
+    private const int MaxPersistenceAttempts = 2;
+
+    public sealed record AcquiredIngestionRun(IngestionRun Run, bool Resumed);
+
+    // Paste extracted methods here — keep signatures identical to IngestionService private methods
+    // but change access modifier to `public` for methods called by IngestionService orchestrator.
+}
+```
+
+- [ ] **Step 4: Update `IngestionService.cs` to delegate to `IngestionLeaseManager`**
+
+Add `_leaseManager` field:
+```csharp
+private readonly IngestionLeaseManager _leaseManager;
+```
+
+In the canonical constructor (line ~135), add `IngestionLeaseManager leaseManager` parameter and assign `_leaseManager = leaseManager`.
+
+Replace every call to the moved private methods with `_leaseManager.MethodName(...)`.
+
+Remove the moved private methods from `IngestionService.cs`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~IngestionLeaseManagerTests" -v minimal
+dotnet test PatchHound.slnx -v minimal
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs
+git commit -m "refactor: extract IngestionLeaseManager from IngestionService"
+```
+
+---
+
+### Task 1.2: Extract `IngestionCheckpointWriter`
+
+Checkpoint writer owns: `IsCheckpointCompletedAsync`, `GetCheckpointBatchNumberAsync`, `CommitCheckpointAsync`, `ClearStagedDataForRunAsync`.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/IngestionCheckpointWriter.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+
+- [ ] **Step 1: Write a failing test**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/IngestionCheckpointWriterTests.cs`:
+
+```csharp
+using FluentAssertions;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class IngestionCheckpointWriterTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public IngestionCheckpointWriterTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    private IngestionCheckpointWriter CreateSut() => new(_db);
+
+    [Fact]
+    public async Task IsCheckpointCompletedAsync_BeforeCommit_ReturnsFalse()
+    {
+        var sut = CreateSut();
+        var result = await sut.IsCheckpointCompletedAsync(Guid.NewGuid(), CheckpointPhases.AssetStaging, CancellationToken.None);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CommitCheckpointAsync_ThenIsCompleted_ReturnsTrue()
+    {
+        var runId = Guid.NewGuid();
+        var sut = CreateSut();
+        await sut.CommitCheckpointAsync(runId, _tenantId, "defender", CheckpointPhases.AssetStaging, 1, null, 10, CheckpointStatuses.Completed, CancellationToken.None);
+        var result = await sut.IsCheckpointCompletedAsync(runId, CheckpointPhases.AssetStaging, CancellationToken.None);
+        result.Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+dotnet test --filter "FullyQualifiedName~IngestionCheckpointWriterTests" -v minimal
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create `IngestionCheckpointWriter.cs`**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class IngestionCheckpointWriter(PatchHoundDbContext dbContext)
+{
+    public async Task<bool> IsCheckpointCompletedAsync(Guid ingestionRunId, string phase, CancellationToken ct) { ... }
+    public async Task<int> GetCheckpointBatchNumberAsync(Guid ingestionRunId, string phase, CancellationToken ct) { ... }
+    public async Task CommitCheckpointAsync(Guid ingestionRunId, Guid tenantId, string sourceKey, string phase, int batchNumber, string? cursorJson, int recordsCommitted, string status, CancellationToken ct) { ... }
+    public async Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct) { ... }
+}
+```
+
+Paste extracted implementations from `IngestionService.cs` lines ~1788–1860 and ~1741–1786.
+
+- [ ] **Step 4: Update `IngestionService.cs` to delegate**
+
+Add `_checkpointWriter` field + constructor param. Replace calls to these methods with `_checkpointWriter.MethodName(...)`. Remove moved methods.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~IngestionCheckpointWriterTests" -v minimal
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionCheckpointWriter.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/IngestionCheckpointWriterTests.cs
+git commit -m "refactor: extract IngestionCheckpointWriter from IngestionService"
+```
+
+---
+
+### Task 1.3: Extract `IngestionStagingPipeline`
+
+Staging pipeline owns: `StageAssetInventorySnapshotAsync`, `StageAssetBatchesAsync`, `ProcessAssetsAsync` (public internal), `StageVulnerabilitiesAsync`, `StageVulnerabilityBatchesAsync`, `EnqueueEnrichmentJobsForRunAsync`, `NormalizeResults`, `Chunk<T>`.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs`:
+
+```csharp
+using FluentAssertions;
+using NSubstitute;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class IngestionStagingPipelineTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public IngestionStagingPipelineTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    [Fact]
+    public async Task StageVulnerabilitiesAsync_EmptyResults_StagedCountIsZero()
+    {
+        var pipeline = new IngestionStagingPipeline(_db, Substitute.For<EnrichmentJobEnqueuer>());
+        var summary = await pipeline.StageVulnerabilitiesAsync(
+            Guid.NewGuid(), _tenantId, "defender", [], 0, CancellationToken.None);
+        summary.StagedCount.Should().Be(0);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+dotnet test --filter "FullyQualifiedName~IngestionStagingPipelineTests" -v minimal
+```
+
+- [ ] **Step 3: Create `IngestionStagingPipeline.cs`**
+
+Extract from `IngestionService.cs`:
+- `StageVulnerabilitiesAsync` (lines ~1862–1912)
+- `StageVulnerabilityBatchesAsync` (lines ~1914–1994)
+- `StageAssetInventorySnapshotAsync` (lines ~1996–2051)
+- `StageAssetBatchesAsync` (lines ~2446–2565)
+- `ProcessAssetsAsync` (lines ~2402–2444) — keep `internal` modifier
+- `EnqueueEnrichmentJobsForRunAsync` (lines ~2053–2105)
+- `NormalizeResults` (lines ~2859–2875)
+- `Chunk<T>` (lines ~2956–2969)
+- Constants `AssetBatchSize = 200`, `VulnerabilityBatchSize = 250`
+
+Return types for staging methods need to expose the summary records. Move `AssetBatchStageSummary` (line ~927) here as well.
+
+Constructor:
+```csharp
+public class IngestionStagingPipeline(
+    PatchHoundDbContext dbContext,
+    EnrichmentJobEnqueuer enrichmentJobEnqueuer,
+    ILogger<IngestionStagingPipeline> logger)
+```
+
+- [ ] **Step 4: Update `IngestionService.cs` to delegate**
+
+Add `_stagingPipeline` field. Wire constructor param. Replace all calls with `_stagingPipeline.MethodName(...)`. Remove moved methods.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~IngestionStagingPipelineTests" -v minimal
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs
+git commit -m "refactor: extract IngestionStagingPipeline from IngestionService"
+```
+
+---
+
+### Task 1.4: Extract `IngestionSnapshotLifecycle`
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+
+- [ ] **Step 1: Create `IngestionSnapshotLifecycle.cs`**
+
+Extract from `IngestionService.cs`:
+- `SupportsSoftwareSnapshots` (line ~2671–2674) — static method
+- `GetOrCreateBuildingSoftwareSnapshotAsync` (lines ~2676–2723)
+- `PublishSnapshotAsync` (lines ~2724–2764)
+- `DiscardBuildingSnapshotAsync` (lines ~2798–2826)
+- `CleanupSnapshotDataAsync` (lines ~2830–2857)
+- `RekeyTenantSoftwareReferencesAsync` — **do NOT extract**; this is removed in Phase 3
+
+Constructor:
+```csharp
+public class IngestionSnapshotLifecycle(
+    PatchHoundDbContext dbContext,
+    ILogger<IngestionSnapshotLifecycle> logger)
+```
+
+In `PublishSnapshotAsync`, remove the call to `RekeyTenantSoftwareReferencesAsync` (it's dead code; the comment explains why — move the comment inline to the method body).
+
+- [ ] **Step 2: Update `IngestionService.cs` to delegate**
+
+Add `_snapshotLifecycle` field. Replace calls. Remove moved methods. Remove `RekeyTenantSoftwareReferencesAsync` entirely.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs
+git commit -m "refactor: extract IngestionSnapshotLifecycle and remove dead RekeyTenantSoftwareReferences"
+```
+
+---
+
+### Task 1.5: Register collaborators in DI
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs`
+
+- [ ] **Step 1: Add registrations**
+
+In `DependencyInjection.cs`, near line ~208 where `IngestionService` is registered, add:
+
+```csharp
+services.AddScoped<IngestionLeaseManager>();
+services.AddScoped<IngestionCheckpointWriter>();
+services.AddScoped<IngestionStagingPipeline>();
+services.AddScoped<IngestionSnapshotLifecycle>();
+```
+
+- [ ] **Step 2: Update `IngestionService`'s canonical constructor**
+
+The canonical constructor (was line ~135) now also takes the four collaborators as parameters. The shorter overload constructors (lines ~43, ~73, ~104) still need to chain to it — add `new IngestionLeaseManager(...)` instantiation OR switch all overloads to pass them via DI (see Phase 2 for full collapse). For now, just wire the canonical constructor and accept that test overloads still work via the shorter constructors which manually instantiate the collaborators.
+
+The test constructors in `IngestionServicePhase3Tests.cs` use the short overload that doesn't take `VulnerabilityResolver`/`NormalizedSoftwareProjectionService?`/`RemediationDecisionService?`. They will need to pass through the collaborators. Check what the test helper `CreateSut()` looks like and update accordingly.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/DependencyInjection.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs
+git commit -m "refactor: register IngestionService collaborators in DI"
+```
+
+---
+
+## Phase 2: Collapse Constructors and IIngestionBulkWriter
+
+### Task 2.1: Introduce `IIngestionBulkWriter`
+
+The 12 `IsInMemoryProvider()` branches all follow the same pattern: either use `ExecuteUpdateAsync`/`ExecuteDeleteAsync` (PostgreSQL) or load-mutate-save (InMemory). An interface adapter hides this.
+
+**Files:**
+- Create: `src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs`
+- Create: `src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs`
+- Create: `src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs` (and all collaborators that have `IsInMemoryProvider()` branches)
+- Modify: `src/PatchHound.Infrastructure/DependencyInjection.cs`
+
+- [ ] **Step 1: Define `IIngestionBulkWriter`**
+
+```csharp
+namespace PatchHound.Infrastructure.Services;
+
+/// <summary>
+/// Wraps bulk EF Core operations that differ between PostgreSQL and the InMemory test provider.
+/// Registered as the concrete implementation for the active DB provider.
+/// </summary>
+public interface IIngestionBulkWriter
+{
+    Task ExecuteUpdateIngestionRunAsync(Guid runId, Action<IngestionRun> mutate, CancellationToken ct);
+    Task ExecuteUpdateTenantSourceAsync(Guid tenantId, string sourceKey, Guid runId, Action<TenantSourceConfiguration> mutate, CancellationToken ct);
+    Task DeleteStagedDevicesForRunAsync(Guid ingestionRunId, CancellationToken ct);
+    Task DeleteStagedVulnerabilitiesForRunAsync(Guid ingestionRunId, CancellationToken ct);
+    Task DeleteStagedExposuresForRunAsync(Guid ingestionRunId, CancellationToken ct);
+    Task DeleteStagedInstallationsForRunAsync(Guid ingestionRunId, CancellationToken ct);
+    Task DeleteSnapshotInstallationsAsync(Guid snapshotId, CancellationToken ct);
+    Task DeleteSnapshotTenantRecordsAsync(Guid snapshotId, CancellationToken ct);
+    Task DeleteExpiredIngestionRunsAsync(DateTimeOffset expiredBefore, DateTimeOffset failedExpiredBefore, CancellationToken ct);
+}
+```
+
+- [ ] **Step 2: Implement `PostgresIngestionBulkWriter`**
+
+Uses `ExecuteUpdateAsync`/`ExecuteDeleteAsync` directly:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class PostgresIngestionBulkWriter(PatchHoundDbContext dbContext) : IIngestionBulkWriter
+{
+    public async Task ExecuteUpdateIngestionRunAsync(Guid runId, Action<IngestionRun> mutate, CancellationToken ct)
+    {
+        var run = await dbContext.IngestionRuns.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(r => r.Id == runId, ct);
+        if (run is null) return;
+        mutate(run);
+        await dbContext.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteStagedDevicesForRunAsync(Guid ingestionRunId, CancellationToken ct)
+    {
+        await dbContext.StagedDevices.IgnoreQueryFilters()
+            .Where(d => d.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    // ... implement all interface members — see existing IsInMemoryProvider branches in IngestionService.cs for the PostgreSQL implementations
+}
+```
+
+- [ ] **Step 3: Implement `InMemoryIngestionBulkWriter`**
+
+Uses load + mutate + SaveChanges pattern (copies from the InMemory branches in IngestionService):
+
+```csharp
+public class InMemoryIngestionBulkWriter(PatchHoundDbContext dbContext) : IIngestionBulkWriter
+{
+    // Load entities, mutate in memory, call SaveChangesAsync — exact copies of InMemory branches
+}
+```
+
+- [ ] **Step 4: Register in DI**
+
+In `DependencyInjection.cs`, after building the `ServiceProvider`, register the correct implementation based on the connection string / provider. Since provider is not known at registration time via attribute, use a factory:
+
+```csharp
+services.AddScoped<IIngestionBulkWriter>(sp =>
+{
+    var db = sp.GetRequiredService<PatchHoundDbContext>();
+    return db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
+        ? new InMemoryIngestionBulkWriter(db)
+        : new PostgresIngestionBulkWriter(db);
+});
+```
+
+- [ ] **Step 5: Replace `IsInMemoryProvider()` branches in all collaborators**
+
+For each `IsInMemoryProvider()` block in `IngestionLeaseManager`, `IngestionCheckpointWriter`, `IngestionStagingPipeline`, `IngestionSnapshotLifecycle`, and `IngestionService`:
+
+Replace:
+```csharp
+if (IsInMemoryProvider())
+{
+    // load-mutate-save
+    return;
+}
+// ExecuteUpdateAsync / ExecuteDeleteAsync
+```
+
+With:
+```csharp
+await _bulkWriter.DeleteStagedDevicesForRunAsync(runId, ct); // (or appropriate method)
+```
+
+Each collaborator gets `IIngestionBulkWriter` injected via constructor.
+
+Remove `IsInMemoryProvider()` method from `IngestionService` after all calls are replaced.
+
+- [ ] **Step 6: Build and test**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs \
+        src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs \
+        src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs \
+        src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs \
+        src/PatchHound.Infrastructure/Services/IngestionCheckpointWriter.cs \
+        src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs \
+        src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs \
+        src/PatchHound.Infrastructure/DependencyInjection.cs
+git commit -m "refactor: introduce IIngestionBulkWriter to eliminate IsInMemoryProvider branches"
+```
+
+---
+
+### Task 2.2: Collapse IngestionService constructors
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs`
+
+Currently there are 4 constructor overloads (lines 43, 73, 104, 135). The canonical (line 135) is the real one; others chain to it with defaulted parameters. After Phase 1, the canonical constructor also takes the 4 collaborators. All the chaining constructors need `[ActivatorUtilitiesConstructor]` is not the right fix — the right fix is to add DI-friendly default values or collapse to one constructor.
+
+Strategy: Keep the single canonical constructor and mark it `[ActivatorUtilitiesConstructor]`. The test-only overloads (3 shorter ones) that exist for test convenience should either be kept as `private` constructors chaining to the canonical, or test helpers should be updated to use the full constructor.
+
+- [ ] **Step 1: Read the existing test helpers**
+
+```bash
+grep -rn "new IngestionService(" tests/
+```
+
+Note which constructor overloads are used in tests. The tests in `IngestionServicePhase3Tests.cs` likely use short overloads.
+
+- [ ] **Step 2: Update test helpers to use the canonical constructor**
+
+In `tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs`, find the `CreateSut()` or `new IngestionService(...)` calls and add the 4 collaborators:
+
+```csharp
+private IngestionService CreateSut() => new(
+    _db,
+    sources: [],
+    enrichmentJobEnqueuer: new EnrichmentJobEnqueuer(_db),
+    stagedDeviceMergeService: Substitute.For<IStagedDeviceMergeService>(),
+    stagedCloudApplicationMergeService: Substitute.For<IStagedCloudApplicationMergeService>(),
+    deviceRuleEvaluationService: Substitute.For<IDeviceRuleEvaluationService>(),
+    exposureDerivationService: new ExposureDerivationService(_db),
+    exposureEpisodeService: new ExposureEpisodeService(_db),
+    exposureAssessmentService: Substitute.For<ExposureAssessmentService>(),
+    riskScoreService: Substitute.For<RiskScoreService>(),
+    vulnerabilityResolver: new VulnerabilityResolver(_db, NullLogger<VulnerabilityResolver>.Instance),
+    normalizedSoftwareProjectionService: null,
+    remediationDecisionService: null,
+    leaseManager: new IngestionLeaseManager(_db, NullLogger<IngestionLeaseManager>.Instance),
+    checkpointWriter: new IngestionCheckpointWriter(_db),
+    stagingPipeline: new IngestionStagingPipeline(_db, new EnrichmentJobEnqueuer(_db), NullLogger<IngestionStagingPipeline>.Instance),
+    snapshotLifecycle: new IngestionSnapshotLifecycle(_db, NullLogger<IngestionSnapshotLifecycle>.Instance),
+    bulkWriter: new InMemoryIngestionBulkWriter(_db),
+    logger: NullLogger<IngestionService>.Instance
+);
+```
+
+- [ ] **Step 3: Remove the 3 shorter constructor overloads**
+
+Delete the constructor overloads at lines ~43, ~73, ~104. Keep only the canonical constructor (was line ~135), now expanded. Add `[ActivatorUtilitiesConstructor]` attribute (from `Microsoft.Extensions.DependencyInjection`) to mark it as the DI constructor.
+
+```csharp
+[ActivatorUtilitiesConstructor]
+public IngestionService(
+    PatchHoundDbContext dbContext,
+    IEnumerable<IIngestionSource> sources,
+    EnrichmentJobEnqueuer enrichmentJobEnqueuer,
+    IStagedDeviceMergeService stagedDeviceMergeService,
+    IStagedCloudApplicationMergeService stagedCloudApplicationMergeService,
+    IDeviceRuleEvaluationService deviceRuleEvaluationService,
+    ExposureDerivationService exposureDerivationService,
+    ExposureEpisodeService exposureEpisodeService,
+    ExposureAssessmentService exposureAssessmentService,
+    RiskScoreService riskScoreService,
+    VulnerabilityResolver vulnerabilityResolver,
+    NormalizedSoftwareProjectionService? normalizedSoftwareProjectionService,
+    RemediationDecisionService? remediationDecisionService,
+    IngestionLeaseManager leaseManager,
+    IngestionCheckpointWriter checkpointWriter,
+    IngestionStagingPipeline stagingPipeline,
+    IngestionSnapshotLifecycle snapshotLifecycle,
+    IIngestionBulkWriter bulkWriter,
+    ILogger<IngestionService> logger)
+{ ... }
+```
+
+- [ ] **Step 4: Build and test**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionService.cs \
+        tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+git commit -m "refactor: collapse IngestionService to single canonical constructor"
+```
+
+---
+
+## Phase 3: Critical Fixes
+
+### Task 3.1: Remove dead `RekeyTenantSoftwareReferencesAsync` code
+
+*(This was already done in Task 1.4 as part of extraction. Verify it's gone.)*
+
+- [ ] **Step 1: Verify removal**
+
+```bash
+grep -n "RekeyTenantSoftwareReferences" src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
+grep -n "RekeyTenantSoftwareReferences" src/PatchHound.Infrastructure/Services/IngestionService.cs
+```
+
+Expected: no matches.
+
+- [ ] **Step 2: Verify `PublishSnapshotAsync` has the inline comment**
+
+Read `IngestionSnapshotLifecycle.cs` `PublishSnapshotAsync` method. It should contain:
+
+```csharp
+// RemediationCase is keyed by (TenantId, SoftwareProductId) and stable across snapshot
+// rotations — no re-keying of downstream entities is required when the active snapshot changes.
+```
+
+If the comment is missing, add it.
+
+---
+
+### Task 3.2: Document `IngestionStateCache` scoped lifetime
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionStateCache.cs`
+
+- [ ] **Step 1: Read `IngestionStateCache.cs`**
+
+```bash
+cat -n src/PatchHound.Infrastructure/Services/IngestionStateCache.cs
+```
+
+- [ ] **Step 2: Add XML doc comment to the class**
+
+```csharp
+/// <summary>
+/// Scoped per-request ingestion state. Registered as AddScoped — one instance per DI scope,
+/// not a singleton. Each IngestionService scope gets its own clean instance.
+/// </summary>
+public class IngestionStateCache
+```
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+dotnet build PatchHound.slnx
+git add src/PatchHound.Infrastructure/Services/IngestionStateCache.cs
+git commit -m "docs: clarify IngestionStateCache scoped (not singleton) registration"
+```
+
+---
+
+## Phase 4: Important Fixes
+
+### Task 4.1: Delete `IngestionWorker.IsDue` — delegate to `IngestionScheduleEvaluator`
+
+**Problem:** `IngestionWorker` has a private static `IsDue(ScheduledSource, DateTimeOffset)` (lines ~250–280) that duplicates `IngestionScheduleEvaluator.IsDue` but is MISSING the active-run guard check (`lastCompletedAt < lastStartedAt`). This means the worker can double-start a source that is still running.
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs`
+- Modify: `src/PatchHound.Worker/IngestionWorker.cs`
+
+- [ ] **Step 1: Write a failing test**
+
+Add to `tests/PatchHound.Tests/Worker/IngestionWorkerTests.cs`:
+
+```csharp
+[Fact]
+public void IsDue_WhenLastStartedAfterLastCompleted_ReturnsFalse()
+{
+    // active run guard: started > completed means currently running
+    var source = new TenantSourceConfiguration(/* ... with appropriate values */);
+    var now = DateTimeOffset.UtcNow;
+    source.UpdateRuntime(null, now.AddMinutes(-1), now.AddMinutes(-10), now.AddMinutes(-10), "Succeeded", null);
+    // lastStartedAt (now-1min) > lastCompletedAt (now-10min) → run is in progress
+    var result = IngestionScheduleEvaluator.IsDue(source, now);
+    result.Should().BeFalse();
+}
+```
+
+Run: `dotnet test --filter "FullyQualifiedName~IngestionWorkerTests" -v minimal`
+
+Note: if `TenantSourceConfiguration` is hard to construct outside infra tests, write this as an `IngestionScheduleEvaluatorTests` in the infra test project.
+
+- [ ] **Step 2: Verify `IngestionScheduleEvaluator.IsDue` already has the active-run guard**
+
+Read `src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs` fully. The current implementation checks `source.LastStartedAt > source.LastCompletedAt` (active run guard). The worker's private `IsDue` does NOT.
+
+- [ ] **Step 3: Add a primitive-field overload to `IngestionScheduleEvaluator`**
+
+`IngestionWorker` builds `ScheduledSource` records from the DB, so it can pass individual fields:
+
+```csharp
+public static bool IsDue(
+    string sourceKey,
+    bool enabled,
+    string? syncSchedule,
+    DateTimeOffset? lastStartedAt,
+    DateTimeOffset? lastCompletedAt,
+    DateTimeOffset nowUtc)
+{
+    if (!enabled) return false;
+    if (string.IsNullOrWhiteSpace(syncSchedule)) return false;
+    if (!TenantSourceCatalog.SupportsScheduling(sourceKey)) return false;
+
+    // Active run guard — same as entity overload
+    if (lastStartedAt.HasValue && lastCompletedAt.HasValue && lastStartedAt > lastCompletedAt)
+        return false;
+
+    var lastRun = lastCompletedAt ?? (lastStartedAt.HasValue ? lastStartedAt.Value.AddYears(-1) : nowUtc.AddYears(-1));
+    return CronExpression.Parse(syncSchedule).GetNextOccurrence(lastRun.UtcDateTime, TimeZoneInfo.Utc) <= nowUtc.UtcDateTime;
+}
+```
+
+(Check `IngestionScheduleEvaluator.cs` to see what cron library is used — use the same one.)
+
+- [ ] **Step 4: Update `IngestionWorker` to call `IngestionScheduleEvaluator.IsDue`**
+
+In `IngestionWorker.cs`, find private static `IsDue(ScheduledSource source, DateTimeOffset nowUtc)` (lines ~250–280). Delete it. Find each call site and replace with:
+
+```csharp
+IngestionScheduleEvaluator.IsDue(
+    source.SourceKey,
+    source.Enabled,
+    source.SyncSchedule,
+    source.LastStartedAt,
+    source.LastCompletedAt,
+    nowUtc)
+```
+
+Delete the private `ScheduledSource` record if `SourceKey`, `Enabled`, etc. are its fields — or keep it if it's used for grouping, but the `IsDue` logic must go.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs \
+        src/PatchHound.Worker/IngestionWorker.cs \
+        tests/PatchHound.Tests/Worker/IngestionWorkerTests.cs
+git commit -m "fix: remove duplicate IngestionWorker.IsDue, delegate to IngestionScheduleEvaluator with active-run guard"
+```
+
+---
+
+### Task 4.2: Call `ClearStagedDataForRunAsync` on failure
+
+**Problem:** `CompleteIngestionRunAsync` only calls `ClearStagedDataForRunAsync` on success (lines ~1450–1452 and ~1573–1575 in original file). Failed runs leave staged rows until `CleanupExpiredIngestionArtifactsAsync` runs (24h). This inflates storage and confuses monitoring.
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs` (after Phase 1) OR `IngestionService.cs` (before Phase 1)
+
+- [ ] **Step 1: Write a failing test**
+
+Add to `IngestionLeaseManagerTests.cs` (or a new `IngestionServiceCleanupTests.cs`):
+
+```csharp
+[Fact]
+public async Task CompleteIngestionRunAsync_OnFailure_ClearsStagedData()
+{
+    // Arrange: create an IngestionRun and add a StagedDevice for it
+    var sut = CreateSut(); // or use full IngestionService
+    var acquired = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+    var stagedDevice = new StagedDevice { IngestionRunId = acquired!.Run.Id, TenantId = _tenantId, /* minimal fields */ };
+    _db.StagedDevices.Add(stagedDevice);
+    await _db.SaveChangesAsync();
+
+    // Act: complete as failure
+    await sut.CompleteIngestionRunAsync(acquired.Run.Id, _tenantId, "defender", succeeded: false, error: "test", /* ... */, CancellationToken.None);
+
+    // Assert: staged device is gone
+    var remaining = await _db.StagedDevices.IgnoreQueryFilters()
+        .Where(d => d.IngestionRunId == acquired.Run.Id).CountAsync();
+    remaining.Should().Be(0);
+}
+```
+
+- [ ] **Step 2: Fix `CompleteIngestionRunAsync`**
+
+In the failure branch (both InMemory and PostgreSQL paths), add a call to `ClearStagedDataForRunAsync` after writing the final run status:
+
+```csharp
+// After: await _dbContext.SaveChangesAsync(ct); (failure branch)
+await ClearStagedDataForRunAsync(runId, ct);
+```
+
+Do this in both the InMemory branch (currently ~line 1450) and the PostgreSQL `ExecuteUpdate` path (currently ~line 1573).
+
+After Phase 1, this will be in `IngestionLeaseManager` and `IngestionCheckpointWriter` respectively.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
+git commit -m "fix: clear staged data for failed ingestion runs, not just successful ones"
+```
+
+---
+
+### Task 4.3: Fix `AuthenticatedScanIngestionService` orphaned staging rows
+
+**Problem:** `AuthenticatedScanIngestionService` at line ~50 creates `var ingestionRunId = Guid.NewGuid()` without creating an `IngestionRun` entity. Staged rows reference this fake ID and are never cleaned up by `CleanupExpiredIngestionArtifactsAsync` (which scans real `IngestionRun` rows for expiry).
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs`
+
+- [ ] **Step 1: Read the full file**
+
+```bash
+cat -n src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs
+```
+
+- [ ] **Step 2: Write a failing test**
+
+Add to a new file `tests/PatchHound.Tests/Infrastructure/AuthenticatedScanIngestionServiceTests.cs`:
+
+```csharp
+[Fact]
+public async Task IngestAsync_AfterMerge_StagedRowsAreDeleted()
+{
+    // Arrange
+    var svc = CreateSut();
+    var scan = BuildTestScanResult();
+
+    // Act
+    await svc.IngestAsync(_tenantId, scan, CancellationToken.None);
+
+    // Assert: no staged rows remain for this tenant
+    var staged = await _db.StagedDevices.IgnoreQueryFilters()
+        .Where(d => d.TenantId == _tenantId).CountAsync();
+    staged.Should().Be(0);
+}
+```
+
+- [ ] **Step 3: Fix `AuthenticatedScanIngestionService`**
+
+After the call to `stagedDeviceMergeService.MergeAsync(...)` and `projectionService.SyncTenantAsync(...)`, delete the staged rows:
+
+```csharp
+await dbContext.StagedDevices.IgnoreQueryFilters()
+    .Where(d => d.IngestionRunId == ingestionRunId)
+    .ExecuteDeleteAsync(ct);
+await dbContext.StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+    .Where(i => i.IngestionRunId == ingestionRunId)
+    .ExecuteDeleteAsync(ct);
+```
+
+Use `IIngestionBulkWriter` if available by this phase; otherwise call `ExecuteDeleteAsync` directly (it's not used in tests, so no in-memory issue here — authenticated scans always run with real Postgres in production).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~AuthenticatedScanIngestionServiceTests" -v minimal
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs \
+        tests/PatchHound.Tests/Infrastructure/AuthenticatedScanIngestionServiceTests.cs
+git commit -m "fix: delete staged rows after AuthenticatedScanIngestionService merge to prevent orphans"
+```
+
+---
+
+### Task 4.4: Fix `StagedDeviceMergeService` N+1 SELECT
+
+**Problem:** In `StagedDeviceMergeService.cs`:
+1. Line ~107–115: `db.Devices.FirstOrDefaultAsync(...)` inside `foreach (var stagedDevice in stagedDevices)` — N+1
+2. Line ~226–236: `db.InstalledSoftware.FirstOrDefaultAsync(...)` inside software link loop — N+1
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs`
+
+- [ ] **Step 1: Read the relevant sections**
+
+```bash
+sed -n '100,250p' src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs
+```
+
+- [ ] **Step 2: Write a failing test (performance assertion)**
+
+Add to `StagedDeviceMergeServiceTests.cs` — not a SQL query-count test (that's brittle), but a correctness test with multiple staged devices that exercises the code path:
+
+```csharp
+[Fact]
+public async Task MergeAsync_TwoStagedDevices_BothMerged()
+{
+    // Arrange: seed 2 staged devices
+    var runId = Guid.NewGuid();
+    _db.StagedDevices.AddRange(
+        BuildStagedDevice(runId, "device-001"),
+        BuildStagedDevice(runId, "device-002"));
+    await _db.SaveChangesAsync();
+
+    // Act
+    var sut = CreateSut();
+    await sut.MergeAsync(_tenantId, runId, CancellationToken.None);
+
+    // Assert
+    var deviceCount = await _db.Devices.Where(d => d.TenantId == _tenantId).CountAsync();
+    deviceCount.Should().Be(2);
+}
+```
+
+- [ ] **Step 3: Pre-load devices before the loop**
+
+Before the `foreach (var stagedDevice in stagedDevices)` loop, add:
+
+```csharp
+var stagedExternalIds = stagedDevices.Select(d => d.ExternalId).Distinct().ToList();
+var existingDevices = await db.Devices
+    .Where(d => d.TenantId == tenantId && stagedExternalIds.Contains(d.ExternalId))
+    .ToDictionaryAsync(d => d.ExternalId, d => d, ct);
+```
+
+Replace `await db.Devices.FirstOrDefaultAsync(d => d.ExternalId == staged.ExternalId && d.TenantId == tenantId, ct)` with `existingDevices.TryGetValue(staged.ExternalId, out var existing) ? existing : null`.
+
+After the loop, add newly created devices to `existingDevices` so later iterations find them (for duplicate staged entries with the same external ID).
+
+- [ ] **Step 4: Pre-load InstalledSoftware before the software link loop**
+
+After all devices are processed and saved, build a dictionary of installed software keyed by (DeviceId, CanonicalProductKey):
+
+```csharp
+var mergedDeviceIds = existingDevices.Values.Select(d => d.Id).ToList();
+var installedSoftwareByKey = await db.InstalledSoftware
+    .Where(i => i.TenantId == tenantId && mergedDeviceIds.Contains(i.DeviceId))
+    .ToDictionaryAsync(i => (i.DeviceId, i.SoftwareProduct.CanonicalProductKey), i => i, ct);
+```
+
+Replace the `FirstOrDefaultAsync` inside the software link loop with a dictionary lookup.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~StagedDeviceMergeService" -v minimal
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs
+git commit -m "fix: eliminate N+1 SELECT in StagedDeviceMergeService device and software lookups"
+```
+
+---
+
+### Task 4.5: Bound `ProcessStagedResultsAsync` exposure load
+
+**Problem:** Line ~2225–2228 in original `IngestionService.cs` (now in `IngestionStagingPipeline` after Phase 1):
+
+```csharp
+var existing = await _dbContext.DeviceVulnerabilityExposures
+    .Where(e => e.TenantId == tenantId)
+    .ToListAsync(ct);
+```
+
+Loads ALL exposures for the tenant. Should be bounded to the device IDs in the current run's staged exposures.
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs` (or `IngestionService.cs` before Phase 1)
+
+- [ ] **Step 1: Bound the load**
+
+After building `deviceIdByExternalId` (the dict mapping external IDs to Device GUIDs, already loaded in Step 2 of the method), bound the query:
+
+```csharp
+// Only load exposures for devices in this run — not all tenant exposures
+var runDeviceIds = deviceIdByExternalId.Values.ToList();
+var existing = await _dbContext.DeviceVulnerabilityExposures
+    .Where(e => e.TenantId == tenantId && runDeviceIds.Contains(e.DeviceId))
+    .ToListAsync(ct);
+```
+
+This is semantically correct: `ProcessStagedResultsAsync` only receives staged exposures for devices staged in this run. Exposures for other devices are not touched.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs
+git commit -m "fix: bound ProcessStagedResultsAsync exposure load to current run's device IDs"
+```
+
+---
+
+## Phase 5: Minor Fixes
+
+### Task 5.1: Seal `IngestionTerminalException`
+
+- [ ] **Step 1: Find and seal**
+
+```bash
+grep -rn "class IngestionTerminalException\|class IngestionAbortedException" src/
+```
+
+- [ ] **Step 2: Add `sealed` modifier**
+
+```csharp
+public sealed class IngestionTerminalException : Exception { ... }
+public sealed class IngestionAbortedException : Exception { ... }
+```
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+dotnet build PatchHound.slnx
+git add <file(s)>
+git commit -m "fix: seal IngestionTerminalException and IngestionAbortedException"
+```
+
+---
+
+### Task 5.2: Fix hardcoded `"Failed"` in `IngestionWorker`
+
+**Files:**
+- Modify: `src/PatchHound.Worker/IngestionWorker.cs`
+
+- [ ] **Step 1: Find and replace**
+
+In `IngestionWorker.cs` line ~169:
+```csharp
+.SetProperty(item => item.LastStatus, "Failed")
+```
+
+Replace with:
+```csharp
+.SetProperty(item => item.LastStatus, IngestionRunStatuses.Failed)
+```
+
+Verify `IngestionRunStatuses.Failed` exists:
+```bash
+grep -rn "IngestionRunStatuses" src/PatchHound.Core/
+grep -rn "IngestionRunStatuses" src/PatchHound.Infrastructure/
+```
+
+Add the required using if needed.
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+dotnet build PatchHound.slnx
+git add src/PatchHound.Worker/IngestionWorker.cs
+git commit -m "fix: use IngestionRunStatuses.Failed constant in IngestionWorker"
+```
+
+---
+
+### Task 5.3: `RefreshDeviceActivityForTenantAsync` → `ExecuteUpdateAsync`
+
+**Problem:** Lines ~904–925 load all tenant devices into memory to set `IsActive` flag. Should use `ExecuteUpdateAsync`.
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/IngestionService.cs` (stays in orchestrator or moves to a utility)
+
+- [ ] **Step 1: Rewrite with `ExecuteUpdateAsync`**
+
+```csharp
+private async Task<int> RefreshDeviceActivityForTenantAsync(Guid tenantId, CancellationToken ct)
+{
+    var cutoff = DateTimeOffset.UtcNow.Subtract(DeviceInactiveThreshold);
+
+    var deactivatedCount = await _dbContext.Devices
+        .IgnoreQueryFilters()
+        .Where(d => d.TenantId == tenantId && d.IsActive && (d.LastSeenAt == null || d.LastSeenAt < cutoff))
+        .ExecuteUpdateAsync(s => s.SetProperty(d => d.IsActive, false), ct);
+
+    await _dbContext.Devices
+        .IgnoreQueryFilters()
+        .Where(d => d.TenantId == tenantId && !d.IsActive && d.LastSeenAt != null && d.LastSeenAt >= cutoff)
+        .ExecuteUpdateAsync(s => s.SetProperty(d => d.IsActive, true), ct);
+
+    return deactivatedCount;
+}
+```
+
+Note: This changes the return value to only count newly-deactivated devices. Verify the caller just logs this count; the semantic is the same.
+
+- [ ] **Step 2: Handle in-memory provider**
+
+If `IIngestionBulkWriter` is implemented by Phase 5, add `RefreshDeviceActivityAsync` to the interface. Otherwise, keep the old load-mutate-save as the InMemory path in an `if (IsInMemoryProvider())` guard (acceptable for a minor fix, full elimination comes from Phase 2).
+
+- [ ] **Step 3: Build and test**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PatchHound.Infrastructure/Services/IngestionService.cs
+git commit -m "perf: rewrite RefreshDeviceActivityForTenantAsync to use ExecuteUpdateAsync"
+```
+
+---
+
+### Task 5.4: Remove `FetchCanonicalVulnerabilitiesAsync` from `IVulnerabilitySource`
+
+**Problem:** `IVulnerabilitySource` declares `FetchCanonicalVulnerabilitiesAsync` which is never called from the ingestion pipeline. Only `DefenderVulnerabilitySource` implements it. Removing it from the interface decouples the abstraction from this dead call path.
+
+**Files:**
+- Modify: `src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs`
+- Modify: all implementors (verify with grep)
+
+- [ ] **Step 1: Verify no callers**
+
+```bash
+grep -rn "FetchCanonicalVulnerabilitiesAsync" src/ tests/
+```
+
+Expected: only declaration in `IVulnerabilitySource.cs` and implementation in `DefenderVulnerabilitySource.cs`.
+
+- [ ] **Step 2: Remove from interface**
+
+Delete the `FetchCanonicalVulnerabilitiesAsync` declaration from `IVulnerabilitySource.cs`.
+
+- [ ] **Step 3: Remove from implementors**
+
+```bash
+grep -rn "FetchCanonicalVulnerabilitiesAsync" src/
+```
+
+Remove the implementation from `DefenderVulnerabilitySource.cs` (lines ~101–178). If it is a large useful method, convert it to a `public` non-interface method on `DefenderVulnerabilitySource` directly for future use. If it's unused beyond the interface, delete it.
+
+- [ ] **Step 4: Build and test**
+
+```bash
+dotnet build PatchHound.slnx
+dotnet test PatchHound.slnx -v minimal
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs \
+        src/PatchHound.Infrastructure/Sources/DefenderVulnerabilitySource.cs
+git commit -m "refactor: remove unused FetchCanonicalVulnerabilitiesAsync from IVulnerabilitySource"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] All phases have exact file paths
+- [x] All test steps show actual test code
+- [x] Phase 0 must complete before Phase 1 (constants are used in extracted classes)
+- [x] Phase 1 must complete before Phase 2 (constructors collapse after extraction)
+- [x] Phase 3 critical fix (dead code) is partially handled in Phase 1 Task 1.4
+- [x] Phase 4 and Phase 5 are independent of each other and can be done in any order after Phase 1
+- [x] No "TBD" placeholders
+- [x] InMemory provider concern addressed in IIngestionBulkWriter (Phase 2)
+
+## Dependency Order
+
+```
+Phase 0 → Phase 1 → Phase 2
+                  → Phase 3 (concurrent with Phase 2)
+                  → Phase 4 (after Phase 1, any order)
+                  → Phase 5 (after Phase 1, any order)
+```

--- a/frontend/src/features/vulnerabilities/list-state.ts
+++ b/frontend/src/features/vulnerabilities/list-state.ts
@@ -45,7 +45,7 @@ export const vulnerabilityQueryKeys = {
     search.knownExploitedOnly,
     search.activeAlertOnly,
     search.presentOnly,
-    search.remediationCaseIds,
+    ...(search.remediationCaseIds ? [search.remediationCaseIds] : []),
     search.page,
     search.pageSize,
   ] as const,

--- a/src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs
+++ b/src/PatchHound.Core/Interfaces/IVulnerabilitySource.cs
@@ -8,9 +8,4 @@ public interface IVulnerabilitySource : IIngestionSource
         Guid tenantId,
         CancellationToken ct
     );
-
-    Task<CanonicalVulnerabilityBatch> FetchCanonicalVulnerabilitiesAsync(
-        Guid tenantId,
-        CancellationToken ct
-    );
 }

--- a/src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs
+++ b/src/PatchHound.Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Entities.AuthenticatedScans;
 using PatchHound.Core.Enums;
@@ -9,31 +10,48 @@ using PatchHound.Infrastructure.Services;
 
 namespace PatchHound.Infrastructure.AuthenticatedScans;
 
-public class AuthenticatedScanIngestionService(
-    PatchHoundDbContext dbContext,
-    AuthenticatedScanOutputValidator validator,
-    IStagedDeviceMergeService stagedDeviceMergeService,
-    NormalizedSoftwareProjectionService projectionService)
+public class AuthenticatedScanIngestionService
 {
     private const string SourceKey = "authenticated-scan";
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly AuthenticatedScanOutputValidator _validator;
+    private readonly IStagedDeviceMergeService _stagedDeviceMergeService;
+    private readonly NormalizedSoftwareProjectionService _projectionService;
+    private readonly IIngestionBulkWriter _bulkWriter;
+
+    [ActivatorUtilitiesConstructor]
+    internal AuthenticatedScanIngestionService(
+        PatchHoundDbContext dbContext,
+        AuthenticatedScanOutputValidator validator,
+        IStagedDeviceMergeService stagedDeviceMergeService,
+        NormalizedSoftwareProjectionService projectionService,
+        IIngestionBulkWriter bulkWriter)
+    {
+        _dbContext = dbContext;
+        _validator = validator;
+        _stagedDeviceMergeService = stagedDeviceMergeService;
+        _projectionService = projectionService;
+        _bulkWriter = bulkWriter;
+    }
+
     public async Task ProcessJobResultAsync(Guid scanJobId, string rawStdout, string rawStderr, CancellationToken ct)
     {
-        var job = await dbContext.ScanJobs.FirstOrDefaultAsync(j => j.Id == scanJobId, ct)
+        var job = await _dbContext.ScanJobs.FirstOrDefaultAsync(j => j.Id == scanJobId, ct)
             ?? throw new InvalidOperationException($"ScanJob {scanJobId} not found");
 
         var result = ScanJobResult.Create(scanJobId, rawStdout, rawStderr, string.Empty);
-        await dbContext.ScanJobResults.AddAsync(result, ct);
+        await _dbContext.ScanJobResults.AddAsync(result, ct);
 
-        var validation = validator.Validate(rawStdout);
+        var validation = _validator.Validate(rawStdout);
 
         if (validation.FatalError)
         {
             job.CompleteFailed(ScanJobStatuses.Failed, $"Validation: {validation.FatalErrorMessage}", DateTimeOffset.UtcNow);
             await SaveValidationIssues(scanJobId, validation.Issues, ct);
-            await dbContext.SaveChangesAsync(ct);
+            await _dbContext.SaveChangesAsync(ct);
             return;
         }
 
@@ -42,7 +60,7 @@ public class AuthenticatedScanIngestionService(
         if (validation.ValidEntries.Count == 0)
         {
             job.CompleteSucceeded(rawStdout.Length, rawStderr.Length, 0, DateTimeOffset.UtcNow);
-            await dbContext.SaveChangesAsync(ct);
+            await _dbContext.SaveChangesAsync(ct);
             return;
         }
 
@@ -103,23 +121,28 @@ public class AuthenticatedScanIngestionService(
             ));
         }
 
-        await dbContext.StagedDevices.AddRangeAsync(stagedSoftware, ct);
-        await dbContext.StagedDeviceSoftwareInstallations.AddRangeAsync(softwareLinks, ct);
-        await dbContext.SaveChangesAsync(ct);
-        dbContext.ChangeTracker.Clear();
+        await _dbContext.StagedDevices.AddRangeAsync(stagedSoftware, ct);
+        await _dbContext.StagedDeviceSoftwareInstallations.AddRangeAsync(softwareLinks, ct);
+        await _dbContext.SaveChangesAsync(ct);
+        _dbContext.ChangeTracker.Clear();
 
         // Merge + resolve + project through the canonical pipeline
-        await stagedDeviceMergeService.MergeAsync(ingestionRunId, job.TenantId, ct);
-        await projectionService.SyncTenantAsync(job.TenantId, null, ct);
+        await _stagedDeviceMergeService.MergeAsync(ingestionRunId, job.TenantId, ct);
+        await _projectionService.SyncTenantAsync(job.TenantId, null, ct);
 
-        job = await dbContext.ScanJobs.FirstAsync(j => j.Id == scanJobId, ct);
+        // Delete staged rows now that merge is complete. No IngestionRun entity is created for
+        // authenticated-scan jobs, so CleanupExpiredIngestionArtifactsAsync would never find these
+        // rows and they would persist indefinitely without explicit cleanup here.
+        await _bulkWriter.ClearStagedDataForRunAsync(ingestionRunId, ct);
+
+        job = await _dbContext.ScanJobs.FirstAsync(j => j.Id == scanJobId, ct);
         job.CompleteSucceeded(rawStdout.Length, rawStderr.Length, validation.ValidEntries.Count, DateTimeOffset.UtcNow);
-        await dbContext.SaveChangesAsync(ct);
+        await _dbContext.SaveChangesAsync(ct);
     }
 
     private async Task<string> GetDeviceExternalId(Guid deviceId, CancellationToken ct)
     {
-        var device = await dbContext.Devices.IgnoreQueryFilters().FirstOrDefaultAsync(d => d.Id == deviceId, ct);
+        var device = await _dbContext.Devices.IgnoreQueryFilters().FirstOrDefaultAsync(d => d.Id == deviceId, ct);
         return device?.ExternalId ?? deviceId.ToString();
     }
 
@@ -134,7 +157,6 @@ public class AuthenticatedScanIngestionService(
     {
         if (issues.Count == 0) return;
         var entities = issues.Select(i => ScanJobValidationIssue.Create(scanJobId, i.FieldPath, i.Message, i.EntryIndex));
-        await dbContext.ScanJobValidationIssues.AddRangeAsync(entities, ct);
+        await _dbContext.ScanJobValidationIssues.AddRangeAsync(entities, ct);
     }
 }
-

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -205,6 +205,7 @@ public static class DependencyInjection
         services.AddScoped<IStagedCloudApplicationMergeService, StagedCloudApplicationMergeService>();
 
         // Ingestion
+        services.AddScoped<IngestionLeaseManager>();
         services.AddScoped<IngestionService>();
 
         // Event Pusher (pushes events to TanStack Start SSE endpoint)

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -205,6 +205,13 @@ public static class DependencyInjection
         services.AddScoped<IStagedCloudApplicationMergeService, StagedCloudApplicationMergeService>();
 
         // Ingestion
+        services.AddScoped<IIngestionBulkWriter>(sp =>
+        {
+            var db = sp.GetRequiredService<PatchHoundDbContext>();
+            return db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
+                ? new InMemoryIngestionBulkWriter(db)
+                : (IIngestionBulkWriter)new PostgresIngestionBulkWriter(db);
+        });
         services.AddScoped<IngestionLeaseManager>();
         services.AddScoped<IngestionCheckpointWriter>();
         services.AddScoped<IngestionStagingPipeline>();

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -207,6 +207,7 @@ public static class DependencyInjection
         // Ingestion
         services.AddScoped<IngestionLeaseManager>();
         services.AddScoped<IngestionCheckpointWriter>();
+        services.AddScoped<IngestionStagingPipeline>();
         services.AddScoped<IngestionService>();
 
         // Event Pusher (pushes events to TanStack Start SSE endpoint)

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -208,6 +208,7 @@ public static class DependencyInjection
         services.AddScoped<IngestionLeaseManager>();
         services.AddScoped<IngestionCheckpointWriter>();
         services.AddScoped<IngestionStagingPipeline>();
+        services.AddScoped<IngestionSnapshotLifecycle>();
         services.AddScoped<IngestionService>();
 
         // Event Pusher (pushes events to TanStack Start SSE endpoint)

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -206,6 +206,7 @@ public static class DependencyInjection
 
         // Ingestion
         services.AddScoped<IngestionLeaseManager>();
+        services.AddScoped<IngestionCheckpointWriter>();
         services.AddScoped<IngestionService>();
 
         // Event Pusher (pushes events to TanStack Start SSE endpoint)

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using PatchHound.Core.Entities;
@@ -133,7 +134,14 @@ public static class DependencyInjection
         services.AddScoped<AdvancedToolExecutionService>();
         services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.ConnectionProfileSecretWriter>();
         services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.AuthenticatedScanOutputValidator>();
-        services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.AuthenticatedScanIngestionService>();
+        services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.AuthenticatedScanIngestionService>(sp =>
+            new PatchHound.Infrastructure.AuthenticatedScans.AuthenticatedScanIngestionService(
+                sp.GetRequiredService<PatchHoundDbContext>(),
+                sp.GetRequiredService<PatchHound.Infrastructure.AuthenticatedScans.AuthenticatedScanOutputValidator>(),
+                sp.GetRequiredService<IStagedDeviceMergeService>(),
+                sp.GetRequiredService<NormalizedSoftwareProjectionService>(),
+                sp.GetRequiredService<IIngestionBulkWriter>()
+            ));
         services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.ScanJobDispatcher>();
         services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.ScanRunCompletionService>();
         services.AddScoped<PatchHound.Infrastructure.AuthenticatedScans.ScanSchedulerTickHandler>();
@@ -212,11 +220,38 @@ public static class DependencyInjection
                 ? new InMemoryIngestionBulkWriter(db)
                 : (IIngestionBulkWriter)new PostgresIngestionBulkWriter(db);
         });
-        services.AddScoped<IngestionLeaseManager>();
+        services.AddScoped<IngestionLeaseManager>(sp => new IngestionLeaseManager(
+            sp.GetRequiredService<PatchHoundDbContext>(),
+            sp.GetRequiredService<IIngestionBulkWriter>(),
+            sp.GetRequiredService<ILogger<IngestionLeaseManager>>()
+        ));
         services.AddScoped<IngestionCheckpointWriter>();
         services.AddScoped<IngestionStagingPipeline>();
-        services.AddScoped<IngestionSnapshotLifecycle>();
-        services.AddScoped<IngestionService>();
+        services.AddScoped<IngestionSnapshotLifecycle>(sp => new IngestionSnapshotLifecycle(
+            sp.GetRequiredService<PatchHoundDbContext>(),
+            sp.GetRequiredService<IIngestionBulkWriter>()
+        ));
+        services.AddScoped<IngestionService>(sp => new IngestionService(
+            sp.GetRequiredService<PatchHoundDbContext>(),
+            sp.GetRequiredService<IEnumerable<IIngestionSource>>(),
+            sp.GetRequiredService<EnrichmentJobEnqueuer>(),
+            sp.GetRequiredService<IStagedDeviceMergeService>(),
+            sp.GetRequiredService<IStagedCloudApplicationMergeService>(),
+            sp.GetRequiredService<IDeviceRuleEvaluationService>(),
+            sp.GetRequiredService<ExposureDerivationService>(),
+            sp.GetRequiredService<ExposureEpisodeService>(),
+            sp.GetRequiredService<ExposureAssessmentService>(),
+            sp.GetRequiredService<RiskScoreService>(),
+            sp.GetRequiredService<VulnerabilityResolver>(),
+            sp.GetService<NormalizedSoftwareProjectionService>(),
+            sp.GetService<RemediationDecisionService>(),
+            sp.GetRequiredService<IngestionLeaseManager>(),
+            sp.GetRequiredService<IngestionCheckpointWriter>(),
+            sp.GetRequiredService<IngestionStagingPipeline>(),
+            sp.GetRequiredService<IngestionSnapshotLifecycle>(),
+            sp.GetRequiredService<IIngestionBulkWriter>(),
+            sp.GetRequiredService<ILogger<IngestionService>>()
+        ));
 
         // Event Pusher (pushes events to TanStack Start SSE endpoint)
         services.AddHttpClient<IEventPusher, HttpEventPusher>();

--- a/src/PatchHound.Infrastructure/Services/CheckpointConstants.cs
+++ b/src/PatchHound.Infrastructure/Services/CheckpointConstants.cs
@@ -1,0 +1,17 @@
+namespace PatchHound.Infrastructure.Services;
+
+internal static class CheckpointPhases
+{
+    public const string AssetStaging = "asset-staging";
+    public const string AssetMerge = "asset-merge";
+    public const string VulnerabilityStaging = "vulnerability-staging";
+    public const string VulnerabilityMerge = "vulnerability-merge";
+    public const string CloudAppStaging = "cloud-app-staging";
+}
+
+internal static class CheckpointStatuses
+{
+    public const string Running = "Running";
+    public const string Staged = "Staged";
+    public const string Completed = "Completed";
+}

--- a/src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs
@@ -69,6 +69,14 @@ internal interface IIngestionBulkWriter
         CancellationToken ct
     );
 
+    // ── Device activity ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Deactivates devices not seen since <paramref name="inactiveThreshold"/> and reactivates
+    /// those that have re-appeared. Returns the count of deactivated devices.
+    /// </summary>
+    Task<int> RefreshDeviceActivityAsync(Guid tenantId, TimeSpan inactiveThreshold, CancellationToken ct);
+
     // ── Compound operations ──────────────────────────────────────────────────
 
     /// <summary>

--- a/src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/IIngestionBulkWriter.cs
@@ -1,0 +1,103 @@
+namespace PatchHound.Infrastructure.Services;
+
+/// <summary>
+/// Abstracts the two EF Core execution paths that differ between the InMemory provider
+/// (used in tests) and PostgreSQL (production): bulk deletes via
+/// <c>ExecuteDeleteAsync</c>/<c>ExecuteUpdateAsync</c> vs. load + mutate + <c>SaveChangesAsync</c>.
+/// </summary>
+internal interface IIngestionBulkWriter
+{
+    // ── Staged data cleanup ──────────────────────────────────────────────────
+
+    /// <summary>Deletes all staged rows (devices, software, vulnerabilities, exposures) for the given run.</summary>
+    Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct);
+
+    /// <summary>
+    /// Deletes all staged rows for the given set of expired run IDs and returns
+    /// per-entity deleted counts.
+    /// </summary>
+    Task<IngestionArtifactCleanupSummary> CleanupExpiredArtifactsAsync(
+        IReadOnlyList<Guid> expiredRunIds,
+        CancellationToken ct
+    );
+
+    // ── Snapshot data cleanup ────────────────────────────────────────────────
+
+    /// <summary>Deletes <c>SoftwareProductInstallations</c> and <c>SoftwareTenantRecords</c> for the given snapshot.</summary>
+    Task CleanupSnapshotDataAsync(Guid snapshotId, CancellationToken ct);
+
+    // ── Source lease updates ─────────────────────────────────────────────────
+
+    /// <summary>Clears the active run / lease fields on the matching <c>TenantSourceConfiguration</c>.</summary>
+    Task ReleaseIngestionLeaseAsync(
+        Guid tenantId,
+        string normalizedSourceKey,
+        Guid runId,
+        CancellationToken ct
+    );
+
+    // ── Run status updates ───────────────────────────────────────────────────
+
+    /// <summary>Updates <c>IngestionRun.Status</c> for the given run.</summary>
+    Task UpdateIngestionRunStatusAsync(Guid runId, string status, CancellationToken ct);
+
+    /// <summary>Updates staged / persisted vulnerability count fields on the run.</summary>
+    Task UpdateVulnerabilityMergeProgressAsync(
+        Guid ingestionRunId,
+        int stagedVulnerabilityCount,
+        int persistedVulnerabilityCount,
+        CancellationToken ct
+    );
+
+    /// <summary>Updates staged / persisted asset count fields on the run.</summary>
+    Task UpdateAssetMergeProgressAsync(
+        Guid ingestionRunId,
+        int stagedMachineCount,
+        int stagedSoftwareCount,
+        int persistedMachineCount,
+        int persistedSoftwareCount,
+        CancellationToken ct
+    );
+
+    // ── Source runtime state updates ─────────────────────────────────────────
+
+    /// <summary>Reads the current runtime state, applies <paramref name="update"/>, then persists it.</summary>
+    Task UpdateRuntimeStateAsync(
+        Guid tenantId,
+        string normalizedSourceKey,
+        Action<TenantIngestionRuntimeState> update,
+        CancellationToken ct
+    );
+
+    // ── Compound operations ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// If the run exists, is not yet completed, has an abort request, and is still in an
+    /// active status, marks it <c>FailedTerminal</c> and releases the source lease.
+    /// </summary>
+    Task FinalizeAbortedRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string normalizedSourceKey,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    );
+
+    /// <summary>
+    /// Writes the final run outcome (run row + source lease release + source runtime state)
+    /// atomically where the provider supports transactions.
+    /// </summary>
+    Task CompleteIngestionRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string normalizedSourceKey,
+        bool succeeded,
+        string? error,
+        StagedVulnerabilityMergeSummary vulnerabilityMergeSummary,
+        StagedAssetMergeSummary assetMergeSummary,
+        int deactivatedMachineCount,
+        string? failureStatus,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    );
+}

--- a/src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs
@@ -222,6 +222,29 @@ internal sealed class InMemoryIngestionBulkWriter(PatchHoundDbContext db) : IIng
         await db.SaveChangesAsync(ct);
     }
 
+    public async Task<int> RefreshDeviceActivityAsync(Guid tenantId, TimeSpan inactiveThreshold, CancellationToken ct)
+    {
+        var cutoff = DateTimeOffset.UtcNow.Subtract(inactiveThreshold);
+        var devices = await db.Devices
+            .IgnoreQueryFilters()
+            .Where(d => d.TenantId == tenantId)
+            .ToListAsync(ct);
+
+        var deactivatedCount = 0;
+        foreach (var device in devices)
+        {
+            var isActive = device.LastSeenAt.HasValue && device.LastSeenAt.Value >= cutoff;
+            device.SetActiveInTenant(isActive);
+            if (!isActive)
+            {
+                deactivatedCount++;
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        return deactivatedCount;
+    }
+
     public async Task FinalizeAbortedRunAsync(
         Guid runId,
         Guid tenantId,

--- a/src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/InMemoryIngestionBulkWriter.cs
@@ -1,0 +1,341 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+/// <summary>
+/// Test/InMemory implementation of <see cref="IIngestionBulkWriter"/> that uses
+/// load + mutate + <c>SaveChangesAsync</c> because the InMemory provider does not
+/// support <c>ExecuteDeleteAsync</c> / <c>ExecuteUpdateAsync</c>.
+/// </summary>
+internal sealed class InMemoryIngestionBulkWriter(PatchHoundDbContext db) : IIngestionBulkWriter
+{
+    public async Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct)
+    {
+        var stagedExposures = await db
+            .StagedVulnerabilityExposures.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ToListAsync(ct);
+        var stagedVulnerabilities = await db
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ToListAsync(ct);
+        var stagedSoftwareLinks = await db
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ToListAsync(ct);
+        var stagedDevices = await db
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ToListAsync(ct);
+
+        db.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
+        db.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
+        db.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
+        db.StagedDevices.RemoveRange(stagedDevices);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<IngestionArtifactCleanupSummary> CleanupExpiredArtifactsAsync(
+        IReadOnlyList<Guid> expiredRunIds,
+        CancellationToken ct
+    )
+    {
+        var stagedExposures = await db
+            .StagedVulnerabilityExposures.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ToListAsync(ct);
+        var stagedVulnerabilities = await db
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ToListAsync(ct);
+        var stagedSoftwareLinks = await db
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ToListAsync(ct);
+        var stagedDeviceRows = await db
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ToListAsync(ct);
+        var checkpoints = await db
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ToListAsync(ct);
+        var runs = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.Id))
+            .ToListAsync(ct);
+
+        db.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
+        db.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
+        db.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
+        db.StagedDevices.RemoveRange(stagedDeviceRows);
+        db.IngestionCheckpoints.RemoveRange(checkpoints);
+        db.IngestionRuns.RemoveRange(runs);
+        await db.SaveChangesAsync(ct);
+
+        return new IngestionArtifactCleanupSummary(
+            runs.Count,
+            stagedVulnerabilities.Count,
+            stagedExposures.Count,
+            stagedDeviceRows.Count,
+            stagedSoftwareLinks.Count
+        );
+    }
+
+    public async Task CleanupSnapshotDataAsync(Guid snapshotId, CancellationToken ct)
+    {
+        var tenantSoftware = await db
+            .SoftwareTenantRecords.IgnoreQueryFilters()
+            .Where(item => item.SnapshotId == snapshotId)
+            .ToListAsync(ct);
+        var installations = await db
+            .SoftwareProductInstallations.IgnoreQueryFilters()
+            .Where(item => item.SnapshotId == snapshotId)
+            .ToListAsync(ct);
+
+        db.SoftwareTenantRecords.RemoveRange(tenantSoftware);
+        db.SoftwareProductInstallations.RemoveRange(installations);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task ReleaseIngestionLeaseAsync(
+        Guid tenantId,
+        string normalizedSourceKey,
+        Guid runId,
+        CancellationToken ct
+    )
+    {
+        var source = await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+        if (source is null)
+        {
+            return;
+        }
+
+        source.ReleaseLease(runId);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateIngestionRunStatusAsync(Guid runId, string status, CancellationToken ct)
+    {
+        var run = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item => item.Id == runId, ct);
+        run?.UpdateStatus(status);
+        if (run is not null)
+        {
+            db.IngestionRuns.Update(run);
+            await db.SaveChangesAsync(ct);
+        }
+    }
+
+    public async Task UpdateVulnerabilityMergeProgressAsync(
+        Guid ingestionRunId,
+        int stagedVulnerabilityCount,
+        int persistedVulnerabilityCount,
+        CancellationToken ct
+    )
+    {
+        var run = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item => item.Id == ingestionRunId, ct);
+        if (run is null)
+        {
+            return;
+        }
+
+        run.UpdateVulnerabilityMergeProgress(stagedVulnerabilityCount, persistedVulnerabilityCount);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateAssetMergeProgressAsync(
+        Guid ingestionRunId,
+        int stagedMachineCount,
+        int stagedSoftwareCount,
+        int persistedMachineCount,
+        int persistedSoftwareCount,
+        CancellationToken ct
+    )
+    {
+        var run = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item => item.Id == ingestionRunId, ct);
+        if (run is null)
+        {
+            return;
+        }
+
+        run.UpdateAssetMergeProgress(
+            stagedMachineCount,
+            stagedSoftwareCount,
+            persistedMachineCount,
+            0,
+            persistedSoftwareCount
+        );
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateRuntimeStateAsync(
+        Guid tenantId,
+        string normalizedSourceKey,
+        Action<TenantIngestionRuntimeState> update,
+        CancellationToken ct
+    )
+    {
+        var trackedSource = await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+
+        if (trackedSource is null)
+        {
+            return;
+        }
+
+        var runtime = new TenantIngestionRuntimeState(
+            trackedSource.ManualRequestedAt,
+            trackedSource.LastStartedAt,
+            trackedSource.LastCompletedAt,
+            trackedSource.LastSucceededAt,
+            trackedSource.LastStatus,
+            trackedSource.LastError
+        );
+        update(runtime);
+
+        trackedSource.UpdateRuntime(
+            runtime.ManualRequestedAt,
+            runtime.LastStartedAt,
+            runtime.LastCompletedAt,
+            runtime.LastSucceededAt,
+            runtime.LastStatus,
+            runtime.LastError
+        );
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task FinalizeAbortedRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string normalizedSourceKey,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    )
+    {
+        var run = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item => item.Id == runId, ct);
+
+        if (
+            run is null
+            || run.CompletedAt.HasValue
+            || !run.AbortRequestedAt.HasValue
+            || !IngestionRunStatePolicy.IsActive(run.Status)
+        )
+        {
+            return;
+        }
+
+        db.Entry(run).Property(nameof(IngestionRun.CompletedAt)).CurrentValue = completedAt;
+        db.Entry(run).Property(nameof(IngestionRun.Status)).CurrentValue = IngestionRunStatuses.FailedTerminal;
+        db.Entry(run).Property(nameof(IngestionRun.Error)).CurrentValue =
+            IngestionFailurePolicy.Describe(new IngestionAbortedException());
+
+        var source = await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item =>
+                    item.TenantId == tenantId
+                    && item.SourceKey == normalizedSourceKey
+                    && item.ActiveIngestionRunId == runId,
+                ct
+            );
+        source?.ReleaseLease(runId);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task CompleteIngestionRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string normalizedSourceKey,
+        bool succeeded,
+        string? error,
+        StagedVulnerabilityMergeSummary vulnerabilityMergeSummary,
+        StagedAssetMergeSummary assetMergeSummary,
+        int deactivatedMachineCount,
+        string? failureStatus,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    )
+    {
+        var run = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item => item.Id == runId, ct);
+        if (run is null)
+        {
+            return;
+        }
+
+        if (succeeded)
+        {
+            run.CompleteSucceeded(
+                completedAt,
+                assetMergeSummary.StagedMachineCount,
+                assetMergeSummary.StagedSoftwareCount,
+                vulnerabilityMergeSummary.StagedVulnerabilityCount,
+                assetMergeSummary.PersistedMachineCount,
+                deactivatedMachineCount,
+                assetMergeSummary.PersistedSoftwareCount,
+                vulnerabilityMergeSummary.PersistedVulnerabilityCount
+            );
+        }
+        else
+        {
+            run.CompleteFailed(
+                completedAt,
+                error ?? "Unknown ingestion failure",
+                failureStatus ?? IngestionRunStatuses.FailedRecoverable,
+                assetMergeSummary.StagedMachineCount,
+                assetMergeSummary.StagedSoftwareCount,
+                vulnerabilityMergeSummary.StagedVulnerabilityCount,
+                assetMergeSummary.PersistedMachineCount,
+                deactivatedMachineCount,
+                assetMergeSummary.PersistedSoftwareCount,
+                vulnerabilityMergeSummary.PersistedVulnerabilityCount
+            );
+        }
+
+        var source = await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item =>
+                    item.TenantId == tenantId
+                    && item.SourceKey == normalizedSourceKey
+                    && item.ActiveIngestionRunId == runId,
+                ct
+            );
+        if (source is not null)
+        {
+            source.ReleaseLease(runId);
+            source.UpdateRuntime(
+                source.ManualRequestedAt,
+                source.LastStartedAt,
+                completedAt,
+                succeeded ? completedAt : source.LastSucceededAt,
+                succeeded
+                    ? IngestionRunStatuses.Succeeded
+                    : failureStatus ?? IngestionRunStatuses.FailedRecoverable,
+                succeeded ? string.Empty : error ?? "Unknown ingestion failure"
+            );
+        }
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/IngestionCheckpointWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionCheckpointWriter.cs
@@ -1,0 +1,82 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class IngestionCheckpointWriter(PatchHoundDbContext dbContext)
+{
+    public async Task<bool> IsCheckpointCompletedAsync(
+        Guid ingestionRunId,
+        string phase,
+        CancellationToken ct
+    )
+    {
+        return await dbContext
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .AnyAsync(
+                item =>
+                    item.IngestionRunId == ingestionRunId
+                    && item.Phase == phase
+                    && item.Status == CheckpointStatuses.Completed,
+                ct
+            );
+    }
+
+    public async Task<int> GetCheckpointBatchNumberAsync(
+        Guid ingestionRunId,
+        string phase,
+        CancellationToken ct
+    )
+    {
+        return await dbContext
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId && item.Phase == phase)
+            .Select(item => item.BatchNumber)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task CommitCheckpointAsync(
+        Guid ingestionRunId,
+        Guid tenantId,
+        string sourceKey,
+        string phase,
+        int batchNumber,
+        string? cursorJson,
+        int recordsCommitted,
+        string status,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var checkpoint = await dbContext
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item => item.IngestionRunId == ingestionRunId && item.Phase == phase,
+                ct
+            );
+
+        if (checkpoint is null)
+        {
+            checkpoint = IngestionCheckpoint.Start(
+                ingestionRunId,
+                tenantId,
+                normalizedSourceKey,
+                phase,
+                DateTimeOffset.UtcNow
+            );
+            await dbContext.IngestionCheckpoints.AddAsync(checkpoint, ct);
+        }
+
+        checkpoint.CommitBatch(
+            batchNumber,
+            cursorJson,
+            recordsCommitted,
+            status,
+            DateTimeOffset.UtcNow
+        );
+
+        await dbContext.SaveChangesAsync(ct);
+        dbContext.ChangeTracker.Clear();
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
@@ -16,13 +16,27 @@ public class IngestionLeaseManager
     private static readonly TimeSpan FailedIngestionRetention = TimeSpan.FromHours(24);
 
     private readonly PatchHoundDbContext _dbContext;
+    private readonly IIngestionBulkWriter _bulkWriter;
     private readonly ILogger<IngestionLeaseManager> _logger;
 
     public IngestionLeaseManager(PatchHoundDbContext dbContext, ILogger<IngestionLeaseManager> logger)
+        : this(dbContext, CreateBulkWriter(dbContext), logger) { }
+
+    internal IngestionLeaseManager(
+        PatchHoundDbContext dbContext,
+        IIngestionBulkWriter bulkWriter,
+        ILogger<IngestionLeaseManager> logger
+    )
     {
         _dbContext = dbContext;
+        _bulkWriter = bulkWriter;
         _logger = logger;
     }
+
+    private static IIngestionBulkWriter CreateBulkWriter(PatchHoundDbContext db) =>
+        db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
+            ? new InMemoryIngestionBulkWriter(db)
+            : new PostgresIngestionBulkWriter(db);
 
     internal async Task<AcquiredIngestionRun?> TryAcquireIngestionRunAsync(
         Guid tenantId,
@@ -36,7 +50,7 @@ public class IngestionLeaseManager
 
         return await strategy.ExecuteAsync(async () =>
         {
-            if (IsInMemoryProvider())
+            if (_dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
             {
                 var sourceConfiguration = await _dbContext
                     .TenantSourceConfigurations.IgnoreQueryFilters()
@@ -209,79 +223,7 @@ public class IngestionLeaseManager
     )
     {
         var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-
-        if (IsInMemoryProvider())
-        {
-            var run = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == runId, ct);
-
-            if (
-                run is null
-                || run.CompletedAt.HasValue
-                || !run.AbortRequestedAt.HasValue
-                || !IngestionRunStatePolicy.IsActive(run.Status)
-            )
-            {
-                return;
-            }
-
-            _dbContext.Entry(run).Property(nameof(IngestionRun.CompletedAt)).CurrentValue =
-                completedAt;
-            _dbContext.Entry(run).Property(nameof(IngestionRun.Status)).CurrentValue =
-                IngestionRunStatuses.FailedTerminal;
-            _dbContext.Entry(run).Property(nameof(IngestionRun.Error)).CurrentValue =
-                IngestionFailurePolicy.Describe(new IngestionAbortedException());
-            var source = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item =>
-                        item.TenantId == tenantId
-                        && item.SourceKey == normalizedSourceKey
-                        && item.ActiveIngestionRunId == runId,
-                    ct
-                );
-            source?.ReleaseLease(runId);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item =>
-                item.Id == runId
-                && item.AbortRequestedAt != null
-                && item.CompletedAt == null
-                && (
-                    item.Status == IngestionRunStatuses.Staging
-                    || item.Status == IngestionRunStatuses.MergePending
-                    || item.Status == IngestionRunStatuses.Merging
-                ))
-            .ExecuteUpdateAsync(
-                setters => setters
-                    .SetProperty(item => item.CompletedAt, completedAt)
-                    .SetProperty(item => item.Status, IngestionRunStatuses.FailedTerminal)
-                    .SetProperty(
-                        item => item.Error,
-                        IngestionFailurePolicy.Describe(new IngestionAbortedException())
-                    ),
-                ct
-            );
-
-        await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.SourceKey == normalizedSourceKey
-                && item.ActiveIngestionRunId == runId)
-            .ExecuteUpdateAsync(
-                setters =>
-                    setters
-                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
-                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
-                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
-                ct
-            );
+        await _bulkWriter.FinalizeAbortedRunAsync(runId, tenantId, normalizedSourceKey, completedAt, ct);
     }
 
     public async Task ThrowIfAbortRequestedAsync(Guid runId, CancellationToken ct)
@@ -315,102 +257,12 @@ public class IngestionLeaseManager
             return;
         }
 
-        if (IsInMemoryProvider())
-        {
-            var trackedSource = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                    ct
-                );
-
-            if (trackedSource is null)
-            {
-                return;
-            }
-
-            var runtime = new TenantIngestionRuntimeState(
-                trackedSource.ManualRequestedAt,
-                trackedSource.LastStartedAt,
-                trackedSource.LastCompletedAt,
-                trackedSource.LastSucceededAt,
-                trackedSource.LastStatus,
-                trackedSource.LastError
-            );
-            update(runtime);
-
-            trackedSource.UpdateRuntime(
-                runtime.ManualRequestedAt,
-                runtime.LastStartedAt,
-                runtime.LastCompletedAt,
-                runtime.LastSucceededAt,
-                runtime.LastStatus,
-                runtime.LastError
-            );
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        var source = await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(
-                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                ct
-            );
-
-        if (source is null)
-        {
-            return;
-        }
-
-        var detachedRuntime = new TenantIngestionRuntimeState(
-            source.ManualRequestedAt,
-            source.LastStartedAt,
-            source.LastCompletedAt,
-            source.LastSucceededAt,
-            source.LastStatus,
-            source.LastError
-        );
-        update(detachedRuntime);
-
-        await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
-            .ExecuteUpdateAsync(
-                setters =>
-                    setters
-                        .SetProperty(item => item.ManualRequestedAt, detachedRuntime.ManualRequestedAt)
-                        .SetProperty(item => item.LastStartedAt, detachedRuntime.LastStartedAt)
-                        .SetProperty(item => item.LastCompletedAt, detachedRuntime.LastCompletedAt)
-                        .SetProperty(item => item.LastSucceededAt, detachedRuntime.LastSucceededAt)
-                        .SetProperty(item => item.LastStatus, detachedRuntime.LastStatus)
-                        .SetProperty(item => item.LastError, detachedRuntime.LastError),
-                ct
-            );
+        await _bulkWriter.UpdateRuntimeStateAsync(tenantId, normalizedSourceKey, update, ct);
     }
 
     public async Task UpdateIngestionRunStatusAsync(Guid runId, string status, CancellationToken ct)
     {
-        if (IsInMemoryProvider())
-        {
-            var run = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == runId, ct);
-            run?.UpdateStatus(status);
-            if (run is not null)
-            {
-                _dbContext.IngestionRuns.Update(run);
-                await _dbContext.SaveChangesAsync(ct);
-            }
-
-            return;
-        }
-
-        await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item => item.Id == runId)
-            .ExecuteUpdateAsync(setters => setters.SetProperty(item => item.Status, status), ct);
+        await _bulkWriter.UpdateIngestionRunStatusAsync(runId, status, ct);
     }
 
     public async Task UpdateActiveRunStatusAsync(
@@ -445,196 +297,24 @@ public class IngestionLeaseManager
     {
         var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
         var completedAt = DateTimeOffset.UtcNow;
-        if (IsInMemoryProvider())
-        {
-            var run = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == runId, ct);
-            if (run is null)
-            {
-                return;
-            }
 
-            if (succeeded)
-            {
-                run.CompleteSucceeded(
-                    completedAt,
-                    assetMergeSummary.StagedMachineCount,
-                    assetMergeSummary.StagedSoftwareCount,
-                    vulnerabilityMergeSummary.StagedVulnerabilityCount,
-                    assetMergeSummary.PersistedMachineCount,
-                    deactivatedMachineCount,
-                    assetMergeSummary.PersistedSoftwareCount,
-                    vulnerabilityMergeSummary.PersistedVulnerabilityCount
-                );
-            }
-            else
-            {
-                run.CompleteFailed(
-                    completedAt,
-                    error ?? "Unknown ingestion failure",
-                    failureStatus ?? IngestionRunStatuses.FailedRecoverable,
-                    assetMergeSummary.StagedMachineCount,
-                    assetMergeSummary.StagedSoftwareCount,
-                    vulnerabilityMergeSummary.StagedVulnerabilityCount,
-                    assetMergeSummary.PersistedMachineCount,
-                    deactivatedMachineCount,
-                    assetMergeSummary.PersistedSoftwareCount,
-                    vulnerabilityMergeSummary.PersistedVulnerabilityCount
-                );
-            }
-
-            var source = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item =>
-                        item.TenantId == tenantId
-                        && item.SourceKey == normalizedSourceKey
-                        && item.ActiveIngestionRunId == runId,
-                    ct
-                );
-            if (source is not null)
-            {
-                source.ReleaseLease(runId);
-                source.UpdateRuntime(
-                    source.ManualRequestedAt,
-                    source.LastStartedAt,
-                    completedAt,
-                    succeeded ? completedAt : source.LastSucceededAt,
-                    succeeded
-                        ? IngestionRunStatuses.Succeeded
-                        : failureStatus ?? IngestionRunStatuses.FailedRecoverable,
-                    succeeded ? string.Empty : error ?? "Unknown ingestion failure"
-                );
-            }
-            await _dbContext.SaveChangesAsync(ct);
-
-            if (succeeded)
-            {
-                await ClearStagedDataForRunAsync(runId, ct);
-            }
-
-            var inMemoryCleanupSummary = await CleanupExpiredIngestionArtifactsAsync(
-                completedAt,
-                ct
-            );
-            if (inMemoryCleanupSummary.PrunedRunCount > 0)
-            {
-                _logger.LogInformation(
-                    "Pruned ingestion artifacts: runs={PrunedRunCount} stagedVulnerabilities={PrunedVulnerabilityCount} stagedExposures={PrunedExposureCount} stagedAssets={PrunedAssetCount} stagedSoftwareLinks={PrunedSoftwareLinkCount}",
-                    inMemoryCleanupSummary.PrunedRunCount,
-                    inMemoryCleanupSummary.PrunedVulnerabilityCount,
-                    inMemoryCleanupSummary.PrunedExposureCount,
-                    inMemoryCleanupSummary.PrunedAssetCount,
-                    inMemoryCleanupSummary.PrunedSoftwareLinkCount
-                );
-            }
-            return;
-        }
-
-        var strategy = _dbContext.Database.CreateExecutionStrategy();
-
-        await strategy.ExecuteAsync(async () =>
-        {
-            await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
-
-            var updatedRunRows = succeeded
-                ? await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .Where(item => item.Id == runId)
-                    .ExecuteUpdateAsync(
-                        setters =>
-                            setters
-                                .SetProperty(item => item.CompletedAt, completedAt)
-                                .SetProperty(item => item.Status, IngestionRunStatuses.Succeeded)
-                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
-                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
-                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
-                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
-                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
-                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
-                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
-                                .SetProperty(item => item.Error, string.Empty),
-                        ct
-                    )
-                : await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .Where(item => item.Id == runId)
-                    .ExecuteUpdateAsync(
-                        setters =>
-                            setters
-                                .SetProperty(item => item.CompletedAt, completedAt)
-                                .SetProperty(item => item.Status, failureStatus ?? IngestionRunStatuses.FailedRecoverable)
-                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
-                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
-                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
-                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
-                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
-                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
-                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
-                                .SetProperty(
-                                    item => item.Error,
-                                    error ?? "Unknown ingestion failure"
-                                ),
-                        ct
-                    );
-
-            if (updatedRunRows == 0)
-            {
-                _logger.LogWarning(
-                    "Expected to complete ingestion run {RunId} for tenant {TenantId} and source {SourceKey}, but no run row was updated.",
-                    runId,
-                    tenantId,
-                    normalizedSourceKey
-                );
-            }
-
-            await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .Where(item =>
-                    item.TenantId == tenantId
-                    && item.SourceKey == normalizedSourceKey
-                    && item.ActiveIngestionRunId == runId
-                )
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
-                            .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
-                            .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
-                    ct
-                );
-
-            await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(item => item.LastCompletedAt, completedAt)
-                            .SetProperty(
-                                item => item.LastSucceededAt,
-                                item => succeeded ? completedAt : item.LastSucceededAt
-                            )
-                            .SetProperty(
-                                item => item.LastStatus,
-                                succeeded
-                                    ? IngestionRunStatuses.Succeeded
-                                    : failureStatus ?? IngestionRunStatuses.FailedRecoverable
-                            )
-                            .SetProperty(
-                                item => item.LastError,
-                                succeeded ? string.Empty : error ?? "Unknown ingestion failure"
-                            ),
-                    ct
-                );
-
-            await transaction.CommitAsync(ct);
-        });
+        await _bulkWriter.CompleteIngestionRunAsync(
+            runId,
+            tenantId,
+            normalizedSourceKey,
+            succeeded,
+            error,
+            vulnerabilityMergeSummary,
+            assetMergeSummary,
+            deactivatedMachineCount,
+            failureStatus,
+            completedAt,
+            ct
+        );
 
         if (succeeded)
         {
-            await ClearStagedDataForRunAsync(runId, ct);
+            await _bulkWriter.ClearStagedDataForRunAsync(runId, ct);
         }
 
         var cleanupSummary = await CleanupExpiredIngestionArtifactsAsync(completedAt, ct);
@@ -679,82 +359,7 @@ public class IngestionLeaseManager
             return new IngestionArtifactCleanupSummary(0, 0, 0, 0, 0);
         }
 
-        if (IsInMemoryProvider())
-        {
-            var stagedExposures = await _dbContext
-                .StagedVulnerabilityExposures.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var stagedVulnerabilities = await _dbContext
-                .StagedVulnerabilities.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var stagedSoftwareLinks = await _dbContext
-                .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var stagedDeviceRows = await _dbContext
-                .StagedDevices.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var checkpoints = await _dbContext
-                .IngestionCheckpoints.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var runs = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.Id))
-                .ToListAsync(ct);
-
-            _dbContext.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
-            _dbContext.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
-            _dbContext.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
-            _dbContext.StagedDevices.RemoveRange(stagedDeviceRows);
-            _dbContext.IngestionCheckpoints.RemoveRange(checkpoints);
-            _dbContext.IngestionRuns.RemoveRange(runs);
-            await _dbContext.SaveChangesAsync(ct);
-
-            return new IngestionArtifactCleanupSummary(
-                runs.Count,
-                stagedVulnerabilities.Count,
-                stagedExposures.Count,
-                stagedDeviceRows.Count,
-                stagedSoftwareLinks.Count
-            );
-        }
-
-        var prunedExposureCount = await _dbContext
-            .StagedVulnerabilityExposures.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedVulnerabilityCount = await _dbContext
-            .StagedVulnerabilities.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedSoftwareLinkCount = await _dbContext
-            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedAssetCount = await _dbContext
-            .StagedDevices.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedRunCount = await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.Id))
-            .ExecuteDeleteAsync(ct);
-
-        return new IngestionArtifactCleanupSummary(
-            prunedRunCount,
-            prunedVulnerabilityCount,
-            prunedExposureCount,
-            prunedAssetCount,
-            prunedSoftwareLinkCount
-        );
+        return await _bulkWriter.CleanupExpiredArtifactsAsync(expiredRunIds, ct);
     }
 
     public async Task ReleaseIngestionLeaseAsync(
@@ -765,94 +370,6 @@ public class IngestionLeaseManager
     )
     {
         var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        if (IsInMemoryProvider())
-        {
-            var source = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                    ct
-                );
-            if (source is null)
-            {
-                return;
-            }
-
-            source.ReleaseLease(runId);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.SourceKey == normalizedSourceKey
-                && item.ActiveIngestionRunId == runId
-            )
-            .ExecuteUpdateAsync(
-                setters =>
-                    setters
-                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
-                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
-                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
-                ct
-            );
-    }
-
-    private async Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct)
-    {
-        if (IsInMemoryProvider())
-        {
-            var stagedExposures = await _dbContext
-                .StagedVulnerabilityExposures.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-            var stagedVulnerabilities = await _dbContext
-                .StagedVulnerabilities.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-            var stagedSoftwareLinks = await _dbContext
-                .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-            var stagedDevices = await _dbContext
-                .StagedDevices.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-
-            _dbContext.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
-            _dbContext.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
-            _dbContext.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
-            _dbContext.StagedDevices.RemoveRange(stagedDevices);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .StagedVulnerabilityExposures.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .StagedVulnerabilities.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .StagedDevices.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-    }
-
-    private bool IsInMemoryProvider()
-    {
-        return string.Equals(
-            _dbContext.Database.ProviderName,
-            "Microsoft.EntityFrameworkCore.InMemory",
-            StringComparison.Ordinal
-        );
+        await _bulkWriter.ReleaseIngestionLeaseAsync(tenantId, normalizedSourceKey, runId, ct);
     }
 }

--- a/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
@@ -1,0 +1,858 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+internal sealed record AcquiredIngestionRun(IngestionRun Run, bool Resumed);
+
+public class IngestionLeaseManager
+{
+    private const int MaxPersistenceAttempts = 2;
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan IngestionArtifactRetention = TimeSpan.FromDays(7);
+    private static readonly TimeSpan FailedIngestionRetention = TimeSpan.FromHours(24);
+
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly ILogger<IngestionLeaseManager> _logger;
+
+    public IngestionLeaseManager(PatchHoundDbContext dbContext, ILogger<IngestionLeaseManager> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    internal async Task<AcquiredIngestionRun?> TryAcquireIngestionRunAsync(
+        Guid tenantId,
+        string sourceKey,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var now = DateTimeOffset.UtcNow;
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            if (IsInMemoryProvider())
+            {
+                var sourceConfiguration = await _dbContext
+                    .TenantSourceConfigurations.IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(
+                        item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                        ct
+                    );
+
+                if (sourceConfiguration is null)
+                {
+                    return null;
+                }
+
+                if (sourceConfiguration.ActiveIngestionRunId.HasValue)
+                {
+                    await FinalizeAbortedRunIfPendingAsync(
+                        sourceConfiguration.ActiveIngestionRunId.Value,
+                        tenantId,
+                        normalizedSourceKey,
+                        now,
+                        ct
+                    );
+                    await _dbContext.Entry(sourceConfiguration).ReloadAsync(ct);
+                }
+
+                if (
+                    sourceConfiguration.ActiveIngestionRunId.HasValue
+                    && sourceConfiguration.LeaseExpiresAt >= now
+                )
+                {
+                    return null;
+                }
+
+                IngestionRun? resumableRun = null;
+                if (sourceConfiguration.ActiveIngestionRunId.HasValue)
+                {
+                    resumableRun = await _dbContext
+                        .IngestionRuns.IgnoreQueryFilters()
+                        .FirstOrDefaultAsync(
+                            item =>
+                                item.Id == sourceConfiguration.ActiveIngestionRunId.Value
+                                && item.AbortRequestedAt == null
+                                && (
+                                    item.Status == IngestionRunStatuses.Staging
+                                    || item.Status == IngestionRunStatuses.MergePending
+                                    || item.Status == IngestionRunStatuses.Merging
+                                )
+                                && !item.CompletedAt.HasValue,
+                            ct
+                        );
+                }
+
+                var resumed = resumableRun is not null;
+                var run = resumableRun ?? IngestionRun.Start(tenantId, normalizedSourceKey, now);
+                sourceConfiguration.AcquireLease(run.Id, now, now.Add(LeaseDuration));
+                if (!resumed)
+                {
+                    await _dbContext.IngestionRuns.AddAsync(run, ct);
+                }
+
+                await _dbContext.SaveChangesAsync(ct);
+                return new AcquiredIngestionRun(run, resumed);
+            }
+
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
+
+            var persistedSourceConfiguration = await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(
+                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                    ct
+                );
+
+            if (persistedSourceConfiguration is null)
+            {
+                await transaction.RollbackAsync(ct);
+                return null;
+            }
+
+            if (persistedSourceConfiguration.ActiveIngestionRunId.HasValue)
+            {
+                await FinalizeAbortedRunIfPendingAsync(
+                    persistedSourceConfiguration.ActiveIngestionRunId.Value,
+                    tenantId,
+                    normalizedSourceKey,
+                    now,
+                    ct
+                );
+                persistedSourceConfiguration = await _dbContext
+                    .TenantSourceConfigurations.IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(
+                        item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                        ct
+                    );
+
+                if (persistedSourceConfiguration is null)
+                {
+                    await transaction.RollbackAsync(ct);
+                    return null;
+                }
+            }
+
+            if (
+                persistedSourceConfiguration.ActiveIngestionRunId.HasValue
+                && persistedSourceConfiguration.LeaseExpiresAt >= now
+            )
+            {
+                await transaction.RollbackAsync(ct);
+                return null;
+            }
+
+            IngestionRun? resumable = null;
+            if (persistedSourceConfiguration.ActiveIngestionRunId.HasValue)
+            {
+                resumable = await _dbContext
+                    .IngestionRuns.IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(
+                        item =>
+                            item.Id == persistedSourceConfiguration.ActiveIngestionRunId.Value
+                            && item.AbortRequestedAt == null
+                            && (
+                                item.Status == IngestionRunStatuses.Staging
+                                || item.Status == IngestionRunStatuses.MergePending
+                                || item.Status == IngestionRunStatuses.Merging
+                            )
+                            && !item.CompletedAt.HasValue,
+                        ct
+                    );
+            }
+
+            var resumedRun = resumable is not null;
+            var acquiredRun = resumable ?? IngestionRun.Start(tenantId, normalizedSourceKey, now);
+
+            var updatedRows = await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .Where(item => item.Id == persistedSourceConfiguration.Id)
+                .ExecuteUpdateAsync(
+                    setters =>
+                        setters
+                            .SetProperty(item => item.ActiveIngestionRunId, acquiredRun.Id)
+                            .SetProperty(item => item.LeaseAcquiredAt, now)
+                            .SetProperty(item => item.LeaseExpiresAt, now.Add(LeaseDuration)),
+                    ct
+                );
+
+            if (updatedRows == 0)
+            {
+                await transaction.RollbackAsync(ct);
+                return null;
+            }
+
+            if (!resumedRun)
+            {
+                await _dbContext.IngestionRuns.AddAsync(acquiredRun, ct);
+            }
+
+            await _dbContext.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+
+            return new AcquiredIngestionRun(acquiredRun, resumedRun);
+        });
+    }
+
+    public async Task FinalizeAbortedRunIfPendingAsync(
+        Guid runId,
+        Guid tenantId,
+        string sourceKey,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+
+        if (IsInMemoryProvider())
+        {
+            var run = await _dbContext
+                .IngestionRuns.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(item => item.Id == runId, ct);
+
+            if (
+                run is null
+                || run.CompletedAt.HasValue
+                || !run.AbortRequestedAt.HasValue
+                || !IngestionRunStatePolicy.IsActive(run.Status)
+            )
+            {
+                return;
+            }
+
+            _dbContext.Entry(run).Property(nameof(IngestionRun.CompletedAt)).CurrentValue =
+                completedAt;
+            _dbContext.Entry(run).Property(nameof(IngestionRun.Status)).CurrentValue =
+                IngestionRunStatuses.FailedTerminal;
+            _dbContext.Entry(run).Property(nameof(IngestionRun.Error)).CurrentValue =
+                IngestionFailurePolicy.Describe(new IngestionAbortedException());
+            var source = await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(
+                    item =>
+                        item.TenantId == tenantId
+                        && item.SourceKey == normalizedSourceKey
+                        && item.ActiveIngestionRunId == runId,
+                    ct
+                );
+            source?.ReleaseLease(runId);
+            await _dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
+        await _dbContext
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item =>
+                item.Id == runId
+                && item.AbortRequestedAt != null
+                && item.CompletedAt == null
+                && (
+                    item.Status == IngestionRunStatuses.Staging
+                    || item.Status == IngestionRunStatuses.MergePending
+                    || item.Status == IngestionRunStatuses.Merging
+                ))
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(item => item.CompletedAt, completedAt)
+                    .SetProperty(item => item.Status, IngestionRunStatuses.FailedTerminal)
+                    .SetProperty(
+                        item => item.Error,
+                        IngestionFailurePolicy.Describe(new IngestionAbortedException())
+                    ),
+                ct
+            );
+
+        await _dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .Where(item =>
+                item.TenantId == tenantId
+                && item.SourceKey == normalizedSourceKey
+                && item.ActiveIngestionRunId == runId)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
+                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
+                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
+                ct
+            );
+    }
+
+    public async Task ThrowIfAbortRequestedAsync(Guid runId, CancellationToken ct)
+    {
+        var abortRequestedAt = await _dbContext
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => item.Id == runId)
+            .Select(item => item.AbortRequestedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (abortRequestedAt.HasValue)
+        {
+            _dbContext.ChangeTracker.Clear();
+            throw new IngestionAbortedException();
+        }
+    }
+
+    internal async Task UpdateRuntimeStateAsync(
+        Guid tenantId,
+        string sourceKey,
+        Action<TenantIngestionRuntimeState> update,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var tenant = await _dbContext
+            .Tenants.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId, ct);
+        if (tenant is null)
+        {
+            return;
+        }
+
+        if (IsInMemoryProvider())
+        {
+            var trackedSource = await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(
+                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                    ct
+                );
+
+            if (trackedSource is null)
+            {
+                return;
+            }
+
+            var runtime = new TenantIngestionRuntimeState(
+                trackedSource.ManualRequestedAt,
+                trackedSource.LastStartedAt,
+                trackedSource.LastCompletedAt,
+                trackedSource.LastSucceededAt,
+                trackedSource.LastStatus,
+                trackedSource.LastError
+            );
+            update(runtime);
+
+            trackedSource.UpdateRuntime(
+                runtime.ManualRequestedAt,
+                runtime.LastStartedAt,
+                runtime.LastCompletedAt,
+                runtime.LastSucceededAt,
+                runtime.LastStatus,
+                runtime.LastError
+            );
+            await _dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
+        var source = await _dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+
+        if (source is null)
+        {
+            return;
+        }
+
+        var detachedRuntime = new TenantIngestionRuntimeState(
+            source.ManualRequestedAt,
+            source.LastStartedAt,
+            source.LastCompletedAt,
+            source.LastSucceededAt,
+            source.LastStatus,
+            source.LastError
+        );
+        update(detachedRuntime);
+
+        await _dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.ManualRequestedAt, detachedRuntime.ManualRequestedAt)
+                        .SetProperty(item => item.LastStartedAt, detachedRuntime.LastStartedAt)
+                        .SetProperty(item => item.LastCompletedAt, detachedRuntime.LastCompletedAt)
+                        .SetProperty(item => item.LastSucceededAt, detachedRuntime.LastSucceededAt)
+                        .SetProperty(item => item.LastStatus, detachedRuntime.LastStatus)
+                        .SetProperty(item => item.LastError, detachedRuntime.LastError),
+                ct
+            );
+    }
+
+    public async Task UpdateIngestionRunStatusAsync(Guid runId, string status, CancellationToken ct)
+    {
+        if (IsInMemoryProvider())
+        {
+            var run = await _dbContext
+                .IngestionRuns.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(item => item.Id == runId, ct);
+            run?.UpdateStatus(status);
+            if (run is not null)
+            {
+                _dbContext.IngestionRuns.Update(run);
+                await _dbContext.SaveChangesAsync(ct);
+            }
+
+            return;
+        }
+
+        await _dbContext
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => item.Id == runId)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(item => item.Status, status), ct);
+    }
+
+    public async Task UpdateActiveRunStatusAsync(
+        Guid runId,
+        Guid tenantId,
+        string sourceKey,
+        string status,
+        CancellationToken ct
+    )
+    {
+        await UpdateIngestionRunStatusAsync(runId, status, ct);
+        await UpdateRuntimeStateAsync(
+            tenantId,
+            sourceKey,
+            runtime => runtime.LastStatus = status,
+            ct
+        );
+    }
+
+    internal async Task CompleteIngestionRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string sourceKey,
+        bool succeeded,
+        string? error,
+        StagedVulnerabilityMergeSummary vulnerabilityMergeSummary,
+        StagedAssetMergeSummary assetMergeSummary,
+        int deactivatedMachineCount,
+        string? failureStatus,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var completedAt = DateTimeOffset.UtcNow;
+        if (IsInMemoryProvider())
+        {
+            var run = await _dbContext
+                .IngestionRuns.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(item => item.Id == runId, ct);
+            if (run is null)
+            {
+                return;
+            }
+
+            if (succeeded)
+            {
+                run.CompleteSucceeded(
+                    completedAt,
+                    assetMergeSummary.StagedMachineCount,
+                    assetMergeSummary.StagedSoftwareCount,
+                    vulnerabilityMergeSummary.StagedVulnerabilityCount,
+                    assetMergeSummary.PersistedMachineCount,
+                    deactivatedMachineCount,
+                    assetMergeSummary.PersistedSoftwareCount,
+                    vulnerabilityMergeSummary.PersistedVulnerabilityCount
+                );
+            }
+            else
+            {
+                run.CompleteFailed(
+                    completedAt,
+                    error ?? "Unknown ingestion failure",
+                    failureStatus ?? IngestionRunStatuses.FailedRecoverable,
+                    assetMergeSummary.StagedMachineCount,
+                    assetMergeSummary.StagedSoftwareCount,
+                    vulnerabilityMergeSummary.StagedVulnerabilityCount,
+                    assetMergeSummary.PersistedMachineCount,
+                    deactivatedMachineCount,
+                    assetMergeSummary.PersistedSoftwareCount,
+                    vulnerabilityMergeSummary.PersistedVulnerabilityCount
+                );
+            }
+
+            var source = await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(
+                    item =>
+                        item.TenantId == tenantId
+                        && item.SourceKey == normalizedSourceKey
+                        && item.ActiveIngestionRunId == runId,
+                    ct
+                );
+            if (source is not null)
+            {
+                source.ReleaseLease(runId);
+                source.UpdateRuntime(
+                    source.ManualRequestedAt,
+                    source.LastStartedAt,
+                    completedAt,
+                    succeeded ? completedAt : source.LastSucceededAt,
+                    succeeded
+                        ? IngestionRunStatuses.Succeeded
+                        : failureStatus ?? IngestionRunStatuses.FailedRecoverable,
+                    succeeded ? string.Empty : error ?? "Unknown ingestion failure"
+                );
+            }
+            await _dbContext.SaveChangesAsync(ct);
+
+            if (succeeded)
+            {
+                await ClearStagedDataForRunAsync(runId, ct);
+            }
+
+            var inMemoryCleanupSummary = await CleanupExpiredIngestionArtifactsAsync(
+                completedAt,
+                ct
+            );
+            if (inMemoryCleanupSummary.PrunedRunCount > 0)
+            {
+                _logger.LogInformation(
+                    "Pruned ingestion artifacts: runs={PrunedRunCount} stagedVulnerabilities={PrunedVulnerabilityCount} stagedExposures={PrunedExposureCount} stagedAssets={PrunedAssetCount} stagedSoftwareLinks={PrunedSoftwareLinkCount}",
+                    inMemoryCleanupSummary.PrunedRunCount,
+                    inMemoryCleanupSummary.PrunedVulnerabilityCount,
+                    inMemoryCleanupSummary.PrunedExposureCount,
+                    inMemoryCleanupSummary.PrunedAssetCount,
+                    inMemoryCleanupSummary.PrunedSoftwareLinkCount
+                );
+            }
+            return;
+        }
+
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
+
+            var updatedRunRows = succeeded
+                ? await _dbContext
+                    .IngestionRuns.IgnoreQueryFilters()
+                    .Where(item => item.Id == runId)
+                    .ExecuteUpdateAsync(
+                        setters =>
+                            setters
+                                .SetProperty(item => item.CompletedAt, completedAt)
+                                .SetProperty(item => item.Status, IngestionRunStatuses.Succeeded)
+                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
+                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
+                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
+                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
+                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
+                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
+                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
+                                .SetProperty(item => item.Error, string.Empty),
+                        ct
+                    )
+                : await _dbContext
+                    .IngestionRuns.IgnoreQueryFilters()
+                    .Where(item => item.Id == runId)
+                    .ExecuteUpdateAsync(
+                        setters =>
+                            setters
+                                .SetProperty(item => item.CompletedAt, completedAt)
+                                .SetProperty(item => item.Status, failureStatus ?? IngestionRunStatuses.FailedRecoverable)
+                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
+                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
+                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
+                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
+                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
+                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
+                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
+                                .SetProperty(
+                                    item => item.Error,
+                                    error ?? "Unknown ingestion failure"
+                                ),
+                        ct
+                    );
+
+            if (updatedRunRows == 0)
+            {
+                _logger.LogWarning(
+                    "Expected to complete ingestion run {RunId} for tenant {TenantId} and source {SourceKey}, but no run row was updated.",
+                    runId,
+                    tenantId,
+                    normalizedSourceKey
+                );
+            }
+
+            await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .Where(item =>
+                    item.TenantId == tenantId
+                    && item.SourceKey == normalizedSourceKey
+                    && item.ActiveIngestionRunId == runId
+                )
+                .ExecuteUpdateAsync(
+                    setters =>
+                        setters
+                            .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
+                            .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
+                            .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
+                    ct
+                );
+
+            await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
+                .ExecuteUpdateAsync(
+                    setters =>
+                        setters
+                            .SetProperty(item => item.LastCompletedAt, completedAt)
+                            .SetProperty(
+                                item => item.LastSucceededAt,
+                                item => succeeded ? completedAt : item.LastSucceededAt
+                            )
+                            .SetProperty(
+                                item => item.LastStatus,
+                                succeeded
+                                    ? IngestionRunStatuses.Succeeded
+                                    : failureStatus ?? IngestionRunStatuses.FailedRecoverable
+                            )
+                            .SetProperty(
+                                item => item.LastError,
+                                succeeded ? string.Empty : error ?? "Unknown ingestion failure"
+                            ),
+                    ct
+                );
+
+            await transaction.CommitAsync(ct);
+        });
+
+        if (succeeded)
+        {
+            await ClearStagedDataForRunAsync(runId, ct);
+        }
+
+        var cleanupSummary = await CleanupExpiredIngestionArtifactsAsync(completedAt, ct);
+        if (cleanupSummary.PrunedRunCount > 0)
+        {
+            _logger.LogInformation(
+                "Pruned ingestion artifacts: runs={PrunedRunCount} stagedVulnerabilities={PrunedVulnerabilityCount} stagedExposures={PrunedExposureCount} stagedAssets={PrunedAssetCount} stagedSoftwareLinks={PrunedSoftwareLinkCount}",
+                cleanupSummary.PrunedRunCount,
+                cleanupSummary.PrunedVulnerabilityCount,
+                cleanupSummary.PrunedExposureCount,
+                cleanupSummary.PrunedAssetCount,
+                cleanupSummary.PrunedSoftwareLinkCount
+            );
+        }
+    }
+
+    internal async Task<IngestionArtifactCleanupSummary> CleanupExpiredIngestionArtifactsAsync(
+        DateTimeOffset now,
+        CancellationToken ct
+    )
+    {
+        var completedCutoff = now.Subtract(IngestionArtifactRetention);
+        var failedCutoff = now.Subtract(FailedIngestionRetention);
+        var expiredRunIds = await _dbContext
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item =>
+                item.CompletedAt.HasValue
+                && (
+                    ((item.Status == IngestionRunStatuses.FailedRecoverable
+                        || item.Status == IngestionRunStatuses.FailedTerminal)
+                        && item.CompletedAt.Value < failedCutoff)
+                    || ((item.Status != IngestionRunStatuses.FailedRecoverable
+                            && item.Status != IngestionRunStatuses.FailedTerminal)
+                        && item.CompletedAt.Value < completedCutoff)
+                )
+            )
+            .Select(item => item.Id)
+            .ToListAsync(ct);
+
+        if (expiredRunIds.Count == 0)
+        {
+            return new IngestionArtifactCleanupSummary(0, 0, 0, 0, 0);
+        }
+
+        if (IsInMemoryProvider())
+        {
+            var stagedExposures = await _dbContext
+                .StagedVulnerabilityExposures.IgnoreQueryFilters()
+                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+                .ToListAsync(ct);
+            var stagedVulnerabilities = await _dbContext
+                .StagedVulnerabilities.IgnoreQueryFilters()
+                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+                .ToListAsync(ct);
+            var stagedSoftwareLinks = await _dbContext
+                .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+                .ToListAsync(ct);
+            var stagedDeviceRows = await _dbContext
+                .StagedDevices.IgnoreQueryFilters()
+                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+                .ToListAsync(ct);
+            var checkpoints = await _dbContext
+                .IngestionCheckpoints.IgnoreQueryFilters()
+                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+                .ToListAsync(ct);
+            var runs = await _dbContext
+                .IngestionRuns.IgnoreQueryFilters()
+                .Where(item => expiredRunIds.Contains(item.Id))
+                .ToListAsync(ct);
+
+            _dbContext.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
+            _dbContext.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
+            _dbContext.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
+            _dbContext.StagedDevices.RemoveRange(stagedDeviceRows);
+            _dbContext.IngestionCheckpoints.RemoveRange(checkpoints);
+            _dbContext.IngestionRuns.RemoveRange(runs);
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new IngestionArtifactCleanupSummary(
+                runs.Count,
+                stagedVulnerabilities.Count,
+                stagedExposures.Count,
+                stagedDeviceRows.Count,
+                stagedSoftwareLinks.Count
+            );
+        }
+
+        var prunedExposureCount = await _dbContext
+            .StagedVulnerabilityExposures.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedVulnerabilityCount = await _dbContext
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedSoftwareLinkCount = await _dbContext
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedAssetCount = await _dbContext
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        await _dbContext
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedRunCount = await _dbContext
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.Id))
+            .ExecuteDeleteAsync(ct);
+
+        return new IngestionArtifactCleanupSummary(
+            prunedRunCount,
+            prunedVulnerabilityCount,
+            prunedExposureCount,
+            prunedAssetCount,
+            prunedSoftwareLinkCount
+        );
+    }
+
+    public async Task ReleaseIngestionLeaseAsync(
+        Guid tenantId,
+        string sourceKey,
+        Guid runId,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        if (IsInMemoryProvider())
+        {
+            var source = await _dbContext
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(
+                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                    ct
+                );
+            if (source is null)
+            {
+                return;
+            }
+
+            source.ReleaseLease(runId);
+            await _dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
+        await _dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .Where(item =>
+                item.TenantId == tenantId
+                && item.SourceKey == normalizedSourceKey
+                && item.ActiveIngestionRunId == runId
+            )
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
+                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
+                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
+                ct
+            );
+    }
+
+    private async Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct)
+    {
+        if (IsInMemoryProvider())
+        {
+            var stagedExposures = await _dbContext
+                .StagedVulnerabilityExposures.IgnoreQueryFilters()
+                .Where(item => item.IngestionRunId == ingestionRunId)
+                .ToListAsync(ct);
+            var stagedVulnerabilities = await _dbContext
+                .StagedVulnerabilities.IgnoreQueryFilters()
+                .Where(item => item.IngestionRunId == ingestionRunId)
+                .ToListAsync(ct);
+            var stagedSoftwareLinks = await _dbContext
+                .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+                .Where(item => item.IngestionRunId == ingestionRunId)
+                .ToListAsync(ct);
+            var stagedDevices = await _dbContext
+                .StagedDevices.IgnoreQueryFilters()
+                .Where(item => item.IngestionRunId == ingestionRunId)
+                .ToListAsync(ct);
+
+            _dbContext.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
+            _dbContext.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
+            _dbContext.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
+            _dbContext.StagedDevices.RemoveRange(stagedDevices);
+            await _dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
+        await _dbContext
+            .StagedVulnerabilityExposures.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+        await _dbContext
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+        await _dbContext
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+        await _dbContext
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    private bool IsInMemoryProvider()
+    {
+        return string.Equals(
+            _dbContext.Database.ProviderName,
+            "Microsoft.EntityFrameworkCore.InMemory",
+            StringComparison.Ordinal
+        );
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
@@ -19,9 +19,6 @@ public class IngestionLeaseManager
     private readonly IIngestionBulkWriter _bulkWriter;
     private readonly ILogger<IngestionLeaseManager> _logger;
 
-    public IngestionLeaseManager(PatchHoundDbContext dbContext, ILogger<IngestionLeaseManager> logger)
-        : this(dbContext, CreateBulkWriter(dbContext), logger) { }
-
     internal IngestionLeaseManager(
         PatchHoundDbContext dbContext,
         IIngestionBulkWriter bulkWriter,
@@ -32,11 +29,6 @@ public class IngestionLeaseManager
         _bulkWriter = bulkWriter;
         _logger = logger;
     }
-
-    private static IIngestionBulkWriter CreateBulkWriter(PatchHoundDbContext db) =>
-        db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
-            ? new InMemoryIngestionBulkWriter(db)
-            : new PostgresIngestionBulkWriter(db);
 
     internal async Task<AcquiredIngestionRun?> TryAcquireIngestionRunAsync(
         Guid tenantId,

--- a/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionLeaseManager.cs
@@ -304,10 +304,7 @@ public class IngestionLeaseManager
             ct
         );
 
-        if (succeeded)
-        {
-            await _bulkWriter.ClearStagedDataForRunAsync(runId, ct);
-        }
+        await _bulkWriter.ClearStagedDataForRunAsync(runId, ct);
 
         var cleanupSummary = await CleanupExpiredIngestionArtifactsAsync(completedAt, ct);
         if (cleanupSummary.PrunedRunCount > 0)

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -990,8 +990,11 @@ public class IngestionService
                 g => (g.First().SoftwareProductId, g.First().Id));
 
         // ── Step 3: Load existing DeviceVulnerabilityExposures for this tenant (for upsert) ──
+        // Bound to the device IDs from this run: ProcessStagedResultsAsync only processes
+        // staged exposures for devices in this run, so exposures for other devices are untouched.
+        var runDeviceIds = deviceIdByExternalId.Values.ToList();
         var existing = await _dbContext.DeviceVulnerabilityExposures
-            .Where(e => e.TenantId == tenantId)
+            .Where(e => e.TenantId == tenantId && runDeviceIds.Contains(e.DeviceId))
             .ToListAsync(ct);
         var existingByPair = existing.ToDictionary(e => (e.DeviceId, e.VulnerabilityId));
 

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -17,8 +17,6 @@ public class IngestionService
 {
     private const int MaxPersistenceAttempts = 2;
     private const int MaxSourceAttempts = 2;
-    private const int AssetBatchSize = 200;
-    private const int VulnerabilityBatchSize = 250;
     private static readonly TimeSpan DeviceInactiveThreshold = TimeSpan.FromDays(30);
     private readonly PatchHoundDbContext _dbContext;
     private readonly IEnumerable<IIngestionSource> _sources;
@@ -35,6 +33,7 @@ public class IngestionService
     private readonly RemediationDecisionService? _remediationDecisionService;
     private readonly IngestionLeaseManager _leaseManager;
     private readonly IngestionCheckpointWriter _checkpointWriter;
+    private readonly IngestionStagingPipeline _stagingPipeline;
     private readonly ILogger<IngestionService> _logger;
 
     public IngestionService(
@@ -66,6 +65,7 @@ public class IngestionService
             remediationDecisionService: null,
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
+            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
             logger
         ) { }
 
@@ -99,6 +99,7 @@ public class IngestionService
             remediationDecisionService: null,
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
+            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
             logger
         ) { }
 
@@ -132,6 +133,7 @@ public class IngestionService
             remediationDecisionService,
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
+            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
             logger
         ) { }
 
@@ -151,6 +153,7 @@ public class IngestionService
         RemediationDecisionService? remediationDecisionService,
         IngestionLeaseManager leaseManager,
         IngestionCheckpointWriter checkpointWriter,
+        IngestionStagingPipeline stagingPipeline,
         ILogger<IngestionService> logger
     )
     {
@@ -169,6 +172,7 @@ public class IngestionService
         _remediationDecisionService = remediationDecisionService;
         _leaseManager = leaseManager;
         _checkpointWriter = checkpointWriter;
+        _stagingPipeline = stagingPipeline;
         _logger = logger;
     }
 
@@ -298,7 +302,7 @@ public class IngestionService
                                 IngestionRunStatuses.Staging,
                                 ct
                             );
-                            var assetBatchSummary = await StageAssetBatchesAsync(
+                            var assetBatchSummary = await _stagingPipeline.StageAssetBatchesAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -380,7 +384,7 @@ public class IngestionService
                                 tenantId,
                                 ct
                             );
-                            var normalizedAssetSnapshot = NormalizeAssetSnapshot(assetSnapshot);
+                            var normalizedAssetSnapshot = IngestionStagingPipeline.NormalizeAssetSnapshot(assetSnapshot);
                             fetchedAssetCount = assetSnapshot.Assets.Count;
                             fetchedSoftwareCount = assetSnapshot.RetrievedSoftwareCount;
                             fetchedSoftwareInstallationCount = assetSnapshot
@@ -388,7 +392,7 @@ public class IngestionService
                                 .Count;
                             softwareWithoutMachineReferencesCount =
                                 assetSnapshot.SoftwareWithoutMachineReferencesCount;
-                            await StageAssetInventorySnapshotAsync(
+                            await _stagingPipeline.StageAssetInventorySnapshotAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -582,7 +586,7 @@ public class IngestionService
                                 IngestionRunStatuses.Staging,
                                 ct
                             );
-                            fetchedVulnerabilityCount = await StageVulnerabilityBatchesAsync(
+                            fetchedVulnerabilityCount = await _stagingPipeline.StageVulnerabilityBatchesAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -603,8 +607,8 @@ public class IngestionService
                             );
                             var results = await vulnSource.FetchVulnerabilitiesAsync(tenantId, ct);
                             fetchedVulnerabilityCount = results.Count;
-                            var normalizedResults = NormalizeResults(results);
-                            await StageVulnerabilitiesAsync(
+                            var normalizedResults = IngestionStagingPipeline.NormalizeResults(results);
+                            await _stagingPipeline.StageVulnerabilitiesAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -692,7 +696,7 @@ public class IngestionService
                             );
                         }
 
-                        await EnqueueEnrichmentJobsForRunAsync(run.Id, tenantId, ct);
+                        await _stagingPipeline.EnqueueEnrichmentJobsForRunAsync(run.Id, tenantId, ct);
 
                         if (_normalizedSoftwareProjectionService is not null)
                         {
@@ -931,14 +935,6 @@ public class IngestionService
         return deactivatedCount;
     }
 
-    private sealed record AssetBatchStageSummary(
-        int AssetCount,
-        int SoftwareCount,
-        int LinkCount,
-        int SoftwareWithoutMachineReferencesCount,
-        int BatchNumber
-    );
-
     private async Task<T> ExecuteWithConcurrencyRetryAsync<T>(
         Func<Task<T>> operation,
         string sourceName,
@@ -966,252 +962,6 @@ public class IngestionService
 
                 _dbContext.ChangeTracker.Clear();
             }
-        }
-    }
-
-
-    private async Task StageVulnerabilitiesAsync(
-        Guid ingestionRunId,
-        Guid tenantId,
-        string sourceKey,
-        IReadOnlyList<IngestionResult> results,
-        int batchNumber,
-        CancellationToken ct
-    )
-    {
-        if (results.Count == 0)
-        {
-            return;
-        }
-
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var stagedAt = DateTimeOffset.UtcNow;
-        var rows = results.Select(result =>
-            StagedVulnerability.Create(
-                ingestionRunId,
-                tenantId,
-                normalizedSourceKey,
-                result.ExternalId,
-                result.Title,
-                result.VendorSeverity,
-                JsonSerializer.Serialize(result with { AffectedAssets = [] }, StagingSerializerOptions.Instance),
-                stagedAt,
-                batchNumber
-            )
-        );
-        var exposures = results.SelectMany(result =>
-            result.AffectedAssets.Select(affectedAsset =>
-                StagedVulnerabilityExposure.Create(
-                    ingestionRunId,
-                    tenantId,
-                    normalizedSourceKey,
-                    result.ExternalId,
-                    affectedAsset.ExternalAssetId,
-                    affectedAsset.AssetName,
-                    affectedAsset.AssetType,
-                    JsonSerializer.Serialize(affectedAsset, StagingSerializerOptions.Instance),
-                    stagedAt,
-                    batchNumber
-                )
-            )
-        );
-
-        await _dbContext.StagedVulnerabilities.AddRangeAsync(rows, ct);
-        await _dbContext.StagedVulnerabilityExposures.AddRangeAsync(exposures, ct);
-        await _dbContext.SaveChangesAsync(ct);
-        _dbContext.ChangeTracker.Clear();
-    }
-
-    private async Task<int> StageVulnerabilityBatchesAsync(
-        Guid ingestionRunId,
-        Guid tenantId,
-        string sourceKey,
-        IVulnerabilityBatchSource batchSource,
-        CancellationToken ct
-    )
-    {
-        var checkpoint = await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(
-                item =>
-                    item.IngestionRunId == ingestionRunId
-                    && item.Phase == CheckpointPhases.VulnerabilityStaging,
-                ct
-            );
-        var batchNumber = checkpoint?.BatchNumber ?? 0;
-        var cursorJson =
-            string.IsNullOrWhiteSpace(checkpoint?.CursorJson) ? null : checkpoint.CursorJson;
-        var totalResults = 0;
-
-        while (true)
-        {
-            await _leaseManager.ThrowIfAbortRequestedAsync(ingestionRunId, ct);
-            batchNumber++;
-            var batch = await batchSource.FetchVulnerabilityBatchAsync(
-                tenantId,
-                cursorJson,
-                VulnerabilityBatchSize,
-                ct
-            );
-            var normalizedResults = NormalizeResults(batch.Items);
-
-            if (normalizedResults.Count > 0)
-            {
-                totalResults += normalizedResults.Count;
-                await StageVulnerabilitiesAsync(
-                    ingestionRunId,
-                    tenantId,
-                    sourceKey,
-                    normalizedResults,
-                    batchNumber,
-                    ct
-                );
-                await _checkpointWriter.CommitCheckpointAsync(
-                    ingestionRunId,
-                    tenantId,
-                    sourceKey,
-                    CheckpointPhases.VulnerabilityStaging,
-                    batchNumber,
-                    batch.NextCursorJson,
-                    normalizedResults.Count,
-                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
-                    ct
-                );
-            }
-            else
-            {
-                await _checkpointWriter.CommitCheckpointAsync(
-                    ingestionRunId,
-                    tenantId,
-                    sourceKey,
-                    CheckpointPhases.VulnerabilityStaging,
-                    batchNumber,
-                    batch.NextCursorJson,
-                    0,
-                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
-                    ct
-                );
-            }
-
-            if (batch.IsComplete)
-            {
-                break;
-            }
-
-            cursorJson = batch.NextCursorJson;
-        }
-
-        return totalResults;
-    }
-
-    private async Task StageAssetInventorySnapshotAsync(
-        Guid ingestionRunId,
-        Guid tenantId,
-        string sourceKey,
-        IngestionAssetInventorySnapshot snapshot,
-        int batchNumber,
-        CancellationToken ct
-    )
-    {
-        if (snapshot.Assets.Count == 0 && snapshot.DeviceSoftwareLinks.Count == 0)
-        {
-            return;
-        }
-
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var stagedAt = DateTimeOffset.UtcNow;
-
-        if (snapshot.Assets.Count > 0)
-        {
-            var stagedDeviceRecords = snapshot.Assets.Select(asset =>
-                StagedDevice.Create(
-                    ingestionRunId,
-                    tenantId,
-                    normalizedSourceKey,
-                    asset.ExternalId,
-                    asset.Name,
-                    asset.AssetType,
-                    JsonSerializer.Serialize(asset, StagingSerializerOptions.Instance),
-                    stagedAt,
-                    batchNumber
-                )
-            );
-            await _dbContext.StagedDevices.AddRangeAsync(stagedDeviceRecords, ct);
-        }
-
-        if (snapshot.DeviceSoftwareLinks.Count > 0)
-        {
-            var stagedLinks = snapshot.DeviceSoftwareLinks.Select(link =>
-                StagedDeviceSoftwareInstallation.Create(
-                    ingestionRunId,
-                    tenantId,
-                    normalizedSourceKey,
-                    link.DeviceExternalId,
-                    link.SoftwareExternalId,
-                    link.ObservedAt,
-                    JsonSerializer.Serialize(link, StagingSerializerOptions.Instance),
-                    stagedAt,
-                    batchNumber
-                )
-            );
-            await _dbContext.StagedDeviceSoftwareInstallations.AddRangeAsync(stagedLinks, ct);
-        }
-
-        await _dbContext.SaveChangesAsync(ct);
-        _dbContext.ChangeTracker.Clear();
-    }
-
-    private async Task EnqueueEnrichmentJobsForRunAsync(
-        Guid ingestionRunId,
-        Guid tenantId,
-        CancellationToken ct
-    )
-    {
-        var externalIds = await _dbContext
-            .StagedVulnerabilities.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .Select(item => item.ExternalId)
-            .Distinct()
-            .ToListAsync(ct);
-
-        if (externalIds.Count == 0)
-        {
-            return;
-        }
-
-        var vulnerabilityIds = await _dbContext
-            .Vulnerabilities.IgnoreQueryFilters()
-            .Where(v => externalIds.Contains(v.ExternalId))
-            .Select(v => v.Id)
-            .Distinct()
-            .ToListAsync(ct);
-
-        await _enrichmentJobEnqueuer.EnqueueVulnerabilityJobsAsync(
-            tenantId,
-            vulnerabilityIds,
-            ct
-        );
-
-        var normalizedSoftwareIds = await _dbContext
-            .SoftwareTenantRecords.IgnoreQueryFilters()
-            .AsNoTracking()
-            .Where(ts => ts.TenantId == tenantId)
-            .Select(ts => ts.SoftwareProductId)
-            .Distinct()
-            .ToListAsync(ct);
-
-        if (normalizedSoftwareIds.Count > 0)
-        {
-            await _enrichmentJobEnqueuer.EnqueueSoftwareEndOfLifeJobsAsync(
-                tenantId,
-                normalizedSoftwareIds,
-                ct
-            );
-            await _enrichmentJobEnqueuer.EnqueueSoftwareSupplyChainJobsAsync(
-                tenantId,
-                normalizedSoftwareIds,
-                ct
-            );
         }
     }
 
@@ -1247,11 +997,11 @@ public class IngestionService
         var stagedVulnCount = stagedVulns.Count;
         var persistedVulnCount = 0;
 
-        // Resolve (upsert) in batches of VulnerabilityBatchSize
+        // Resolve (upsert) in batches of IngestionStagingPipeline.VulnerabilityBatchSize
         var vulnExternalIdToId = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 0; i < stagedVulns.Count; i += VulnerabilityBatchSize)
+        for (var i = 0; i < stagedVulns.Count; i += IngestionStagingPipeline.VulnerabilityBatchSize)
         {
-            var batch = stagedVulns.Skip(i).Take(VulnerabilityBatchSize);
+            var batch = stagedVulns.Skip(i).Take(IngestionStagingPipeline.VulnerabilityBatchSize);
             foreach (var staged in batch)
             {
                 IngestionResult? payload = null;
@@ -1346,9 +1096,9 @@ public class IngestionService
         var resolvedCount = 0;
 
         // ── Step 4: Upsert exposures in batches ──
-        for (var i = 0; i < stagedExposures.Count; i += VulnerabilityBatchSize)
+        for (var i = 0; i < stagedExposures.Count; i += IngestionStagingPipeline.VulnerabilityBatchSize)
         {
-            var batch = stagedExposures.Skip(i).Take(VulnerabilityBatchSize);
+            var batch = stagedExposures.Skip(i).Take(IngestionStagingPipeline.VulnerabilityBatchSize);
             foreach (var exposure in batch)
             {
                 if (!vulnExternalIdToId.TryGetValue(exposure.VulnerabilityExternalId, out var vulnerabilityId))
@@ -1520,8 +1270,8 @@ public class IngestionService
         await _dbContext.IngestionRuns.AddAsync(run, ct);
         await _dbContext.SaveChangesAsync(ct);
 
-        var normalizedSnapshot = NormalizeAssetSnapshot(snapshot);
-        await StageAssetInventorySnapshotAsync(
+        var normalizedSnapshot = IngestionStagingPipeline.NormalizeAssetSnapshot(snapshot);
+        await _stagingPipeline.StageAssetInventorySnapshotAsync(
             run.Id,
             tenantId,
             run.SourceKey,
@@ -1551,127 +1301,6 @@ public class IngestionService
             normalizedSnapshot.Assets.Count + normalizedSnapshot.DeviceSoftwareLinks.Count,
             CheckpointStatuses.Completed,
             ct
-        );
-    }
-
-    private async Task<AssetBatchStageSummary> StageAssetBatchesAsync(
-        Guid ingestionRunId,
-        Guid tenantId,
-        string sourceKey,
-        IAssetInventoryBatchSource batchSource,
-        CancellationToken ct
-    )
-    {
-        var checkpoint = await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(item =>
-                item.IngestionRunId == ingestionRunId
-                && item.TenantId == tenantId
-                && item.SourceKey == sourceKey
-                && item.Phase == CheckpointPhases.AssetStaging,
-                ct
-            );
-
-        var batchNumber = checkpoint?.BatchNumber ?? 0;
-        var cursorJson = string.IsNullOrWhiteSpace(checkpoint?.CursorJson)
-            ? null
-            : checkpoint!.CursorJson;
-        var totalAssets = 0;
-        var totalSoftware = 0;
-        var totalLinks = 0;
-        var totalSoftwareWithoutMachineReferences = 0;
-
-        while (true)
-        {
-            await _leaseManager.ThrowIfAbortRequestedAsync(ingestionRunId, ct);
-            var batch = await batchSource.FetchAssetBatchAsync(
-                tenantId,
-                cursorJson,
-                AssetBatchSize,
-                ct
-            );
-            batchNumber++;
-
-            var normalizedBatch = NormalizeAssetSnapshots(batch.Items);
-            if (
-                normalizedBatch.Assets.Count > 0
-                || normalizedBatch.DeviceSoftwareLinks.Count > 0
-                || normalizedBatch.RetrievedSoftwareCount > 0
-                || normalizedBatch.SoftwareWithoutMachineReferencesCount > 0
-            )
-            {
-                totalAssets += normalizedBatch.Assets.Count;
-                totalSoftwareWithoutMachineReferences +=
-                    normalizedBatch.SoftwareWithoutMachineReferencesCount;
-
-                await StageAssetInventorySnapshotAsync(
-                    ingestionRunId,
-                    tenantId,
-                    sourceKey,
-                    normalizedBatch,
-                    batchNumber,
-                    ct
-                );
-                await _checkpointWriter.CommitCheckpointAsync(
-                    ingestionRunId,
-                    tenantId,
-                    sourceKey,
-                    CheckpointPhases.AssetStaging,
-                    batchNumber,
-                    batch.NextCursorJson,
-                    normalizedBatch.Assets.Count + normalizedBatch.DeviceSoftwareLinks.Count,
-                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
-                    ct
-                );
-            }
-            else if (batch.IsComplete)
-            {
-                await _checkpointWriter.CommitCheckpointAsync(
-                    ingestionRunId,
-                    tenantId,
-                    sourceKey,
-                    CheckpointPhases.AssetStaging,
-                    batchNumber,
-                    batch.NextCursorJson,
-                    0,
-                    CheckpointStatuses.Completed,
-                    ct
-                );
-            }
-
-            if (batch.IsComplete)
-            {
-                break;
-            }
-
-            cursorJson = batch.NextCursorJson;
-        }
-
-        totalSoftware = await _dbContext
-            .StagedDevices.IgnoreQueryFilters()
-            .Where(
-                item =>
-                    item.IngestionRunId == ingestionRunId
-                    && EF.Functions.Like(item.ExternalId, "defender-sw::%")
-            )
-            .Select(item => item.ExternalId)
-            .Distinct()
-            .CountAsync(
-                ct
-            );
-        totalLinks = await _dbContext
-            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .Select(item => new { item.DeviceExternalId, item.SoftwareExternalId })
-            .Distinct()
-            .CountAsync(ct);
-
-        return new AssetBatchStageSummary(
-            totalAssets,
-            totalSoftware,
-            totalLinks,
-            totalSoftwareWithoutMachineReferences,
-            batchNumber
         );
     }
 
@@ -1967,94 +1596,6 @@ public class IngestionService
             .ExecuteDeleteAsync(ct);
     }
 
-    private static IReadOnlyList<IngestionResult> NormalizeResults(
-        IReadOnlyList<IngestionResult> results
-    )
-    {
-        return results
-            .GroupBy(result => result.ExternalId, StringComparer.OrdinalIgnoreCase)
-            .Select(group =>
-            {
-                var first = group.First();
-                var affectedAssets = group
-                    .SelectMany(item => item.AffectedAssets)
-                    .GroupBy(asset => asset.ExternalAssetId, StringComparer.OrdinalIgnoreCase)
-                    .Select(assetGroup => assetGroup.First())
-                    .ToList();
-                var references = group
-                    .SelectMany(item => item.References ?? [])
-                    .GroupBy(reference => reference.Url, StringComparer.OrdinalIgnoreCase)
-                    .Select(referenceGroup => referenceGroup.First())
-                    .ToList();
-                var affectedSoftware = group
-                    .SelectMany(item => item.AffectedSoftware ?? [])
-                    .GroupBy(
-                        item =>
-                            $"{item.Criteria}|{item.VersionStartIncluding}|{item.VersionStartExcluding}|{item.VersionEndIncluding}|{item.VersionEndExcluding}|{item.Vulnerable}",
-                        StringComparer.OrdinalIgnoreCase
-                    )
-                    .Select(softwareGroup => softwareGroup.First())
-                    .ToList();
-                var sources = group
-                    .SelectMany(item => item.Sources ?? [])
-                    .Where(source => !string.IsNullOrWhiteSpace(source))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToList();
-
-                return first with
-                {
-                    AffectedAssets = affectedAssets,
-                    References = references,
-                    AffectedSoftware = affectedSoftware,
-                    Sources = sources,
-                };
-            })
-            .ToList();
-    }
-
-    private static IngestionAssetInventorySnapshot NormalizeAssetSnapshot(
-        IngestionAssetInventorySnapshot snapshot
-    )
-    {
-        var assets = snapshot
-            .Assets.GroupBy(asset => asset.ExternalId, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.Last())
-            .ToList();
-        var deviceSoftwareLinks = snapshot
-            .DeviceSoftwareLinks.GroupBy(
-                link => $"{link.DeviceExternalId}:{link.SoftwareExternalId}",
-                StringComparer.OrdinalIgnoreCase
-            )
-            .Select(group => group.OrderByDescending(link => link.ObservedAt).First())
-            .ToList();
-
-        return new IngestionAssetInventorySnapshot(
-            assets,
-            deviceSoftwareLinks,
-            snapshot.RetrievedSoftwareCount,
-            snapshot.SoftwareWithoutMachineReferencesCount
-        );
-    }
-
-    private static IngestionAssetInventorySnapshot NormalizeAssetSnapshots(
-        IReadOnlyList<IngestionAssetInventorySnapshot> snapshots
-    )
-    {
-        if (snapshots.Count == 0)
-        {
-            return new IngestionAssetInventorySnapshot([], []);
-        }
-
-        return NormalizeAssetSnapshot(
-            new IngestionAssetInventorySnapshot(
-                snapshots.SelectMany(item => item.Assets).ToList(),
-                snapshots.SelectMany(item => item.DeviceSoftwareLinks).ToList(),
-                snapshots.Sum(item => item.RetrievedSoftwareCount),
-                snapshots.Sum(item => item.SoftwareWithoutMachineReferencesCount)
-            )
-        );
-    }
-
     private bool IsInMemoryProvider()
     {
         return string.Equals(
@@ -2062,21 +1603,6 @@ public class IngestionService
             "Microsoft.EntityFrameworkCore.InMemory",
             StringComparison.Ordinal
         );
-    }
-
-    private static IEnumerable<IReadOnlyList<T>> Chunk<T>(IReadOnlyList<T> items, int size)
-    {
-        for (var index = 0; index < items.Count; index += size)
-        {
-            var count = Math.Min(size, items.Count - index);
-            var chunk = new List<T>(count);
-            for (var offset = 0; offset < count; offset++)
-            {
-                chunk.Add(items[index + offset]);
-            }
-
-            yield return chunk;
-        }
     }
 
     private static string DescribeConcurrencyEntries(DbUpdateConcurrencyException ex)

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -250,22 +250,22 @@ public class IngestionService
 
                         var assetStagingCompleted = await IsCheckpointCompletedAsync(
                             run.Id,
-                            "asset-staging",
+                            CheckpointPhases.AssetStaging,
                             ct
                         );
                         var assetMergeCompleted = await IsCheckpointCompletedAsync(
                             run.Id,
-                            "asset-merge",
+                            CheckpointPhases.AssetMerge,
                             ct
                         );
                         var vulnerabilityStagingCompleted = await IsCheckpointCompletedAsync(
                             run.Id,
-                            "vulnerability-staging",
+                            CheckpointPhases.VulnerabilityStaging,
                             ct
                         );
                         var vulnerabilityMergeCompleted = await IsCheckpointCompletedAsync(
                             run.Id,
-                            "vulnerability-merge",
+                            CheckpointPhases.VulnerabilityMerge,
                             ct
                         );
 
@@ -336,11 +336,11 @@ public class IngestionService
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
-                                "asset-merge",
+                                CheckpointPhases.AssetMerge,
                                 assetBatchSummary.BatchNumber,
                                 null,
                                 assetMergeSummary.MergedAssetCount,
-                                "Completed",
+                                CheckpointStatuses.Completed,
                                 ct
                             );
                             assetStagingCompleted = true;
@@ -393,11 +393,11 @@ public class IngestionService
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
-                                "asset-staging",
+                                CheckpointPhases.AssetStaging,
                                 0,
                                 null,
                                 normalizedAssetSnapshot.Assets.Count + normalizedAssetSnapshot.DeviceSoftwareLinks.Count,
-                                "Staged",
+                                CheckpointStatuses.Staged,
                                 ct
                             );
                             await UpdateActiveRunStatusAsync(
@@ -432,11 +432,11 @@ public class IngestionService
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
-                                "asset-merge",
+                                CheckpointPhases.AssetMerge,
                                 0,
                                 null,
                                 assetMergeSummary.MergedAssetCount,
-                                "Completed",
+                                CheckpointStatuses.Completed,
                                 ct
                             );
                             assetStagingCompleted = true;
@@ -499,18 +499,18 @@ public class IngestionService
                             );
                             var assetMergeBatchNumber = await GetCheckpointBatchNumberAsync(
                                 run.Id,
-                                "asset-staging",
+                                CheckpointPhases.AssetStaging,
                                 ct
                             );
                             await CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
-                                "asset-merge",
+                                CheckpointPhases.AssetMerge,
                                 assetMergeBatchNumber,
                                 null,
                                 assetMergeSummary.MergedAssetCount,
-                                "Completed",
+                                CheckpointStatuses.Completed,
                                 ct
                             );
                             assetMergeCompleted = true;
@@ -609,11 +609,11 @@ public class IngestionService
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
-                                "vulnerability-staging",
+                                CheckpointPhases.VulnerabilityStaging,
                                 0,
                                 null,
                                 normalizedResults.Count,
-                                "Staged",
+                                CheckpointStatuses.Staged,
                                 ct
                             );
                             vulnerabilityStagingCompleted = true;
@@ -659,18 +659,18 @@ public class IngestionService
                             );
                             var vulnerabilityMergeBatchNumber = await GetCheckpointBatchNumberAsync(
                                 run.Id,
-                                "vulnerability-staging",
+                                CheckpointPhases.VulnerabilityStaging,
                                 ct
                             );
                             await CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
-                                "vulnerability-merge",
+                                CheckpointPhases.VulnerabilityMerge,
                                 vulnerabilityMergeBatchNumber,
                                 null,
                                 vulnerabilityMergeSummary.MergedExposureCount,
-                                "Completed",
+                                CheckpointStatuses.Completed,
                                 ct
                             );
                             vulnerabilityMergeCompleted = true;
@@ -1797,7 +1797,7 @@ public class IngestionService
                 item =>
                     item.IngestionRunId == ingestionRunId
                     && item.Phase == phase
-                    && item.Status == "Completed",
+                    && item.Status == CheckpointStatuses.Completed,
                 ct
             );
     }
@@ -1924,7 +1924,7 @@ public class IngestionService
             .FirstOrDefaultAsync(
                 item =>
                     item.IngestionRunId == ingestionRunId
-                    && item.Phase == "vulnerability-staging",
+                    && item.Phase == CheckpointPhases.VulnerabilityStaging,
                 ct
             );
         var batchNumber = checkpoint?.BatchNumber ?? 0;
@@ -1959,11 +1959,11 @@ public class IngestionService
                     ingestionRunId,
                     tenantId,
                     sourceKey,
-                    "vulnerability-staging",
+                    CheckpointPhases.VulnerabilityStaging,
                     batchNumber,
                     batch.NextCursorJson,
                     normalizedResults.Count,
-                    batch.IsComplete ? "Completed" : "Running",
+                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
                     ct
                 );
             }
@@ -1973,11 +1973,11 @@ public class IngestionService
                     ingestionRunId,
                     tenantId,
                     sourceKey,
-                    "vulnerability-staging",
+                    CheckpointPhases.VulnerabilityStaging,
                     batchNumber,
                     batch.NextCursorJson,
                     0,
-                    batch.IsComplete ? "Completed" : "Running",
+                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
                     ct
                 );
             }
@@ -2422,11 +2422,11 @@ public class IngestionService
             run.Id,
             tenantId,
             run.SourceKey,
-            "asset-staging",
+            CheckpointPhases.AssetStaging,
             0,
             null,
             normalizedSnapshot.Assets.Count + normalizedSnapshot.DeviceSoftwareLinks.Count,
-            "Staged",
+            CheckpointStatuses.Staged,
             ct
         );
         await ProcessStagedAssetsAsync(run.Id, tenantId, run.SourceKey, null, ct);
@@ -2434,11 +2434,11 @@ public class IngestionService
             run.Id,
             tenantId,
             run.SourceKey,
-            "asset-merge",
+            CheckpointPhases.AssetMerge,
             0,
             null,
             normalizedSnapshot.Assets.Count + normalizedSnapshot.DeviceSoftwareLinks.Count,
-            "Completed",
+            CheckpointStatuses.Completed,
             ct
         );
     }
@@ -2457,7 +2457,7 @@ public class IngestionService
                 item.IngestionRunId == ingestionRunId
                 && item.TenantId == tenantId
                 && item.SourceKey == sourceKey
-                && item.Phase == "asset-staging",
+                && item.Phase == CheckpointPhases.AssetStaging,
                 ct
             );
 
@@ -2505,11 +2505,11 @@ public class IngestionService
                     ingestionRunId,
                     tenantId,
                     sourceKey,
-                    "asset-staging",
+                    CheckpointPhases.AssetStaging,
                     batchNumber,
                     batch.NextCursorJson,
                     normalizedBatch.Assets.Count + normalizedBatch.DeviceSoftwareLinks.Count,
-                    batch.IsComplete ? "Completed" : "Running",
+                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
                     ct
                 );
             }
@@ -2519,11 +2519,11 @@ public class IngestionService
                     ingestionRunId,
                     tenantId,
                     sourceKey,
-                    "asset-staging",
+                    CheckpointPhases.AssetStaging,
                     batchNumber,
                     batch.NextCursorJson,
                     0,
-                    "Completed",
+                    CheckpointStatuses.Completed,
                     ct
                 );
             }

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -35,6 +35,7 @@ public class IngestionService
     private readonly IngestionCheckpointWriter _checkpointWriter;
     private readonly IngestionStagingPipeline _stagingPipeline;
     private readonly IngestionSnapshotLifecycle _snapshotLifecycle;
+    private readonly IIngestionBulkWriter _bulkWriter;
     private readonly ILogger<IngestionService> _logger;
 
     public IngestionService(
@@ -68,6 +69,7 @@ public class IngestionService
             new IngestionCheckpointWriter(dbContext),
             new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
             new IngestionSnapshotLifecycle(dbContext),
+            CreateBulkWriter(dbContext),
             logger
         ) { }
 
@@ -103,6 +105,7 @@ public class IngestionService
             new IngestionCheckpointWriter(dbContext),
             new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
             new IngestionSnapshotLifecycle(dbContext),
+            CreateBulkWriter(dbContext),
             logger
         ) { }
 
@@ -138,10 +141,16 @@ public class IngestionService
             new IngestionCheckpointWriter(dbContext),
             new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
             new IngestionSnapshotLifecycle(dbContext),
+            CreateBulkWriter(dbContext),
             logger
         ) { }
 
-    public IngestionService(
+    private static IIngestionBulkWriter CreateBulkWriter(PatchHoundDbContext db) =>
+        db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
+            ? new InMemoryIngestionBulkWriter(db)
+            : new PostgresIngestionBulkWriter(db);
+
+    internal IngestionService(
         PatchHoundDbContext dbContext,
         IEnumerable<IIngestionSource> sources,
         EnrichmentJobEnqueuer enrichmentJobEnqueuer,
@@ -159,6 +168,7 @@ public class IngestionService
         IngestionCheckpointWriter checkpointWriter,
         IngestionStagingPipeline stagingPipeline,
         IngestionSnapshotLifecycle snapshotLifecycle,
+        IIngestionBulkWriter bulkWriter,
         ILogger<IngestionService> logger
     )
     {
@@ -179,6 +189,7 @@ public class IngestionService
         _checkpointWriter = checkpointWriter;
         _stagingPipeline = stagingPipeline;
         _snapshotLifecycle = snapshotLifecycle;
+        _bulkWriter = bulkWriter;
         _logger = logger;
     }
 
@@ -1229,40 +1240,12 @@ public class IngestionService
             CancellationToken callbackCt
         )
         {
-            if (_dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
-            {
-                var run = await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(item => item.Id == ingestionRunId, callbackCt);
-                if (run is null)
-                {
-                    return;
-                }
-
-                run.UpdateVulnerabilityMergeProgress(
-                    stagedVulnerabilityCount,
-                    persistedVulnerabilityCount
-                );
-                await _dbContext.SaveChangesAsync(callbackCt);
-                return;
-            }
-
-            await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .Where(item => item.Id == ingestionRunId && !item.CompletedAt.HasValue)
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(
-                                item => item.StagedVulnerabilityCount,
-                                stagedVulnerabilityCount
-                            )
-                            .SetProperty(
-                                item => item.PersistedVulnerabilityCount,
-                                persistedVulnerabilityCount
-                            ),
-                    callbackCt
-                );
+            await _bulkWriter.UpdateVulnerabilityMergeProgressAsync(
+                ingestionRunId,
+                stagedVulnerabilityCount,
+                persistedVulnerabilityCount,
+                callbackCt
+            );
         }
     }
 
@@ -1362,67 +1345,17 @@ public class IngestionService
             CancellationToken callbackCt
         )
         {
-            if (_dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
-            {
-                var run = await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(item => item.Id == ingestionRunId, callbackCt);
-                if (run is null)
-                {
-                    return;
-                }
-
-                run.UpdateAssetMergeProgress(
-                    stagedMachineCount,
-                    stagedSoftwareCount,
-                    persistedMachineCount,
-                    0,
-                    persistedSoftwareCount
-                );
-                await _dbContext.SaveChangesAsync(callbackCt);
-                return;
-            }
-
-            await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .Where(item => item.Id == ingestionRunId && !item.CompletedAt.HasValue)
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(
-                                item => item.StagedMachineCount,
-                                stagedMachineCount
-                            )
-                            .SetProperty(
-                                item => item.StagedSoftwareCount,
-                                stagedSoftwareCount
-                            )
-                            .SetProperty(
-                                item => item.PersistedMachineCount,
-                                persistedMachineCount
-                            )
-                            .SetProperty(
-                                item => item.DeactivatedMachineCount,
-                                0
-                            )
-                            .SetProperty(
-                                item => item.PersistedSoftwareCount,
-                                persistedSoftwareCount
-                            ),
-                    callbackCt
-                );
+            await _bulkWriter.UpdateAssetMergeProgressAsync(
+                ingestionRunId,
+                stagedMachineCount,
+                stagedSoftwareCount,
+                persistedMachineCount,
+                persistedSoftwareCount,
+                callbackCt
+            );
         }
     }
 
-
-    private bool IsInMemoryProvider()
-    {
-        return string.Equals(
-            _dbContext.Database.ProviderName,
-            "Microsoft.EntityFrameworkCore.InMemory",
-            StringComparison.Ordinal
-        );
-    }
 
     private static string DescribeConcurrencyEntries(DbUpdateConcurrencyException ex)
     {

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -34,6 +34,7 @@ public class IngestionService
     private readonly IngestionLeaseManager _leaseManager;
     private readonly IngestionCheckpointWriter _checkpointWriter;
     private readonly IngestionStagingPipeline _stagingPipeline;
+    private readonly IngestionSnapshotLifecycle _snapshotLifecycle;
     private readonly ILogger<IngestionService> _logger;
 
     public IngestionService(
@@ -66,6 +67,7 @@ public class IngestionService
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
             new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
+            new IngestionSnapshotLifecycle(dbContext),
             logger
         ) { }
 
@@ -100,6 +102,7 @@ public class IngestionService
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
             new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
+            new IngestionSnapshotLifecycle(dbContext),
             logger
         ) { }
 
@@ -134,6 +137,7 @@ public class IngestionService
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
             new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
+            new IngestionSnapshotLifecycle(dbContext),
             logger
         ) { }
 
@@ -154,6 +158,7 @@ public class IngestionService
         IngestionLeaseManager leaseManager,
         IngestionCheckpointWriter checkpointWriter,
         IngestionStagingPipeline stagingPipeline,
+        IngestionSnapshotLifecycle snapshotLifecycle,
         ILogger<IngestionService> logger
     )
     {
@@ -173,6 +178,7 @@ public class IngestionService
         _leaseManager = leaseManager;
         _checkpointWriter = checkpointWriter;
         _stagingPipeline = stagingPipeline;
+        _snapshotLifecycle = snapshotLifecycle;
         _logger = logger;
     }
 
@@ -282,9 +288,9 @@ public class IngestionService
 
                         deactivatedMachineCount = await RefreshDeviceActivityForTenantAsync(tenantId, ct);
 
-                        if (SupportsSoftwareSnapshots(source.SourceKey))
+                        if (IngestionSnapshotLifecycle.SupportsSoftwareSnapshots(source.SourceKey))
                         {
-                            softwareSnapshot ??= await GetOrCreateBuildingSoftwareSnapshotAsync(
+                            softwareSnapshot ??= await _snapshotLifecycle.GetOrCreateBuildingSoftwareSnapshotAsync(
                                 tenantId,
                                 source.SourceKey,
                                 run.Id,
@@ -709,9 +715,9 @@ public class IngestionService
 
                         await _deviceRuleEvaluationService.EvaluateRulesAsync(tenantId, ct);
 
-                        if (SupportsSoftwareSnapshots(source.SourceKey))
+                        if (IngestionSnapshotLifecycle.SupportsSoftwareSnapshots(source.SourceKey))
                         {
-                            softwareSnapshot ??= await GetOrCreateBuildingSoftwareSnapshotAsync(
+                            softwareSnapshot ??= await _snapshotLifecycle.GetOrCreateBuildingSoftwareSnapshotAsync(
                                 tenantId,
                                 source.SourceKey,
                                 run.Id,
@@ -735,7 +741,7 @@ public class IngestionService
                                 (DateTimeOffset.UtcNow - softwareMatchStartedAt).TotalMilliseconds
                             );
                             var snapshotPublishStartedAt = DateTimeOffset.UtcNow;
-                            await PublishSnapshotAsync(
+                            await _snapshotLifecycle.PublishSnapshotAsync(
                                 tenantId,
                                 source.SourceKey,
                                 softwareSnapshot.Id,
@@ -863,7 +869,7 @@ public class IngestionService
                             && failureStatus == IngestionRunStatuses.FailedTerminal
                         )
                         {
-                            await DiscardBuildingSnapshotAsync(
+                            await _snapshotLifecycle.DiscardBuildingSnapshotAsync(
                                 tenantId,
                                 source.SourceKey,
                                 softwareSnapshot.Id,
@@ -1408,193 +1414,6 @@ public class IngestionService
         }
     }
 
-    private static bool SupportsSoftwareSnapshots(string sourceKey)
-    {
-        return sourceKey.Trim().ToLowerInvariant() == TenantSourceCatalog.DefenderSourceKey;
-    }
-
-    private async Task<IngestionSnapshot> GetOrCreateBuildingSoftwareSnapshotAsync(
-        Guid tenantId,
-        string sourceKey,
-        Guid ingestionRunId,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var source = await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .FirstAsync(
-                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                ct
-            );
-
-        if (source.BuildingSnapshotId is Guid buildingSnapshotId)
-        {
-            var existing = await _dbContext
-                .IngestionSnapshots.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == buildingSnapshotId, ct);
-            if (
-                existing is not null
-                && existing.IngestionRunId == ingestionRunId
-                && existing.Status == IngestionSnapshotStatuses.Building
-            )
-            {
-                return existing;
-            }
-
-            if (existing is not null && existing.Status == IngestionSnapshotStatuses.Building)
-            {
-                existing.Discard();
-                await CleanupSnapshotDataAsync(existing.Id, ct);
-            }
-        }
-
-        var snapshot = IngestionSnapshot.Create(
-            tenantId,
-            normalizedSourceKey,
-            ingestionRunId,
-            DateTimeOffset.UtcNow
-        );
-        source.SetSnapshotPointers(source.ActiveSnapshotId, snapshot.Id);
-        await _dbContext.IngestionSnapshots.AddAsync(snapshot, ct);
-        await _dbContext.SaveChangesAsync(ct);
-        return snapshot;
-    }
-
-    private async Task PublishSnapshotAsync(
-        Guid tenantId,
-        string sourceKey,
-        Guid snapshotId,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var source = await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .FirstAsync(
-                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                ct
-            );
-        var snapshot = await _dbContext
-            .IngestionSnapshots.IgnoreQueryFilters()
-            .FirstAsync(item => item.Id == snapshotId, ct);
-
-        Guid? retiredSnapshotId = null;
-        if (source.ActiveSnapshotId is Guid previousActiveSnapshotId && previousActiveSnapshotId != snapshotId)
-        {
-            var previous = await _dbContext
-                .IngestionSnapshots.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == previousActiveSnapshotId, ct);
-            if (previous is not null)
-            {
-                previous.Discard();
-                retiredSnapshotId = previous.Id;
-            }
-        }
-
-        snapshot.MarkPublished();
-        source.SetSnapshotPointers(snapshot.Id, null);
-        await _dbContext.SaveChangesAsync(ct);
-
-        if (retiredSnapshotId.HasValue)
-        {
-            await RekeyTenantSoftwareReferencesAsync(retiredSnapshotId.Value, snapshotId, ct);
-            await CleanupSnapshotDataAsync(retiredSnapshotId.Value, ct);
-        }
-    }
-
-    private async Task RekeyTenantSoftwareReferencesAsync(
-        Guid oldSnapshotId,
-        Guid newSnapshotId,
-        CancellationToken ct
-    )
-    {
-        var oldRows = await _dbContext
-            .SoftwareTenantRecords.IgnoreQueryFilters()
-            .Where(ts => ts.SnapshotId == oldSnapshotId)
-            .Select(ts => new { ts.Id, ts.SoftwareProductId })
-            .ToListAsync(ct);
-
-        var newRows = await _dbContext
-            .SoftwareTenantRecords.IgnoreQueryFilters()
-            .Where(ts => ts.SnapshotId == newSnapshotId)
-            .Select(ts => new { ts.Id, ts.SoftwareProductId })
-            .ToListAsync(ct);
-
-        var newByNormalized = newRows.ToDictionary(r => r.SoftwareProductId, r => r.Id);
-        var oldToNew = oldRows
-            .Where(old => newByNormalized.ContainsKey(old.SoftwareProductId))
-            .ToDictionary(old => old.Id, old => newByNormalized[old.SoftwareProductId]);
-
-        if (oldToNew.Count == 0)
-            return;
-
-        // Phase 4: Remediation entities (RemediationDecision, RemediationWorkflow, PatchingTask)
-        // are now anchored on RemediationCase, which is keyed by (TenantId, SoftwareProductId).
-        // RemediationCase IDs are stable across snapshot rotations — no re-keying required.
-        await Task.CompletedTask;
-    }
-
-    private async Task DiscardBuildingSnapshotAsync(
-        Guid tenantId,
-        string sourceKey,
-        Guid snapshotId,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var source = await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(
-                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                ct
-            );
-        var snapshot = await _dbContext
-            .IngestionSnapshots.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(item => item.Id == snapshotId, ct);
-
-        if (snapshot is not null && snapshot.Status == IngestionSnapshotStatuses.Building)
-        {
-            snapshot.Discard();
-        }
-
-        if (source is not null && source.BuildingSnapshotId == snapshotId)
-        {
-            source.SetSnapshotPointers(source.ActiveSnapshotId, null);
-        }
-
-        await _dbContext.SaveChangesAsync(ct);
-        await CleanupSnapshotDataAsync(snapshotId, ct);
-    }
-
-    private async Task CleanupSnapshotDataAsync(Guid snapshotId, CancellationToken ct)
-    {
-        if (_dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
-        {
-            var tenantSoftware = await _dbContext
-                .SoftwareTenantRecords.IgnoreQueryFilters()
-                .Where(item => item.SnapshotId == snapshotId)
-                .ToListAsync(ct);
-            var installations = await _dbContext
-                .SoftwareProductInstallations.IgnoreQueryFilters()
-                .Where(item => item.SnapshotId == snapshotId)
-                .ToListAsync(ct);
-
-            _dbContext.SoftwareTenantRecords.RemoveRange(tenantSoftware);
-            _dbContext.SoftwareProductInstallations.RemoveRange(installations);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .SoftwareProductInstallations.IgnoreQueryFilters()
-            .Where(item => item.SnapshotId == snapshotId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .SoftwareTenantRecords.IgnoreQueryFilters()
-            .Where(item => item.SnapshotId == snapshotId)
-            .ExecuteDeleteAsync(ct);
-    }
 
     private bool IsInMemoryProvider()
     {

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -20,9 +20,6 @@ public class IngestionService
     private const int AssetBatchSize = 200;
     private const int VulnerabilityBatchSize = 250;
     private static readonly TimeSpan DeviceInactiveThreshold = TimeSpan.FromDays(30);
-    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(30);
-    private static readonly TimeSpan IngestionArtifactRetention = TimeSpan.FromDays(7);
-    private static readonly TimeSpan FailedIngestionRetention = TimeSpan.FromHours(24);
     private readonly PatchHoundDbContext _dbContext;
     private readonly IEnumerable<IIngestionSource> _sources;
     private readonly EnrichmentJobEnqueuer _enrichmentJobEnqueuer;
@@ -36,9 +33,8 @@ public class IngestionService
     private readonly VulnerabilityResolver _vulnerabilityResolver;
     private readonly NormalizedSoftwareProjectionService? _normalizedSoftwareProjectionService;
     private readonly RemediationDecisionService? _remediationDecisionService;
+    private readonly IngestionLeaseManager _leaseManager;
     private readonly ILogger<IngestionService> _logger;
-
-    private sealed record AcquiredIngestionRun(IngestionRun Run, bool Resumed);
 
     public IngestionService(
         PatchHoundDbContext dbContext,
@@ -67,6 +63,7 @@ public class IngestionService
             new VulnerabilityResolver(dbContext, NullLogger<VulnerabilityResolver>.Instance),
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
+            new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             logger
         ) { }
 
@@ -98,6 +95,7 @@ public class IngestionService
             vulnerabilityResolver,
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
+            new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             logger
         ) { }
 
@@ -129,6 +127,7 @@ public class IngestionService
             new VulnerabilityResolver(dbContext, NullLogger<VulnerabilityResolver>.Instance),
             normalizedSoftwareProjectionService: null,
             remediationDecisionService,
+            new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
             logger
         ) { }
 
@@ -146,6 +145,7 @@ public class IngestionService
         VulnerabilityResolver vulnerabilityResolver,
         NormalizedSoftwareProjectionService? normalizedSoftwareProjectionService,
         RemediationDecisionService? remediationDecisionService,
+        IngestionLeaseManager leaseManager,
         ILogger<IngestionService> logger
     )
     {
@@ -162,6 +162,7 @@ public class IngestionService
         _vulnerabilityResolver = vulnerabilityResolver;
         _normalizedSoftwareProjectionService = normalizedSoftwareProjectionService;
         _remediationDecisionService = remediationDecisionService;
+        _leaseManager = leaseManager;
         _logger = logger;
     }
 
@@ -196,7 +197,7 @@ public class IngestionService
 
         foreach (var source in sources)
         {
-            var acquiredRun = await TryAcquireIngestionRunAsync(tenantId, source.SourceKey, ct);
+            var acquiredRun = await _leaseManager.TryAcquireIngestionRunAsync(tenantId, source.SourceKey, ct);
             if (acquiredRun is null)
             {
                 _logger.LogInformation(
@@ -225,7 +226,7 @@ public class IngestionService
             {
                 for (var attempt = 1; attempt <= MaxSourceAttempts; attempt++)
                 {
-                    await UpdateRuntimeStateAsync(
+                    await _leaseManager.UpdateRuntimeStateAsync(
                         tenantId,
                         source.SourceKey,
                         runtime =>
@@ -240,7 +241,7 @@ public class IngestionService
 
                     try
                     {
-                        await ThrowIfAbortRequestedAsync(run.Id, ct);
+                        await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
 
                         _logger.LogInformation(
                             "Starting ingestion from {Source} for tenant {TenantId}",
@@ -283,8 +284,8 @@ public class IngestionService
 
                         if (!assetStagingCompleted && source is IAssetInventoryBatchSource assetInventoryBatchSource)
                         {
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -303,15 +304,15 @@ public class IngestionService
                             fetchedSoftwareInstallationCount = assetBatchSummary.LinkCount;
                             softwareWithoutMachineReferencesCount =
                                 assetBatchSummary.SoftwareWithoutMachineReferencesCount;
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
                                 IngestionRunStatuses.MergePending,
                                 ct
                             );
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -362,7 +363,7 @@ public class IngestionService
                         }
                         else if (!assetStagingCompleted && source is IAssetInventorySource assetInventorySource)
                         {
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -400,14 +401,14 @@ public class IngestionService
                                 CheckpointStatuses.Staged,
                                 ct
                             );
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
                                 IngestionRunStatuses.MergePending,
                                 ct
                             );
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -468,15 +469,15 @@ public class IngestionService
 
                         if (!assetMergeCompleted && assetStagingCompleted)
                         {
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
                                 IngestionRunStatuses.MergePending,
                                 ct
                             );
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -523,8 +524,8 @@ public class IngestionService
 
                         if (source is ICloudApplicationSource cloudAppSource)
                         {
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -550,7 +551,7 @@ public class IngestionService
                             }
                             await _dbContext.SaveChangesAsync(ct);
 
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -567,8 +568,8 @@ public class IngestionService
 
                         if (!vulnerabilityStagingCompleted && source is IVulnerabilityBatchSource batchSource)
                         {
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -586,8 +587,8 @@ public class IngestionService
                         }
                         else if (!vulnerabilityStagingCompleted && source is IVulnerabilitySource vulnSource)
                         {
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -627,15 +628,15 @@ public class IngestionService
 
                         if (!vulnerabilityMergeCompleted && vulnerabilityStagingCompleted)
                         {
-                            await ThrowIfAbortRequestedAsync(run.Id, ct);
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.ThrowIfAbortRequestedAsync(run.Id, ct);
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
                                 IngestionRunStatuses.MergePending,
                                 ct
                             );
-                            await UpdateActiveRunStatusAsync(
+                            await _leaseManager.UpdateActiveRunStatusAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -791,7 +792,7 @@ public class IngestionService
                             fetchedVulnerabilityCount
                         );
 
-                        await UpdateRuntimeStateAsync(
+                        await _leaseManager.UpdateRuntimeStateAsync(
                             tenantId,
                             source.SourceKey,
                             runtime =>
@@ -804,7 +805,7 @@ public class IngestionService
                             },
                             ct
                         );
-                        await CompleteIngestionRunAsync(
+                        await _leaseManager.CompleteIngestionRunAsync(
                             run.Id,
                             tenantId,
                             source.SourceKey,
@@ -860,7 +861,7 @@ public class IngestionService
                             );
                         }
 
-                        await UpdateRuntimeStateAsync(
+                        await _leaseManager.UpdateRuntimeStateAsync(
                             tenantId,
                             source.SourceKey,
                             runtime =>
@@ -871,7 +872,7 @@ public class IngestionService
                             },
                             ct
                         );
-                        await CompleteIngestionRunAsync(
+                        await _leaseManager.CompleteIngestionRunAsync(
                             run.Id,
                             tenantId,
                             source.SourceKey,
@@ -893,7 +894,7 @@ public class IngestionService
             {
                 if (!runCompleted)
                 {
-                    await ReleaseIngestionLeaseAsync(tenantId, source.SourceKey, run.Id, ct);
+                    await _leaseManager.ReleaseIngestionLeaseAsync(tenantId, source.SourceKey, run.Id, ct);
                 }
             }
         }
@@ -960,829 +961,6 @@ public class IngestionService
                 _dbContext.ChangeTracker.Clear();
             }
         }
-    }
-
-    private async Task UpdateRuntimeStateAsync(
-        Guid tenantId,
-        string sourceKey,
-        Action<TenantIngestionRuntimeState> update,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var tenant = await _dbContext
-            .Tenants.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(t => t.Id == tenantId, ct);
-        if (tenant is null)
-        {
-            return;
-        }
-
-        if (IsInMemoryProvider())
-        {
-            var trackedSource = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                    ct
-                );
-
-            if (trackedSource is null)
-            {
-                return;
-            }
-
-            var runtime = new TenantIngestionRuntimeState(
-                trackedSource.ManualRequestedAt,
-                trackedSource.LastStartedAt,
-                trackedSource.LastCompletedAt,
-                trackedSource.LastSucceededAt,
-                trackedSource.LastStatus,
-                trackedSource.LastError
-            );
-            update(runtime);
-
-            trackedSource.UpdateRuntime(
-                runtime.ManualRequestedAt,
-                runtime.LastStartedAt,
-                runtime.LastCompletedAt,
-                runtime.LastSucceededAt,
-                runtime.LastStatus,
-                runtime.LastError
-            );
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        var source = await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(
-                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                ct
-            );
-
-        if (source is null)
-        {
-            return;
-        }
-
-        var detachedRuntime = new TenantIngestionRuntimeState(
-            source.ManualRequestedAt,
-            source.LastStartedAt,
-            source.LastCompletedAt,
-            source.LastSucceededAt,
-            source.LastStatus,
-            source.LastError
-        );
-        update(detachedRuntime);
-
-        await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
-            .ExecuteUpdateAsync(
-                setters =>
-                    setters
-                        .SetProperty(item => item.ManualRequestedAt, detachedRuntime.ManualRequestedAt)
-                        .SetProperty(item => item.LastStartedAt, detachedRuntime.LastStartedAt)
-                        .SetProperty(item => item.LastCompletedAt, detachedRuntime.LastCompletedAt)
-                        .SetProperty(item => item.LastSucceededAt, detachedRuntime.LastSucceededAt)
-                        .SetProperty(item => item.LastStatus, detachedRuntime.LastStatus)
-                        .SetProperty(item => item.LastError, detachedRuntime.LastError),
-                ct
-            );
-    }
-
-    private async Task UpdateActiveRunStatusAsync(
-        Guid runId,
-        Guid tenantId,
-        string sourceKey,
-        string status,
-        CancellationToken ct
-    )
-    {
-        await UpdateIngestionRunStatusAsync(runId, status, ct);
-        await UpdateRuntimeStateAsync(
-            tenantId,
-            sourceKey,
-            runtime => runtime.LastStatus = status,
-            ct
-        );
-    }
-
-    private async Task UpdateIngestionRunStatusAsync(Guid runId, string status, CancellationToken ct)
-    {
-        if (IsInMemoryProvider())
-        {
-            var run = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == runId, ct);
-            run?.UpdateStatus(status);
-            if (run is not null)
-            {
-                _dbContext.IngestionRuns.Update(run);
-                await _dbContext.SaveChangesAsync(ct);
-            }
-
-            return;
-        }
-
-        await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item => item.Id == runId)
-            .ExecuteUpdateAsync(setters => setters.SetProperty(item => item.Status, status), ct);
-    }
-
-    private async Task<AcquiredIngestionRun?> TryAcquireIngestionRunAsync(
-        Guid tenantId,
-        string sourceKey,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var now = DateTimeOffset.UtcNow;
-        var strategy = _dbContext.Database.CreateExecutionStrategy();
-
-        return await strategy.ExecuteAsync(async () =>
-        {
-            if (IsInMemoryProvider())
-            {
-                var sourceConfiguration = await _dbContext
-                    .TenantSourceConfigurations.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(
-                        item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                        ct
-                    );
-
-                if (sourceConfiguration is null)
-                {
-                    return null;
-                }
-
-                if (sourceConfiguration.ActiveIngestionRunId.HasValue)
-                {
-                    await FinalizeAbortedRunIfPendingAsync(
-                        sourceConfiguration.ActiveIngestionRunId.Value,
-                        tenantId,
-                        normalizedSourceKey,
-                        now,
-                        ct
-                    );
-                    await _dbContext.Entry(sourceConfiguration).ReloadAsync(ct);
-                }
-
-                if (
-                    sourceConfiguration.ActiveIngestionRunId.HasValue
-                    && sourceConfiguration.LeaseExpiresAt >= now
-                )
-                {
-                    return null;
-                }
-
-                IngestionRun? resumableRun = null;
-                if (sourceConfiguration.ActiveIngestionRunId.HasValue)
-                {
-                    resumableRun = await _dbContext
-                        .IngestionRuns.IgnoreQueryFilters()
-                        .FirstOrDefaultAsync(
-                            item =>
-                                item.Id == sourceConfiguration.ActiveIngestionRunId.Value
-                                && item.AbortRequestedAt == null
-                                && (
-                                    item.Status == IngestionRunStatuses.Staging
-                                    || item.Status == IngestionRunStatuses.MergePending
-                                    || item.Status == IngestionRunStatuses.Merging
-                                )
-                                && !item.CompletedAt.HasValue,
-                            ct
-                        );
-                }
-
-                var resumed = resumableRun is not null;
-                var run = resumableRun ?? IngestionRun.Start(tenantId, normalizedSourceKey, now);
-                sourceConfiguration.AcquireLease(run.Id, now, now.Add(LeaseDuration));
-                if (!resumed)
-                {
-                    await _dbContext.IngestionRuns.AddAsync(run, ct);
-                }
-
-                await _dbContext.SaveChangesAsync(ct);
-                return new AcquiredIngestionRun(run, resumed);
-            }
-
-            await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
-
-            var persistedSourceConfiguration = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                    ct
-                );
-
-            if (persistedSourceConfiguration is null)
-            {
-                await transaction.RollbackAsync(ct);
-                return null;
-            }
-
-            if (persistedSourceConfiguration.ActiveIngestionRunId.HasValue)
-            {
-                await FinalizeAbortedRunIfPendingAsync(
-                    persistedSourceConfiguration.ActiveIngestionRunId.Value,
-                    tenantId,
-                    normalizedSourceKey,
-                    now,
-                    ct
-                );
-                persistedSourceConfiguration = await _dbContext
-                    .TenantSourceConfigurations.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(
-                        item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                        ct
-                    );
-
-                if (persistedSourceConfiguration is null)
-                {
-                    await transaction.RollbackAsync(ct);
-                    return null;
-                }
-            }
-
-            if (
-                persistedSourceConfiguration.ActiveIngestionRunId.HasValue
-                && persistedSourceConfiguration.LeaseExpiresAt >= now
-            )
-            {
-                await transaction.RollbackAsync(ct);
-                return null;
-            }
-
-            IngestionRun? resumable = null;
-            if (persistedSourceConfiguration.ActiveIngestionRunId.HasValue)
-            {
-                resumable = await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(
-                        item =>
-                            item.Id == persistedSourceConfiguration.ActiveIngestionRunId.Value
-                            && item.AbortRequestedAt == null
-                            && (
-                                item.Status == IngestionRunStatuses.Staging
-                                || item.Status == IngestionRunStatuses.MergePending
-                                || item.Status == IngestionRunStatuses.Merging
-                            )
-                            && !item.CompletedAt.HasValue,
-                        ct
-                    );
-            }
-
-            var resumedRun = resumable is not null;
-            var acquiredRun = resumable ?? IngestionRun.Start(tenantId, normalizedSourceKey, now);
-
-            var updatedRows = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .Where(item => item.Id == persistedSourceConfiguration.Id)
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(item => item.ActiveIngestionRunId, acquiredRun.Id)
-                            .SetProperty(item => item.LeaseAcquiredAt, now)
-                            .SetProperty(item => item.LeaseExpiresAt, now.Add(LeaseDuration)),
-                    ct
-                );
-
-            if (updatedRows == 0)
-            {
-                await transaction.RollbackAsync(ct);
-                return null;
-            }
-
-            if (!resumedRun)
-            {
-                await _dbContext.IngestionRuns.AddAsync(acquiredRun, ct);
-            }
-
-            await _dbContext.SaveChangesAsync(ct);
-            await transaction.CommitAsync(ct);
-
-            return new AcquiredIngestionRun(acquiredRun, resumedRun);
-        });
-    }
-
-    private async Task FinalizeAbortedRunIfPendingAsync(
-        Guid runId,
-        Guid tenantId,
-        string sourceKey,
-        DateTimeOffset completedAt,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-
-        if (IsInMemoryProvider())
-        {
-            var run = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == runId, ct);
-
-            if (
-                run is null
-                || run.CompletedAt.HasValue
-                || !run.AbortRequestedAt.HasValue
-                || !IngestionRunStatePolicy.IsActive(run.Status)
-            )
-            {
-                return;
-            }
-
-            _dbContext.Entry(run).Property(nameof(IngestionRun.CompletedAt)).CurrentValue =
-                completedAt;
-            _dbContext.Entry(run).Property(nameof(IngestionRun.Status)).CurrentValue =
-                IngestionRunStatuses.FailedTerminal;
-            _dbContext.Entry(run).Property(nameof(IngestionRun.Error)).CurrentValue =
-                IngestionFailurePolicy.Describe(new IngestionAbortedException());
-            var source = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item =>
-                        item.TenantId == tenantId
-                        && item.SourceKey == normalizedSourceKey
-                        && item.ActiveIngestionRunId == runId,
-                    ct
-                );
-            source?.ReleaseLease(runId);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item =>
-                item.Id == runId
-                && item.AbortRequestedAt != null
-                && item.CompletedAt == null
-                && (
-                    item.Status == IngestionRunStatuses.Staging
-                    || item.Status == IngestionRunStatuses.MergePending
-                    || item.Status == IngestionRunStatuses.Merging
-                ))
-            .ExecuteUpdateAsync(
-                setters => setters
-                    .SetProperty(item => item.CompletedAt, completedAt)
-                    .SetProperty(item => item.Status, IngestionRunStatuses.FailedTerminal)
-                    .SetProperty(
-                        item => item.Error,
-                        IngestionFailurePolicy.Describe(new IngestionAbortedException())
-                    ),
-                ct
-            );
-
-        await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.SourceKey == normalizedSourceKey
-                && item.ActiveIngestionRunId == runId)
-            .ExecuteUpdateAsync(
-                setters =>
-                    setters
-                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
-                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
-                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
-                ct
-            );
-    }
-
-    private async Task ThrowIfAbortRequestedAsync(Guid runId, CancellationToken ct)
-    {
-        var abortRequestedAt = await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item => item.Id == runId)
-            .Select(item => item.AbortRequestedAt)
-            .FirstOrDefaultAsync(ct);
-
-        if (abortRequestedAt.HasValue)
-        {
-            _dbContext.ChangeTracker.Clear();
-            throw new IngestionAbortedException();
-        }
-    }
-
-    private async Task CompleteIngestionRunAsync(
-        Guid runId,
-        Guid tenantId,
-        string sourceKey,
-        bool succeeded,
-        string? error,
-        StagedVulnerabilityMergeSummary vulnerabilityMergeSummary,
-        StagedAssetMergeSummary assetMergeSummary,
-        int deactivatedMachineCount,
-        string? failureStatus,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var completedAt = DateTimeOffset.UtcNow;
-        if (IsInMemoryProvider())
-        {
-            var run = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(item => item.Id == runId, ct);
-            if (run is null)
-            {
-                return;
-            }
-
-            if (succeeded)
-            {
-                run.CompleteSucceeded(
-                    completedAt,
-                    assetMergeSummary.StagedMachineCount,
-                    assetMergeSummary.StagedSoftwareCount,
-                    vulnerabilityMergeSummary.StagedVulnerabilityCount,
-                    assetMergeSummary.PersistedMachineCount,
-                    deactivatedMachineCount,
-                    assetMergeSummary.PersistedSoftwareCount,
-                    vulnerabilityMergeSummary.PersistedVulnerabilityCount
-                );
-            }
-            else
-            {
-                run.CompleteFailed(
-                    completedAt,
-                    error ?? "Unknown ingestion failure",
-                    failureStatus ?? IngestionRunStatuses.FailedRecoverable,
-                    assetMergeSummary.StagedMachineCount,
-                    assetMergeSummary.StagedSoftwareCount,
-                    vulnerabilityMergeSummary.StagedVulnerabilityCount,
-                    assetMergeSummary.PersistedMachineCount,
-                    deactivatedMachineCount,
-                    assetMergeSummary.PersistedSoftwareCount,
-                    vulnerabilityMergeSummary.PersistedVulnerabilityCount
-                );
-            }
-
-            var source = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item =>
-                        item.TenantId == tenantId
-                        && item.SourceKey == normalizedSourceKey
-                        && item.ActiveIngestionRunId == runId,
-                    ct
-                );
-            if (source is not null)
-            {
-                source.ReleaseLease(runId);
-                source.UpdateRuntime(
-                    source.ManualRequestedAt,
-                    source.LastStartedAt,
-                    completedAt,
-                    succeeded ? completedAt : source.LastSucceededAt,
-                    succeeded
-                        ? IngestionRunStatuses.Succeeded
-                        : failureStatus ?? IngestionRunStatuses.FailedRecoverable,
-                    succeeded ? string.Empty : error ?? "Unknown ingestion failure"
-                );
-            }
-            await _dbContext.SaveChangesAsync(ct);
-
-            if (succeeded)
-            {
-                await ClearStagedDataForRunAsync(runId, ct);
-            }
-
-            var inMemoryCleanupSummary = await CleanupExpiredIngestionArtifactsAsync(
-                completedAt,
-                ct
-            );
-            if (inMemoryCleanupSummary.PrunedRunCount > 0)
-            {
-                _logger.LogInformation(
-                    "Pruned ingestion artifacts: runs={PrunedRunCount} stagedVulnerabilities={PrunedVulnerabilityCount} stagedExposures={PrunedExposureCount} stagedAssets={PrunedAssetCount} stagedSoftwareLinks={PrunedSoftwareLinkCount}",
-                    inMemoryCleanupSummary.PrunedRunCount,
-                    inMemoryCleanupSummary.PrunedVulnerabilityCount,
-                    inMemoryCleanupSummary.PrunedExposureCount,
-                    inMemoryCleanupSummary.PrunedAssetCount,
-                    inMemoryCleanupSummary.PrunedSoftwareLinkCount
-                );
-            }
-            return;
-        }
-
-        var strategy = _dbContext.Database.CreateExecutionStrategy();
-
-        await strategy.ExecuteAsync(async () =>
-        {
-            await using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
-
-            var updatedRunRows = succeeded
-                ? await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .Where(item => item.Id == runId)
-                    .ExecuteUpdateAsync(
-                        setters =>
-                            setters
-                                .SetProperty(item => item.CompletedAt, completedAt)
-                                .SetProperty(item => item.Status, IngestionRunStatuses.Succeeded)
-                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
-                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
-                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
-                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
-                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
-                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
-                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
-                                .SetProperty(item => item.Error, string.Empty),
-                        ct
-                    )
-                : await _dbContext
-                    .IngestionRuns.IgnoreQueryFilters()
-                    .Where(item => item.Id == runId)
-                    .ExecuteUpdateAsync(
-                        setters =>
-                            setters
-                                .SetProperty(item => item.CompletedAt, completedAt)
-                                .SetProperty(item => item.Status, failureStatus ?? IngestionRunStatuses.FailedRecoverable)
-                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
-                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
-                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
-                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
-                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
-                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
-                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
-                                .SetProperty(
-                                    item => item.Error,
-                                    error ?? "Unknown ingestion failure"
-                                ),
-                        ct
-                    );
-
-            if (updatedRunRows == 0)
-            {
-                _logger.LogWarning(
-                    "Expected to complete ingestion run {RunId} for tenant {TenantId} and source {SourceKey}, but no run row was updated.",
-                    runId,
-                    tenantId,
-                    normalizedSourceKey
-                );
-            }
-
-            await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .Where(item =>
-                    item.TenantId == tenantId
-                    && item.SourceKey == normalizedSourceKey
-                    && item.ActiveIngestionRunId == runId
-                )
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
-                            .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
-                            .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
-                    ct
-                );
-
-            await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
-                .ExecuteUpdateAsync(
-                    setters =>
-                        setters
-                            .SetProperty(item => item.LastCompletedAt, completedAt)
-                            .SetProperty(
-                                item => item.LastSucceededAt,
-                                item => succeeded ? completedAt : item.LastSucceededAt
-                            )
-                            .SetProperty(
-                                item => item.LastStatus,
-                                succeeded
-                                    ? IngestionRunStatuses.Succeeded
-                                    : failureStatus ?? IngestionRunStatuses.FailedRecoverable
-                            )
-                            .SetProperty(
-                                item => item.LastError,
-                                succeeded ? string.Empty : error ?? "Unknown ingestion failure"
-                            ),
-                    ct
-                );
-
-            await transaction.CommitAsync(ct);
-        });
-
-        if (succeeded)
-        {
-            await ClearStagedDataForRunAsync(runId, ct);
-        }
-
-        var cleanupSummary = await CleanupExpiredIngestionArtifactsAsync(completedAt, ct);
-        if (cleanupSummary.PrunedRunCount > 0)
-        {
-            _logger.LogInformation(
-                "Pruned ingestion artifacts: runs={PrunedRunCount} stagedVulnerabilities={PrunedVulnerabilityCount} stagedExposures={PrunedExposureCount} stagedAssets={PrunedAssetCount} stagedSoftwareLinks={PrunedSoftwareLinkCount}",
-                cleanupSummary.PrunedRunCount,
-                cleanupSummary.PrunedVulnerabilityCount,
-                cleanupSummary.PrunedExposureCount,
-                cleanupSummary.PrunedAssetCount,
-                cleanupSummary.PrunedSoftwareLinkCount
-            );
-        }
-    }
-
-    private async Task<IngestionArtifactCleanupSummary> CleanupExpiredIngestionArtifactsAsync(
-        DateTimeOffset now,
-        CancellationToken ct
-    )
-    {
-        var completedCutoff = now.Subtract(IngestionArtifactRetention);
-        var failedCutoff = now.Subtract(FailedIngestionRetention);
-        var expiredRunIds = await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item =>
-                item.CompletedAt.HasValue
-                && (
-                    ((item.Status == IngestionRunStatuses.FailedRecoverable
-                        || item.Status == IngestionRunStatuses.FailedTerminal)
-                        && item.CompletedAt.Value < failedCutoff)
-                    || ((item.Status != IngestionRunStatuses.FailedRecoverable
-                            && item.Status != IngestionRunStatuses.FailedTerminal)
-                        && item.CompletedAt.Value < completedCutoff)
-                )
-            )
-            .Select(item => item.Id)
-            .ToListAsync(ct);
-
-        if (expiredRunIds.Count == 0)
-        {
-            return new IngestionArtifactCleanupSummary(0, 0, 0, 0, 0);
-        }
-
-        if (IsInMemoryProvider())
-        {
-            var stagedExposures = await _dbContext
-                .StagedVulnerabilityExposures.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var stagedVulnerabilities = await _dbContext
-                .StagedVulnerabilities.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var stagedSoftwareLinks = await _dbContext
-                .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var stagedDeviceRows = await _dbContext
-                .StagedDevices.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var checkpoints = await _dbContext
-                .IngestionCheckpoints.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-                .ToListAsync(ct);
-            var runs = await _dbContext
-                .IngestionRuns.IgnoreQueryFilters()
-                .Where(item => expiredRunIds.Contains(item.Id))
-                .ToListAsync(ct);
-
-            _dbContext.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
-            _dbContext.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
-            _dbContext.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
-            _dbContext.StagedDevices.RemoveRange(stagedDeviceRows);
-            _dbContext.IngestionCheckpoints.RemoveRange(checkpoints);
-            _dbContext.IngestionRuns.RemoveRange(runs);
-            await _dbContext.SaveChangesAsync(ct);
-
-            return new IngestionArtifactCleanupSummary(
-                runs.Count,
-                stagedVulnerabilities.Count,
-                stagedExposures.Count,
-                stagedDeviceRows.Count,
-                stagedSoftwareLinks.Count
-            );
-        }
-
-        var prunedExposureCount = await _dbContext
-            .StagedVulnerabilityExposures.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedVulnerabilityCount = await _dbContext
-            .StagedVulnerabilities.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedSoftwareLinkCount = await _dbContext
-            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedAssetCount = await _dbContext
-            .StagedDevices.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
-            .ExecuteDeleteAsync(ct);
-        var prunedRunCount = await _dbContext
-            .IngestionRuns.IgnoreQueryFilters()
-            .Where(item => expiredRunIds.Contains(item.Id))
-            .ExecuteDeleteAsync(ct);
-
-        return new IngestionArtifactCleanupSummary(
-            prunedRunCount,
-            prunedVulnerabilityCount,
-            prunedExposureCount,
-            prunedAssetCount,
-            prunedSoftwareLinkCount
-        );
-    }
-
-    private async Task ReleaseIngestionLeaseAsync(
-        Guid tenantId,
-        string sourceKey,
-        Guid runId,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        if (IsInMemoryProvider())
-        {
-            var source = await _dbContext
-                .TenantSourceConfigurations.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
-                    ct
-                );
-            if (source is null)
-            {
-                return;
-            }
-
-            source.ReleaseLease(runId);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .TenantSourceConfigurations.IgnoreQueryFilters()
-            .Where(item =>
-                item.TenantId == tenantId
-                && item.SourceKey == normalizedSourceKey
-                && item.ActiveIngestionRunId == runId
-            )
-            .ExecuteUpdateAsync(
-                setters =>
-                    setters
-                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
-                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
-                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
-                ct
-            );
-    }
-
-    private async Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct)
-    {
-        if (IsInMemoryProvider())
-        {
-            var stagedExposures = await _dbContext
-                .StagedVulnerabilityExposures.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-            var stagedVulnerabilities = await _dbContext
-                .StagedVulnerabilities.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-            var stagedSoftwareLinks = await _dbContext
-                .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-            var stagedDevices = await _dbContext
-                .StagedDevices.IgnoreQueryFilters()
-                .Where(item => item.IngestionRunId == ingestionRunId)
-                .ToListAsync(ct);
-
-            _dbContext.StagedVulnerabilityExposures.RemoveRange(stagedExposures);
-            _dbContext.StagedVulnerabilities.RemoveRange(stagedVulnerabilities);
-            _dbContext.StagedDeviceSoftwareInstallations.RemoveRange(stagedSoftwareLinks);
-            _dbContext.StagedDevices.RemoveRange(stagedDevices);
-            await _dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await _dbContext
-            .StagedVulnerabilityExposures.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .StagedVulnerabilities.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
-        await _dbContext
-            .StagedDevices.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId)
-            .ExecuteDeleteAsync(ct);
     }
 
     private async Task<bool> IsCheckpointCompletedAsync(
@@ -1934,7 +1112,7 @@ public class IngestionService
 
         while (true)
         {
-            await ThrowIfAbortRequestedAsync(ingestionRunId, ct);
+            await _leaseManager.ThrowIfAbortRequestedAsync(ingestionRunId, ct);
             batchNumber++;
             var batch = await batchSource.FetchVulnerabilityBatchAsync(
                 tenantId,
@@ -2472,7 +1650,7 @@ public class IngestionService
 
         while (true)
         {
-            await ThrowIfAbortRequestedAsync(ingestionRunId, ct);
+            await _leaseManager.ThrowIfAbortRequestedAsync(ingestionRunId, ct);
             var batch = await batchSource.FetchAssetBatchAsync(
                 tenantId,
                 cursorJson,

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -65,11 +65,11 @@ public class IngestionService
             new VulnerabilityResolver(dbContext, NullLogger<VulnerabilityResolver>.Instance),
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
-            new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
-            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
-            new IngestionSnapshotLifecycle(dbContext),
-            CreateBulkWriter(dbContext),
+            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
+            new IngestionSnapshotLifecycle(dbContext, new InMemoryIngestionBulkWriter(dbContext)),
+            new InMemoryIngestionBulkWriter(dbContext),
             logger
         ) { }
 
@@ -101,11 +101,11 @@ public class IngestionService
             vulnerabilityResolver,
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
-            new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
-            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
-            new IngestionSnapshotLifecycle(dbContext),
-            CreateBulkWriter(dbContext),
+            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
+            new IngestionSnapshotLifecycle(dbContext, new InMemoryIngestionBulkWriter(dbContext)),
+            new InMemoryIngestionBulkWriter(dbContext),
             logger
         ) { }
 
@@ -137,18 +137,13 @@ public class IngestionService
             new VulnerabilityResolver(dbContext, NullLogger<VulnerabilityResolver>.Instance),
             normalizedSoftwareProjectionService: null,
             remediationDecisionService,
-            new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(dbContext),
-            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
-            new IngestionSnapshotLifecycle(dbContext),
-            CreateBulkWriter(dbContext),
+            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
+            new IngestionSnapshotLifecycle(dbContext, new InMemoryIngestionBulkWriter(dbContext)),
+            new InMemoryIngestionBulkWriter(dbContext),
             logger
         ) { }
-
-    private static IIngestionBulkWriter CreateBulkWriter(PatchHoundDbContext db) =>
-        db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
-            ? new InMemoryIngestionBulkWriter(db)
-            : new PostgresIngestionBulkWriter(db);
 
     internal IngestionService(
         PatchHoundDbContext dbContext,

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -34,6 +34,7 @@ public class IngestionService
     private readonly NormalizedSoftwareProjectionService? _normalizedSoftwareProjectionService;
     private readonly RemediationDecisionService? _remediationDecisionService;
     private readonly IngestionLeaseManager _leaseManager;
+    private readonly IngestionCheckpointWriter _checkpointWriter;
     private readonly ILogger<IngestionService> _logger;
 
     public IngestionService(
@@ -64,6 +65,7 @@ public class IngestionService
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionCheckpointWriter(dbContext),
             logger
         ) { }
 
@@ -96,6 +98,7 @@ public class IngestionService
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionCheckpointWriter(dbContext),
             logger
         ) { }
 
@@ -128,6 +131,7 @@ public class IngestionService
             normalizedSoftwareProjectionService: null,
             remediationDecisionService,
             new IngestionLeaseManager(dbContext, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionCheckpointWriter(dbContext),
             logger
         ) { }
 
@@ -146,6 +150,7 @@ public class IngestionService
         NormalizedSoftwareProjectionService? normalizedSoftwareProjectionService,
         RemediationDecisionService? remediationDecisionService,
         IngestionLeaseManager leaseManager,
+        IngestionCheckpointWriter checkpointWriter,
         ILogger<IngestionService> logger
     )
     {
@@ -163,6 +168,7 @@ public class IngestionService
         _normalizedSoftwareProjectionService = normalizedSoftwareProjectionService;
         _remediationDecisionService = remediationDecisionService;
         _leaseManager = leaseManager;
+        _checkpointWriter = checkpointWriter;
         _logger = logger;
     }
 
@@ -249,22 +255,22 @@ public class IngestionService
                             tenantId
                         );
 
-                        var assetStagingCompleted = await IsCheckpointCompletedAsync(
+                        var assetStagingCompleted = await _checkpointWriter.IsCheckpointCompletedAsync(
                             run.Id,
                             CheckpointPhases.AssetStaging,
                             ct
                         );
-                        var assetMergeCompleted = await IsCheckpointCompletedAsync(
+                        var assetMergeCompleted = await _checkpointWriter.IsCheckpointCompletedAsync(
                             run.Id,
                             CheckpointPhases.AssetMerge,
                             ct
                         );
-                        var vulnerabilityStagingCompleted = await IsCheckpointCompletedAsync(
+                        var vulnerabilityStagingCompleted = await _checkpointWriter.IsCheckpointCompletedAsync(
                             run.Id,
                             CheckpointPhases.VulnerabilityStaging,
                             ct
                         );
-                        var vulnerabilityMergeCompleted = await IsCheckpointCompletedAsync(
+                        var vulnerabilityMergeCompleted = await _checkpointWriter.IsCheckpointCompletedAsync(
                             run.Id,
                             CheckpointPhases.VulnerabilityMerge,
                             ct
@@ -333,7 +339,7 @@ public class IngestionService
                                 tenantId,
                                 ct
                             );
-                            await CommitCheckpointAsync(
+                            await _checkpointWriter.CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -390,7 +396,7 @@ public class IngestionService
                                 0,
                                 ct
                             );
-                            await CommitCheckpointAsync(
+                            await _checkpointWriter.CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -429,7 +435,7 @@ public class IngestionService
                                 tenantId,
                                 ct
                             );
-                            await CommitCheckpointAsync(
+                            await _checkpointWriter.CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -498,12 +504,12 @@ public class IngestionService
                                 tenantId,
                                 ct
                             );
-                            var assetMergeBatchNumber = await GetCheckpointBatchNumberAsync(
+                            var assetMergeBatchNumber = await _checkpointWriter.GetCheckpointBatchNumberAsync(
                                 run.Id,
                                 CheckpointPhases.AssetStaging,
                                 ct
                             );
-                            await CommitCheckpointAsync(
+                            await _checkpointWriter.CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -606,7 +612,7 @@ public class IngestionService
                                 0,
                                 ct
                             );
-                            await CommitCheckpointAsync(
+                            await _checkpointWriter.CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -658,12 +664,12 @@ public class IngestionService
                                 tenantId,
                                 ct
                             );
-                            var vulnerabilityMergeBatchNumber = await GetCheckpointBatchNumberAsync(
+                            var vulnerabilityMergeBatchNumber = await _checkpointWriter.GetCheckpointBatchNumberAsync(
                                 run.Id,
                                 CheckpointPhases.VulnerabilityStaging,
                                 ct
                             );
-                            await CommitCheckpointAsync(
+                            await _checkpointWriter.CommitCheckpointAsync(
                                 run.Id,
                                 tenantId,
                                 source.SourceKey,
@@ -963,79 +969,6 @@ public class IngestionService
         }
     }
 
-    private async Task<bool> IsCheckpointCompletedAsync(
-        Guid ingestionRunId,
-        string phase,
-        CancellationToken ct
-    )
-    {
-        return await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .AnyAsync(
-                item =>
-                    item.IngestionRunId == ingestionRunId
-                    && item.Phase == phase
-                    && item.Status == CheckpointStatuses.Completed,
-                ct
-            );
-    }
-
-    private async Task<int> GetCheckpointBatchNumberAsync(
-        Guid ingestionRunId,
-        string phase,
-        CancellationToken ct
-    )
-    {
-        return await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .Where(item => item.IngestionRunId == ingestionRunId && item.Phase == phase)
-            .Select(item => item.BatchNumber)
-            .FirstOrDefaultAsync(ct);
-    }
-
-    private async Task CommitCheckpointAsync(
-        Guid ingestionRunId,
-        Guid tenantId,
-        string sourceKey,
-        string phase,
-        int batchNumber,
-        string? cursorJson,
-        int recordsCommitted,
-        string status,
-        CancellationToken ct
-    )
-    {
-        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
-        var checkpoint = await _dbContext
-            .IngestionCheckpoints.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(
-                item => item.IngestionRunId == ingestionRunId && item.Phase == phase,
-                ct
-            );
-
-        if (checkpoint is null)
-        {
-            checkpoint = IngestionCheckpoint.Start(
-                ingestionRunId,
-                tenantId,
-                normalizedSourceKey,
-                phase,
-                DateTimeOffset.UtcNow
-            );
-            await _dbContext.IngestionCheckpoints.AddAsync(checkpoint, ct);
-        }
-
-        checkpoint.CommitBatch(
-            batchNumber,
-            cursorJson,
-            recordsCommitted,
-            status,
-            DateTimeOffset.UtcNow
-        );
-
-        await _dbContext.SaveChangesAsync(ct);
-        _dbContext.ChangeTracker.Clear();
-    }
 
     private async Task StageVulnerabilitiesAsync(
         Guid ingestionRunId,
@@ -1133,7 +1066,7 @@ public class IngestionService
                     batchNumber,
                     ct
                 );
-                await CommitCheckpointAsync(
+                await _checkpointWriter.CommitCheckpointAsync(
                     ingestionRunId,
                     tenantId,
                     sourceKey,
@@ -1147,7 +1080,7 @@ public class IngestionService
             }
             else
             {
-                await CommitCheckpointAsync(
+                await _checkpointWriter.CommitCheckpointAsync(
                     ingestionRunId,
                     tenantId,
                     sourceKey,
@@ -1596,7 +1529,7 @@ public class IngestionService
             0,
             ct
         );
-        await CommitCheckpointAsync(
+        await _checkpointWriter.CommitCheckpointAsync(
             run.Id,
             tenantId,
             run.SourceKey,
@@ -1608,7 +1541,7 @@ public class IngestionService
             ct
         );
         await ProcessStagedAssetsAsync(run.Id, tenantId, run.SourceKey, null, ct);
-        await CommitCheckpointAsync(
+        await _checkpointWriter.CommitCheckpointAsync(
             run.Id,
             tenantId,
             run.SourceKey,
@@ -1679,7 +1612,7 @@ public class IngestionService
                     batchNumber,
                     ct
                 );
-                await CommitCheckpointAsync(
+                await _checkpointWriter.CommitCheckpointAsync(
                     ingestionRunId,
                     tenantId,
                     sourceKey,
@@ -1693,7 +1626,7 @@ public class IngestionService
             }
             else if (batch.IsComplete)
             {
-                await CommitCheckpointAsync(
+                await _checkpointWriter.CommitCheckpointAsync(
                     ingestionRunId,
                     tenantId,
                     sourceKey,

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -819,28 +819,8 @@ public class IngestionService
         return startedAny;
     }
 
-    private async Task<int> RefreshDeviceActivityForTenantAsync(Guid tenantId, CancellationToken ct)
-    {
-        var cutoff = DateTimeOffset.UtcNow.Subtract(DeviceInactiveThreshold);
-        var devices = await _dbContext.Devices
-            .IgnoreQueryFilters()
-            .Where(d => d.TenantId == tenantId)
-            .ToListAsync(ct);
-        var deactivatedCount = 0;
-
-        foreach (var device in devices)
-        {
-            var isActive = device.LastSeenAt.HasValue && device.LastSeenAt.Value >= cutoff;
-            device.SetActiveInTenant(isActive);
-            if (!isActive)
-            {
-                deactivatedCount++;
-            }
-        }
-
-        await _dbContext.SaveChangesAsync(ct);
-        return deactivatedCount;
-    }
+    private Task<int> RefreshDeviceActivityForTenantAsync(Guid tenantId, CancellationToken ct) =>
+        _bulkWriter.RefreshDeviceActivityAsync(tenantId, DeviceInactiveThreshold, ct);
 
     private async Task<T> ExecuteWithConcurrencyRetryAsync<T>(
         Func<Task<T>> operation,

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using PatchHound.Core.Entities;
@@ -38,113 +39,7 @@ public class IngestionService
     private readonly IIngestionBulkWriter _bulkWriter;
     private readonly ILogger<IngestionService> _logger;
 
-    public IngestionService(
-        PatchHoundDbContext dbContext,
-        IEnumerable<IIngestionSource> sources,
-        EnrichmentJobEnqueuer enrichmentJobEnqueuer,
-        IStagedDeviceMergeService stagedDeviceMergeService,
-        IStagedCloudApplicationMergeService stagedCloudApplicationMergeService,
-        IDeviceRuleEvaluationService deviceRuleEvaluationService,
-        ExposureDerivationService exposureDerivationService,
-        ExposureEpisodeService exposureEpisodeService,
-        ExposureAssessmentService exposureAssessmentService,
-        RiskScoreService riskScoreService,
-        ILogger<IngestionService> logger
-    )
-        : this(
-            dbContext,
-            sources,
-            enrichmentJobEnqueuer,
-            stagedDeviceMergeService,
-            stagedCloudApplicationMergeService,
-            deviceRuleEvaluationService,
-            exposureDerivationService,
-            exposureEpisodeService,
-            exposureAssessmentService,
-            riskScoreService,
-            new VulnerabilityResolver(dbContext, NullLogger<VulnerabilityResolver>.Instance),
-            normalizedSoftwareProjectionService: null,
-            remediationDecisionService: null,
-            new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance),
-            new IngestionCheckpointWriter(dbContext),
-            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
-            new IngestionSnapshotLifecycle(dbContext, new InMemoryIngestionBulkWriter(dbContext)),
-            new InMemoryIngestionBulkWriter(dbContext),
-            logger
-        ) { }
-
-    public IngestionService(
-        PatchHoundDbContext dbContext,
-        IEnumerable<IIngestionSource> sources,
-        EnrichmentJobEnqueuer enrichmentJobEnqueuer,
-        IStagedDeviceMergeService stagedDeviceMergeService,
-        IStagedCloudApplicationMergeService stagedCloudApplicationMergeService,
-        IDeviceRuleEvaluationService deviceRuleEvaluationService,
-        ExposureDerivationService exposureDerivationService,
-        ExposureEpisodeService exposureEpisodeService,
-        ExposureAssessmentService exposureAssessmentService,
-        RiskScoreService riskScoreService,
-        VulnerabilityResolver vulnerabilityResolver,
-        ILogger<IngestionService> logger
-    )
-        : this(
-            dbContext,
-            sources,
-            enrichmentJobEnqueuer,
-            stagedDeviceMergeService,
-            stagedCloudApplicationMergeService,
-            deviceRuleEvaluationService,
-            exposureDerivationService,
-            exposureEpisodeService,
-            exposureAssessmentService,
-            riskScoreService,
-            vulnerabilityResolver,
-            normalizedSoftwareProjectionService: null,
-            remediationDecisionService: null,
-            new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance),
-            new IngestionCheckpointWriter(dbContext),
-            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
-            new IngestionSnapshotLifecycle(dbContext, new InMemoryIngestionBulkWriter(dbContext)),
-            new InMemoryIngestionBulkWriter(dbContext),
-            logger
-        ) { }
-
-    public IngestionService(
-        PatchHoundDbContext dbContext,
-        IEnumerable<IIngestionSource> sources,
-        EnrichmentJobEnqueuer enrichmentJobEnqueuer,
-        IStagedDeviceMergeService stagedDeviceMergeService,
-        IStagedCloudApplicationMergeService stagedCloudApplicationMergeService,
-        IDeviceRuleEvaluationService deviceRuleEvaluationService,
-        ExposureDerivationService exposureDerivationService,
-        ExposureEpisodeService exposureEpisodeService,
-        ExposureAssessmentService exposureAssessmentService,
-        RiskScoreService riskScoreService,
-        RemediationDecisionService? remediationDecisionService,
-        ILogger<IngestionService> logger
-    )
-        : this(
-            dbContext,
-            sources,
-            enrichmentJobEnqueuer,
-            stagedDeviceMergeService,
-            stagedCloudApplicationMergeService,
-            deviceRuleEvaluationService,
-            exposureDerivationService,
-            exposureEpisodeService,
-            exposureAssessmentService,
-            riskScoreService,
-            new VulnerabilityResolver(dbContext, NullLogger<VulnerabilityResolver>.Instance),
-            normalizedSoftwareProjectionService: null,
-            remediationDecisionService,
-            new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance),
-            new IngestionCheckpointWriter(dbContext),
-            new IngestionStagingPipeline(dbContext, enrichmentJobEnqueuer, new IngestionLeaseManager(dbContext, new InMemoryIngestionBulkWriter(dbContext), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(dbContext)),
-            new IngestionSnapshotLifecycle(dbContext, new InMemoryIngestionBulkWriter(dbContext)),
-            new InMemoryIngestionBulkWriter(dbContext),
-            logger
-        ) { }
-
+    [ActivatorUtilitiesConstructor]
     internal IngestionService(
         PatchHoundDbContext dbContext,
         IEnumerable<IIngestionSource> sources,

--- a/src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
@@ -5,8 +5,25 @@ using PatchHound.Infrastructure.Tenants;
 
 namespace PatchHound.Infrastructure.Services;
 
-public class IngestionSnapshotLifecycle(PatchHoundDbContext dbContext)
+public class IngestionSnapshotLifecycle
 {
+    private readonly PatchHoundDbContext dbContext;
+    private readonly IIngestionBulkWriter _bulkWriter;
+
+    public IngestionSnapshotLifecycle(PatchHoundDbContext dbContext)
+        : this(dbContext, CreateBulkWriter(dbContext)) { }
+
+    internal IngestionSnapshotLifecycle(PatchHoundDbContext dbContext, IIngestionBulkWriter bulkWriter)
+    {
+        this.dbContext = dbContext;
+        _bulkWriter = bulkWriter;
+    }
+
+    private static IIngestionBulkWriter CreateBulkWriter(PatchHoundDbContext db) =>
+        db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
+            ? new InMemoryIngestionBulkWriter(db)
+            : new PostgresIngestionBulkWriter(db);
+
     internal static bool SupportsSoftwareSnapshots(string sourceKey)
     {
         return sourceKey.Trim().ToLowerInvariant() == TenantSourceCatalog.DefenderSourceKey;
@@ -137,30 +154,6 @@ public class IngestionSnapshotLifecycle(PatchHoundDbContext dbContext)
 
     internal async Task CleanupSnapshotDataAsync(Guid snapshotId, CancellationToken ct)
     {
-        if (dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
-        {
-            var tenantSoftware = await dbContext
-                .SoftwareTenantRecords.IgnoreQueryFilters()
-                .Where(item => item.SnapshotId == snapshotId)
-                .ToListAsync(ct);
-            var installations = await dbContext
-                .SoftwareProductInstallations.IgnoreQueryFilters()
-                .Where(item => item.SnapshotId == snapshotId)
-                .ToListAsync(ct);
-
-            dbContext.SoftwareTenantRecords.RemoveRange(tenantSoftware);
-            dbContext.SoftwareProductInstallations.RemoveRange(installations);
-            await dbContext.SaveChangesAsync(ct);
-            return;
-        }
-
-        await dbContext
-            .SoftwareProductInstallations.IgnoreQueryFilters()
-            .Where(item => item.SnapshotId == snapshotId)
-            .ExecuteDeleteAsync(ct);
-        await dbContext
-            .SoftwareTenantRecords.IgnoreQueryFilters()
-            .Where(item => item.SnapshotId == snapshotId)
-            .ExecuteDeleteAsync(ct);
+        await _bulkWriter.CleanupSnapshotDataAsync(snapshotId, ct);
     }
 }

--- a/src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
@@ -10,19 +10,11 @@ public class IngestionSnapshotLifecycle
     private readonly PatchHoundDbContext dbContext;
     private readonly IIngestionBulkWriter _bulkWriter;
 
-    public IngestionSnapshotLifecycle(PatchHoundDbContext dbContext)
-        : this(dbContext, CreateBulkWriter(dbContext)) { }
-
     internal IngestionSnapshotLifecycle(PatchHoundDbContext dbContext, IIngestionBulkWriter bulkWriter)
     {
         this.dbContext = dbContext;
         _bulkWriter = bulkWriter;
     }
-
-    private static IIngestionBulkWriter CreateBulkWriter(PatchHoundDbContext db) =>
-        db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
-            ? new InMemoryIngestionBulkWriter(db)
-            : new PostgresIngestionBulkWriter(db);
 
     internal static bool SupportsSoftwareSnapshots(string sourceKey)
     {

--- a/src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionSnapshotLifecycle.cs
@@ -1,0 +1,166 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Tenants;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class IngestionSnapshotLifecycle(PatchHoundDbContext dbContext)
+{
+    internal static bool SupportsSoftwareSnapshots(string sourceKey)
+    {
+        return sourceKey.Trim().ToLowerInvariant() == TenantSourceCatalog.DefenderSourceKey;
+    }
+
+    internal async Task<IngestionSnapshot> GetOrCreateBuildingSoftwareSnapshotAsync(
+        Guid tenantId,
+        string sourceKey,
+        Guid ingestionRunId,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var source = await dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+
+        if (source.BuildingSnapshotId is Guid buildingSnapshotId)
+        {
+            var existing = await dbContext
+                .IngestionSnapshots.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(item => item.Id == buildingSnapshotId, ct);
+            if (
+                existing is not null
+                && existing.IngestionRunId == ingestionRunId
+                && existing.Status == IngestionSnapshotStatuses.Building
+            )
+            {
+                return existing;
+            }
+
+            if (existing is not null && existing.Status == IngestionSnapshotStatuses.Building)
+            {
+                existing.Discard();
+                await CleanupSnapshotDataAsync(existing.Id, ct);
+            }
+        }
+
+        var snapshot = IngestionSnapshot.Create(
+            tenantId,
+            normalizedSourceKey,
+            ingestionRunId,
+            DateTimeOffset.UtcNow
+        );
+        source.SetSnapshotPointers(source.ActiveSnapshotId, snapshot.Id);
+        await dbContext.IngestionSnapshots.AddAsync(snapshot, ct);
+        await dbContext.SaveChangesAsync(ct);
+        return snapshot;
+    }
+
+    internal async Task PublishSnapshotAsync(
+        Guid tenantId,
+        string sourceKey,
+        Guid snapshotId,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var source = await dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+        var snapshot = await dbContext
+            .IngestionSnapshots.IgnoreQueryFilters()
+            .FirstAsync(item => item.Id == snapshotId, ct);
+
+        Guid? retiredSnapshotId = null;
+        if (source.ActiveSnapshotId is Guid previousActiveSnapshotId && previousActiveSnapshotId != snapshotId)
+        {
+            var previous = await dbContext
+                .IngestionSnapshots.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(item => item.Id == previousActiveSnapshotId, ct);
+            if (previous is not null)
+            {
+                previous.Discard();
+                retiredSnapshotId = previous.Id;
+            }
+        }
+
+        snapshot.MarkPublished();
+        source.SetSnapshotPointers(snapshot.Id, null);
+        await dbContext.SaveChangesAsync(ct);
+
+        if (retiredSnapshotId.HasValue)
+        {
+            // RemediationCase is keyed by (TenantId, SoftwareProductId) and stable across snapshot
+            // rotations — no re-keying of downstream entities is required when the active snapshot changes.
+            await CleanupSnapshotDataAsync(retiredSnapshotId.Value, ct);
+        }
+    }
+
+    internal async Task DiscardBuildingSnapshotAsync(
+        Guid tenantId,
+        string sourceKey,
+        Guid snapshotId,
+        CancellationToken ct
+    )
+    {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var source = await dbContext
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+        var snapshot = await dbContext
+            .IngestionSnapshots.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item => item.Id == snapshotId, ct);
+
+        if (snapshot is not null && snapshot.Status == IngestionSnapshotStatuses.Building)
+        {
+            snapshot.Discard();
+        }
+
+        if (source is not null && source.BuildingSnapshotId == snapshotId)
+        {
+            source.SetSnapshotPointers(source.ActiveSnapshotId, null);
+        }
+
+        await dbContext.SaveChangesAsync(ct);
+        await CleanupSnapshotDataAsync(snapshotId, ct);
+    }
+
+    internal async Task CleanupSnapshotDataAsync(Guid snapshotId, CancellationToken ct)
+    {
+        if (dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
+        {
+            var tenantSoftware = await dbContext
+                .SoftwareTenantRecords.IgnoreQueryFilters()
+                .Where(item => item.SnapshotId == snapshotId)
+                .ToListAsync(ct);
+            var installations = await dbContext
+                .SoftwareProductInstallations.IgnoreQueryFilters()
+                .Where(item => item.SnapshotId == snapshotId)
+                .ToListAsync(ct);
+
+            dbContext.SoftwareTenantRecords.RemoveRange(tenantSoftware);
+            dbContext.SoftwareProductInstallations.RemoveRange(installations);
+            await dbContext.SaveChangesAsync(ct);
+            return;
+        }
+
+        await dbContext
+            .SoftwareProductInstallations.IgnoreQueryFilters()
+            .Where(item => item.SnapshotId == snapshotId)
+            .ExecuteDeleteAsync(ct);
+        await dbContext
+            .SoftwareTenantRecords.IgnoreQueryFilters()
+            .Where(item => item.SnapshotId == snapshotId)
+            .ExecuteDeleteAsync(ct);
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs
@@ -1,0 +1,515 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+
+namespace PatchHound.Infrastructure.Services;
+
+/// <summary>
+/// Handles the staging phase of the ingestion pipeline: writing raw vulnerability and
+/// asset records into the staging tables, enqueuing enrichment jobs, and exposing
+/// normalisation helpers that callers can reference before staging.
+/// </summary>
+public class IngestionStagingPipeline(
+    PatchHoundDbContext dbContext,
+    EnrichmentJobEnqueuer enrichmentJobEnqueuer,
+    IngestionLeaseManager leaseManager,
+    IngestionCheckpointWriter checkpointWriter
+)
+{
+    internal const int AssetBatchSize = 200;
+    internal const int VulnerabilityBatchSize = 250;
+
+    // ── Vulnerability staging ────────────────────────────────────────────────
+
+    internal async Task StageVulnerabilitiesAsync(
+        Guid ingestionRunId,
+        Guid tenantId,
+        string sourceKey,
+        IReadOnlyList<IngestionResult> results,
+        int batchNumber,
+        CancellationToken ct
+    )
+    {
+        if (results.Count == 0)
+        {
+            return;
+        }
+
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var stagedAt = DateTimeOffset.UtcNow;
+        var rows = results.Select(result =>
+            StagedVulnerability.Create(
+                ingestionRunId,
+                tenantId,
+                normalizedSourceKey,
+                result.ExternalId,
+                result.Title,
+                result.VendorSeverity,
+                JsonSerializer.Serialize(result with { AffectedAssets = [] }, StagingSerializerOptions.Instance),
+                stagedAt,
+                batchNumber
+            )
+        );
+        var exposures = results.SelectMany(result =>
+            result.AffectedAssets.Select(affectedAsset =>
+                StagedVulnerabilityExposure.Create(
+                    ingestionRunId,
+                    tenantId,
+                    normalizedSourceKey,
+                    result.ExternalId,
+                    affectedAsset.ExternalAssetId,
+                    affectedAsset.AssetName,
+                    affectedAsset.AssetType,
+                    JsonSerializer.Serialize(affectedAsset, StagingSerializerOptions.Instance),
+                    stagedAt,
+                    batchNumber
+                )
+            )
+        );
+
+        await dbContext.StagedVulnerabilities.AddRangeAsync(rows, ct);
+        await dbContext.StagedVulnerabilityExposures.AddRangeAsync(exposures, ct);
+        await dbContext.SaveChangesAsync(ct);
+        dbContext.ChangeTracker.Clear();
+    }
+
+    internal async Task<int> StageVulnerabilityBatchesAsync(
+        Guid ingestionRunId,
+        Guid tenantId,
+        string sourceKey,
+        IVulnerabilityBatchSource batchSource,
+        CancellationToken ct
+    )
+    {
+        var checkpoint = await dbContext
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                item =>
+                    item.IngestionRunId == ingestionRunId
+                    && item.Phase == CheckpointPhases.VulnerabilityStaging,
+                ct
+            );
+        var batchNumber = checkpoint?.BatchNumber ?? 0;
+        var cursorJson =
+            string.IsNullOrWhiteSpace(checkpoint?.CursorJson) ? null : checkpoint.CursorJson;
+        var totalResults = 0;
+
+        while (true)
+        {
+            await leaseManager.ThrowIfAbortRequestedAsync(ingestionRunId, ct);
+            batchNumber++;
+            var batch = await batchSource.FetchVulnerabilityBatchAsync(
+                tenantId,
+                cursorJson,
+                VulnerabilityBatchSize,
+                ct
+            );
+            var normalizedResults = NormalizeResults(batch.Items);
+
+            if (normalizedResults.Count > 0)
+            {
+                totalResults += normalizedResults.Count;
+                await StageVulnerabilitiesAsync(
+                    ingestionRunId,
+                    tenantId,
+                    sourceKey,
+                    normalizedResults,
+                    batchNumber,
+                    ct
+                );
+                await checkpointWriter.CommitCheckpointAsync(
+                    ingestionRunId,
+                    tenantId,
+                    sourceKey,
+                    CheckpointPhases.VulnerabilityStaging,
+                    batchNumber,
+                    batch.NextCursorJson,
+                    normalizedResults.Count,
+                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
+                    ct
+                );
+            }
+            else
+            {
+                await checkpointWriter.CommitCheckpointAsync(
+                    ingestionRunId,
+                    tenantId,
+                    sourceKey,
+                    CheckpointPhases.VulnerabilityStaging,
+                    batchNumber,
+                    batch.NextCursorJson,
+                    0,
+                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
+                    ct
+                );
+            }
+
+            if (batch.IsComplete)
+            {
+                break;
+            }
+
+            cursorJson = batch.NextCursorJson;
+        }
+
+        return totalResults;
+    }
+
+    // ── Asset staging ────────────────────────────────────────────────────────
+
+    internal async Task StageAssetInventorySnapshotAsync(
+        Guid ingestionRunId,
+        Guid tenantId,
+        string sourceKey,
+        IngestionAssetInventorySnapshot snapshot,
+        int batchNumber,
+        CancellationToken ct
+    )
+    {
+        if (snapshot.Assets.Count == 0 && snapshot.DeviceSoftwareLinks.Count == 0)
+        {
+            return;
+        }
+
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
+        var stagedAt = DateTimeOffset.UtcNow;
+
+        if (snapshot.Assets.Count > 0)
+        {
+            var stagedDeviceRecords = snapshot.Assets.Select(asset =>
+                StagedDevice.Create(
+                    ingestionRunId,
+                    tenantId,
+                    normalizedSourceKey,
+                    asset.ExternalId,
+                    asset.Name,
+                    asset.AssetType,
+                    JsonSerializer.Serialize(asset, StagingSerializerOptions.Instance),
+                    stagedAt,
+                    batchNumber
+                )
+            );
+            await dbContext.StagedDevices.AddRangeAsync(stagedDeviceRecords, ct);
+        }
+
+        if (snapshot.DeviceSoftwareLinks.Count > 0)
+        {
+            var stagedLinks = snapshot.DeviceSoftwareLinks.Select(link =>
+                StagedDeviceSoftwareInstallation.Create(
+                    ingestionRunId,
+                    tenantId,
+                    normalizedSourceKey,
+                    link.DeviceExternalId,
+                    link.SoftwareExternalId,
+                    link.ObservedAt,
+                    JsonSerializer.Serialize(link, StagingSerializerOptions.Instance),
+                    stagedAt,
+                    batchNumber
+                )
+            );
+            await dbContext.StagedDeviceSoftwareInstallations.AddRangeAsync(stagedLinks, ct);
+        }
+
+        await dbContext.SaveChangesAsync(ct);
+        dbContext.ChangeTracker.Clear();
+    }
+
+    internal async Task<AssetBatchStageSummary> StageAssetBatchesAsync(
+        Guid ingestionRunId,
+        Guid tenantId,
+        string sourceKey,
+        IAssetInventoryBatchSource batchSource,
+        CancellationToken ct
+    )
+    {
+        var checkpoint = await dbContext
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(item =>
+                item.IngestionRunId == ingestionRunId
+                && item.TenantId == tenantId
+                && item.SourceKey == sourceKey
+                && item.Phase == CheckpointPhases.AssetStaging,
+                ct
+            );
+
+        var batchNumber = checkpoint?.BatchNumber ?? 0;
+        var cursorJson = string.IsNullOrWhiteSpace(checkpoint?.CursorJson)
+            ? null
+            : checkpoint!.CursorJson;
+        var totalAssets = 0;
+        var totalSoftware = 0;
+        var totalLinks = 0;
+        var totalSoftwareWithoutMachineReferences = 0;
+
+        while (true)
+        {
+            await leaseManager.ThrowIfAbortRequestedAsync(ingestionRunId, ct);
+            var batch = await batchSource.FetchAssetBatchAsync(
+                tenantId,
+                cursorJson,
+                AssetBatchSize,
+                ct
+            );
+            batchNumber++;
+
+            var normalizedBatch = NormalizeAssetSnapshots(batch.Items);
+            if (
+                normalizedBatch.Assets.Count > 0
+                || normalizedBatch.DeviceSoftwareLinks.Count > 0
+                || normalizedBatch.RetrievedSoftwareCount > 0
+                || normalizedBatch.SoftwareWithoutMachineReferencesCount > 0
+            )
+            {
+                totalAssets += normalizedBatch.Assets.Count;
+                totalSoftwareWithoutMachineReferences +=
+                    normalizedBatch.SoftwareWithoutMachineReferencesCount;
+
+                await StageAssetInventorySnapshotAsync(
+                    ingestionRunId,
+                    tenantId,
+                    sourceKey,
+                    normalizedBatch,
+                    batchNumber,
+                    ct
+                );
+                await checkpointWriter.CommitCheckpointAsync(
+                    ingestionRunId,
+                    tenantId,
+                    sourceKey,
+                    CheckpointPhases.AssetStaging,
+                    batchNumber,
+                    batch.NextCursorJson,
+                    normalizedBatch.Assets.Count + normalizedBatch.DeviceSoftwareLinks.Count,
+                    batch.IsComplete ? CheckpointStatuses.Completed : CheckpointStatuses.Running,
+                    ct
+                );
+            }
+            else if (batch.IsComplete)
+            {
+                await checkpointWriter.CommitCheckpointAsync(
+                    ingestionRunId,
+                    tenantId,
+                    sourceKey,
+                    CheckpointPhases.AssetStaging,
+                    batchNumber,
+                    batch.NextCursorJson,
+                    0,
+                    CheckpointStatuses.Completed,
+                    ct
+                );
+            }
+
+            if (batch.IsComplete)
+            {
+                break;
+            }
+
+            cursorJson = batch.NextCursorJson;
+        }
+
+        totalSoftware = await dbContext
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(
+                item =>
+                    item.IngestionRunId == ingestionRunId
+                    && EF.Functions.Like(item.ExternalId, "defender-sw::%")
+            )
+            .Select(item => item.ExternalId)
+            .Distinct()
+            .CountAsync(
+                ct
+            );
+        totalLinks = await dbContext
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .Select(item => new { item.DeviceExternalId, item.SoftwareExternalId })
+            .Distinct()
+            .CountAsync(ct);
+
+        return new AssetBatchStageSummary(
+            totalAssets,
+            totalSoftware,
+            totalLinks,
+            totalSoftwareWithoutMachineReferences,
+            batchNumber
+        );
+    }
+
+    // ── Enrichment job enqueueing ─────────────────────────────────────────────
+
+    internal async Task EnqueueEnrichmentJobsForRunAsync(
+        Guid ingestionRunId,
+        Guid tenantId,
+        CancellationToken ct
+    )
+    {
+        var externalIds = await dbContext
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .Select(item => item.ExternalId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        if (externalIds.Count == 0)
+        {
+            return;
+        }
+
+        var vulnerabilityIds = await dbContext
+            .Vulnerabilities.IgnoreQueryFilters()
+            .Where(v => externalIds.Contains(v.ExternalId))
+            .Select(v => v.Id)
+            .Distinct()
+            .ToListAsync(ct);
+
+        await enrichmentJobEnqueuer.EnqueueVulnerabilityJobsAsync(
+            tenantId,
+            vulnerabilityIds,
+            ct
+        );
+
+        var normalizedSoftwareIds = await dbContext
+            .SoftwareTenantRecords.IgnoreQueryFilters()
+            .AsNoTracking()
+            .Where(ts => ts.TenantId == tenantId)
+            .Select(ts => ts.SoftwareProductId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        if (normalizedSoftwareIds.Count > 0)
+        {
+            await enrichmentJobEnqueuer.EnqueueSoftwareEndOfLifeJobsAsync(
+                tenantId,
+                normalizedSoftwareIds,
+                ct
+            );
+            await enrichmentJobEnqueuer.EnqueueSoftwareSupplyChainJobsAsync(
+                tenantId,
+                normalizedSoftwareIds,
+                ct
+            );
+        }
+    }
+
+    // ── Static normalisation helpers ─────────────────────────────────────────
+
+    internal static IReadOnlyList<IngestionResult> NormalizeResults(
+        IReadOnlyList<IngestionResult> results
+    )
+    {
+        return results
+            .GroupBy(result => result.ExternalId, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var first = group.First();
+                var affectedAssets = group
+                    .SelectMany(item => item.AffectedAssets)
+                    .GroupBy(asset => asset.ExternalAssetId, StringComparer.OrdinalIgnoreCase)
+                    .Select(assetGroup => assetGroup.First())
+                    .ToList();
+                var references = group
+                    .SelectMany(item => item.References ?? [])
+                    .GroupBy(reference => reference.Url, StringComparer.OrdinalIgnoreCase)
+                    .Select(referenceGroup => referenceGroup.First())
+                    .ToList();
+                var affectedSoftware = group
+                    .SelectMany(item => item.AffectedSoftware ?? [])
+                    .GroupBy(
+                        item =>
+                            $"{item.Criteria}|{item.VersionStartIncluding}|{item.VersionStartExcluding}|{item.VersionEndIncluding}|{item.VersionEndExcluding}|{item.Vulnerable}",
+                        StringComparer.OrdinalIgnoreCase
+                    )
+                    .Select(softwareGroup => softwareGroup.First())
+                    .ToList();
+                var sources = group
+                    .SelectMany(item => item.Sources ?? [])
+                    .Where(source => !string.IsNullOrWhiteSpace(source))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                return first with
+                {
+                    AffectedAssets = affectedAssets,
+                    References = references,
+                    AffectedSoftware = affectedSoftware,
+                    Sources = sources,
+                };
+            })
+            .ToList();
+    }
+
+    internal static IngestionAssetInventorySnapshot NormalizeAssetSnapshot(
+        IngestionAssetInventorySnapshot snapshot
+    )
+    {
+        var assets = snapshot
+            .Assets.GroupBy(asset => asset.ExternalId, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.Last())
+            .ToList();
+        var deviceSoftwareLinks = snapshot
+            .DeviceSoftwareLinks.GroupBy(
+                link => $"{link.DeviceExternalId}:{link.SoftwareExternalId}",
+                StringComparer.OrdinalIgnoreCase
+            )
+            .Select(group => group.OrderByDescending(link => link.ObservedAt).First())
+            .ToList();
+
+        return new IngestionAssetInventorySnapshot(
+            assets,
+            deviceSoftwareLinks,
+            snapshot.RetrievedSoftwareCount,
+            snapshot.SoftwareWithoutMachineReferencesCount
+        );
+    }
+
+    internal static IngestionAssetInventorySnapshot NormalizeAssetSnapshots(
+        IReadOnlyList<IngestionAssetInventorySnapshot> snapshots
+    )
+    {
+        if (snapshots.Count == 0)
+        {
+            return new IngestionAssetInventorySnapshot([], []);
+        }
+
+        return NormalizeAssetSnapshot(
+            new IngestionAssetInventorySnapshot(
+                snapshots.SelectMany(item => item.Assets).ToList(),
+                snapshots.SelectMany(item => item.DeviceSoftwareLinks).ToList(),
+                snapshots.Sum(item => item.RetrievedSoftwareCount),
+                snapshots.Sum(item => item.SoftwareWithoutMachineReferencesCount)
+            )
+        );
+    }
+
+    // ── Static chunking utility ───────────────────────────────────────────────
+
+    internal static IEnumerable<IReadOnlyList<T>> Chunk<T>(IReadOnlyList<T> items, int size)
+    {
+        for (var index = 0; index < items.Count; index += size)
+        {
+            var count = Math.Min(size, items.Count - index);
+            var chunk = new List<T>(count);
+            for (var offset = 0; offset < count; offset++)
+            {
+                chunk.Add(items[index + offset]);
+            }
+
+            yield return chunk;
+        }
+    }
+}
+
+/// <summary>
+/// Accumulates counts from a multi-batch asset staging pass.
+/// </summary>
+internal sealed record AssetBatchStageSummary(
+    int AssetCount,
+    int SoftwareCount,
+    int LinkCount,
+    int SoftwareWithoutMachineReferencesCount,
+    int BatchNumber
+);

--- a/src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionStagingPipeline.cs
@@ -226,12 +226,13 @@ public class IngestionStagingPipeline(
         CancellationToken ct
     )
     {
+        var normalizedSourceKey = sourceKey.Trim().ToLowerInvariant();
         var checkpoint = await dbContext
             .IngestionCheckpoints.IgnoreQueryFilters()
             .FirstOrDefaultAsync(item =>
                 item.IngestionRunId == ingestionRunId
                 && item.TenantId == tenantId
-                && item.SourceKey == sourceKey
+                && item.SourceKey == normalizedSourceKey
                 && item.Phase == CheckpointPhases.AssetStaging,
                 ct
             );
@@ -271,7 +272,7 @@ public class IngestionStagingPipeline(
                 await StageAssetInventorySnapshotAsync(
                     ingestionRunId,
                     tenantId,
-                    sourceKey,
+                    normalizedSourceKey,
                     normalizedBatch,
                     batchNumber,
                     ct
@@ -279,7 +280,7 @@ public class IngestionStagingPipeline(
                 await checkpointWriter.CommitCheckpointAsync(
                     ingestionRunId,
                     tenantId,
-                    sourceKey,
+                    normalizedSourceKey,
                     CheckpointPhases.AssetStaging,
                     batchNumber,
                     batch.NextCursorJson,
@@ -293,7 +294,7 @@ public class IngestionStagingPipeline(
                 await checkpointWriter.CommitCheckpointAsync(
                     ingestionRunId,
                     tenantId,
-                    sourceKey,
+                    normalizedSourceKey,
                     CheckpointPhases.AssetStaging,
                     batchNumber,
                     batch.NextCursorJson,

--- a/src/PatchHound.Infrastructure/Services/IngestionStateCache.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionStateCache.cs
@@ -6,6 +6,11 @@ using StackExchange.Redis;
 
 namespace PatchHound.Infrastructure.Services;
 
+/// <summary>
+/// Scoped per-ingestion-run state cache. Registered as <c>AddScoped</c> — one instance
+/// per DI scope, not a singleton. Each <see cref="IngestionService"/> scope gets its own
+/// clean instance; concurrent ingestion runs for different tenants do not share state.
+/// </summary>
 public class IngestionStateCache
 {
     private readonly IConnectionMultiplexer? _redis;

--- a/src/PatchHound.Infrastructure/Services/IngestionTerminalException.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionTerminalException.cs
@@ -1,6 +1,6 @@
 namespace PatchHound.Infrastructure.Services;
 
-public class IngestionTerminalException : Exception
+public sealed class IngestionTerminalException : Exception
 {
     public IngestionTerminalException(string message)
         : base(message) { }

--- a/src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs
@@ -203,6 +203,23 @@ internal sealed class PostgresIngestionBulkWriter(PatchHoundDbContext db) : IIng
             );
     }
 
+    public async Task<int> RefreshDeviceActivityAsync(Guid tenantId, TimeSpan inactiveThreshold, CancellationToken ct)
+    {
+        var cutoff = DateTimeOffset.UtcNow.Subtract(inactiveThreshold);
+
+        var deactivatedCount = await db.Devices
+            .IgnoreQueryFilters()
+            .Where(d => d.TenantId == tenantId && d.ActiveInTenant && (d.LastSeenAt == null || d.LastSeenAt < cutoff))
+            .ExecuteUpdateAsync(s => s.SetProperty(d => d.ActiveInTenant, false), ct);
+
+        await db.Devices
+            .IgnoreQueryFilters()
+            .Where(d => d.TenantId == tenantId && !d.ActiveInTenant && d.LastSeenAt != null && d.LastSeenAt >= cutoff)
+            .ExecuteUpdateAsync(s => s.SetProperty(d => d.ActiveInTenant, true), ct);
+
+        return deactivatedCount;
+    }
+
     public async Task FinalizeAbortedRunAsync(
         Guid runId,
         Guid tenantId,

--- a/src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs
+++ b/src/PatchHound.Infrastructure/Services/PostgresIngestionBulkWriter.cs
@@ -1,0 +1,353 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+/// <summary>
+/// Production implementation of <see cref="IIngestionBulkWriter"/> that uses
+/// <c>ExecuteDeleteAsync</c> / <c>ExecuteUpdateAsync</c> for bulk operations.
+/// </summary>
+internal sealed class PostgresIngestionBulkWriter(PatchHoundDbContext db) : IIngestionBulkWriter
+{
+    public async Task ClearStagedDataForRunAsync(Guid ingestionRunId, CancellationToken ct)
+    {
+        await db
+            .StagedVulnerabilityExposures.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+        await db
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+        await db
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+        await db
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(item => item.IngestionRunId == ingestionRunId)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    public async Task<IngestionArtifactCleanupSummary> CleanupExpiredArtifactsAsync(
+        IReadOnlyList<Guid> expiredRunIds,
+        CancellationToken ct
+    )
+    {
+        var prunedExposureCount = await db
+            .StagedVulnerabilityExposures.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedVulnerabilityCount = await db
+            .StagedVulnerabilities.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedSoftwareLinkCount = await db
+            .StagedDeviceSoftwareInstallations.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedAssetCount = await db
+            .StagedDevices.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        await db
+            .IngestionCheckpoints.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.IngestionRunId))
+            .ExecuteDeleteAsync(ct);
+        var prunedRunCount = await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => expiredRunIds.Contains(item.Id))
+            .ExecuteDeleteAsync(ct);
+
+        return new IngestionArtifactCleanupSummary(
+            prunedRunCount,
+            prunedVulnerabilityCount,
+            prunedExposureCount,
+            prunedAssetCount,
+            prunedSoftwareLinkCount
+        );
+    }
+
+    public async Task CleanupSnapshotDataAsync(Guid snapshotId, CancellationToken ct)
+    {
+        await db
+            .SoftwareProductInstallations.IgnoreQueryFilters()
+            .Where(item => item.SnapshotId == snapshotId)
+            .ExecuteDeleteAsync(ct);
+        await db
+            .SoftwareTenantRecords.IgnoreQueryFilters()
+            .Where(item => item.SnapshotId == snapshotId)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    public async Task ReleaseIngestionLeaseAsync(
+        Guid tenantId,
+        string normalizedSourceKey,
+        Guid runId,
+        CancellationToken ct
+    )
+    {
+        await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .Where(item =>
+                item.TenantId == tenantId
+                && item.SourceKey == normalizedSourceKey
+                && item.ActiveIngestionRunId == runId
+            )
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
+                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
+                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
+                ct
+            );
+    }
+
+    public async Task UpdateIngestionRunStatusAsync(Guid runId, string status, CancellationToken ct)
+    {
+        await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => item.Id == runId)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(item => item.Status, status), ct);
+    }
+
+    public async Task UpdateVulnerabilityMergeProgressAsync(
+        Guid ingestionRunId,
+        int stagedVulnerabilityCount,
+        int persistedVulnerabilityCount,
+        CancellationToken ct
+    )
+    {
+        await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => item.Id == ingestionRunId && !item.CompletedAt.HasValue)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.StagedVulnerabilityCount, stagedVulnerabilityCount)
+                        .SetProperty(item => item.PersistedVulnerabilityCount, persistedVulnerabilityCount),
+                ct
+            );
+    }
+
+    public async Task UpdateAssetMergeProgressAsync(
+        Guid ingestionRunId,
+        int stagedMachineCount,
+        int stagedSoftwareCount,
+        int persistedMachineCount,
+        int persistedSoftwareCount,
+        CancellationToken ct
+    )
+    {
+        await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item => item.Id == ingestionRunId && !item.CompletedAt.HasValue)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.StagedMachineCount, stagedMachineCount)
+                        .SetProperty(item => item.StagedSoftwareCount, stagedSoftwareCount)
+                        .SetProperty(item => item.PersistedMachineCount, persistedMachineCount)
+                        .SetProperty(item => item.DeactivatedMachineCount, 0)
+                        .SetProperty(item => item.PersistedSoftwareCount, persistedSoftwareCount),
+                ct
+            );
+    }
+
+    public async Task UpdateRuntimeStateAsync(
+        Guid tenantId,
+        string normalizedSourceKey,
+        Action<TenantIngestionRuntimeState> update,
+        CancellationToken ct
+    )
+    {
+        var source = await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey,
+                ct
+            );
+
+        if (source is null)
+        {
+            return;
+        }
+
+        var detachedRuntime = new TenantIngestionRuntimeState(
+            source.ManualRequestedAt,
+            source.LastStartedAt,
+            source.LastCompletedAt,
+            source.LastSucceededAt,
+            source.LastStatus,
+            source.LastError
+        );
+        update(detachedRuntime);
+
+        await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.ManualRequestedAt, detachedRuntime.ManualRequestedAt)
+                        .SetProperty(item => item.LastStartedAt, detachedRuntime.LastStartedAt)
+                        .SetProperty(item => item.LastCompletedAt, detachedRuntime.LastCompletedAt)
+                        .SetProperty(item => item.LastSucceededAt, detachedRuntime.LastSucceededAt)
+                        .SetProperty(item => item.LastStatus, detachedRuntime.LastStatus)
+                        .SetProperty(item => item.LastError, detachedRuntime.LastError),
+                ct
+            );
+    }
+
+    public async Task FinalizeAbortedRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string normalizedSourceKey,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    )
+    {
+        await db
+            .IngestionRuns.IgnoreQueryFilters()
+            .Where(item =>
+                item.Id == runId
+                && item.AbortRequestedAt != null
+                && item.CompletedAt == null
+                && (
+                    item.Status == IngestionRunStatuses.Staging
+                    || item.Status == IngestionRunStatuses.MergePending
+                    || item.Status == IngestionRunStatuses.Merging
+                ))
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(item => item.CompletedAt, completedAt)
+                    .SetProperty(item => item.Status, IngestionRunStatuses.FailedTerminal)
+                    .SetProperty(
+                        item => item.Error,
+                        IngestionFailurePolicy.Describe(new IngestionAbortedException())
+                    ),
+                ct
+            );
+
+        await db
+            .TenantSourceConfigurations.IgnoreQueryFilters()
+            .Where(item =>
+                item.TenantId == tenantId
+                && item.SourceKey == normalizedSourceKey
+                && item.ActiveIngestionRunId == runId)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
+                        .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
+                        .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
+                ct
+            );
+    }
+
+    public async Task CompleteIngestionRunAsync(
+        Guid runId,
+        Guid tenantId,
+        string normalizedSourceKey,
+        bool succeeded,
+        string? error,
+        StagedVulnerabilityMergeSummary vulnerabilityMergeSummary,
+        StagedAssetMergeSummary assetMergeSummary,
+        int deactivatedMachineCount,
+        string? failureStatus,
+        DateTimeOffset completedAt,
+        CancellationToken ct
+    )
+    {
+        var strategy = db.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await db.Database.BeginTransactionAsync(ct);
+
+            _ = succeeded
+                ? await db
+                    .IngestionRuns.IgnoreQueryFilters()
+                    .Where(item => item.Id == runId)
+                    .ExecuteUpdateAsync(
+                        setters =>
+                            setters
+                                .SetProperty(item => item.CompletedAt, completedAt)
+                                .SetProperty(item => item.Status, IngestionRunStatuses.Succeeded)
+                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
+                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
+                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
+                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
+                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
+                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
+                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
+                                .SetProperty(item => item.Error, string.Empty),
+                        ct
+                    )
+                : await db
+                    .IngestionRuns.IgnoreQueryFilters()
+                    .Where(item => item.Id == runId)
+                    .ExecuteUpdateAsync(
+                        setters =>
+                            setters
+                                .SetProperty(item => item.CompletedAt, completedAt)
+                                .SetProperty(item => item.Status, failureStatus ?? IngestionRunStatuses.FailedRecoverable)
+                                .SetProperty(item => item.StagedMachineCount, assetMergeSummary.StagedMachineCount)
+                                .SetProperty(item => item.StagedSoftwareCount, assetMergeSummary.StagedSoftwareCount)
+                                .SetProperty(item => item.StagedVulnerabilityCount, vulnerabilityMergeSummary.StagedVulnerabilityCount)
+                                .SetProperty(item => item.PersistedMachineCount, assetMergeSummary.PersistedMachineCount)
+                                .SetProperty(item => item.DeactivatedMachineCount, deactivatedMachineCount)
+                                .SetProperty(item => item.PersistedSoftwareCount, assetMergeSummary.PersistedSoftwareCount)
+                                .SetProperty(item => item.PersistedVulnerabilityCount, vulnerabilityMergeSummary.PersistedVulnerabilityCount)
+                                .SetProperty(item => item.Error, error ?? "Unknown ingestion failure"),
+                        ct
+                    );
+
+            await db
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .Where(item =>
+                    item.TenantId == tenantId
+                    && item.SourceKey == normalizedSourceKey
+                    && item.ActiveIngestionRunId == runId
+                )
+                .ExecuteUpdateAsync(
+                    setters =>
+                        setters
+                            .SetProperty(item => item.ActiveIngestionRunId, (Guid?)null)
+                            .SetProperty(item => item.LeaseAcquiredAt, (DateTimeOffset?)null)
+                            .SetProperty(item => item.LeaseExpiresAt, (DateTimeOffset?)null),
+                    ct
+                );
+
+            await db
+                .TenantSourceConfigurations.IgnoreQueryFilters()
+                .Where(item => item.TenantId == tenantId && item.SourceKey == normalizedSourceKey)
+                .ExecuteUpdateAsync(
+                    setters =>
+                        setters
+                            .SetProperty(item => item.LastCompletedAt, completedAt)
+                            .SetProperty(
+                                item => item.LastSucceededAt,
+                                item => succeeded ? completedAt : item.LastSucceededAt
+                            )
+                            .SetProperty(
+                                item => item.LastStatus,
+                                succeeded
+                                    ? IngestionRunStatuses.Succeeded
+                                    : failureStatus ?? IngestionRunStatuses.FailedRecoverable
+                            )
+                            .SetProperty(
+                                item => item.LastError,
+                                succeeded ? string.Empty : error ?? "Unknown ingestion failure"
+                            ),
+                    ct
+                );
+
+            await transaction.CommitAsync(ct);
+        });
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs
+++ b/src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs
@@ -91,7 +91,7 @@ public class StagedDeviceMergeService(
 
         // ── Pass 1: Upsert devices ──────────────────────────────────────────────────────────
         // Collect Device entities by their ExternalId for the software-link pass below.
-        var deviceByExternalId = new Dictionary<string, Device>(StringComparer.OrdinalIgnoreCase);
+        var deviceByExternalId = new Dictionary<(string SourceKey, string ExternalId), Device>();
 
         foreach (var stagedDevice in stagedDevices)
         {
@@ -191,7 +191,7 @@ public class StagedDeviceMergeService(
             );
             device.SetActiveInTenant(true);
 
-            deviceByExternalId[stagedDevice.ExternalId] = device;
+            deviceByExternalId[(stagedDevice.SourceKey, stagedDevice.ExternalId)] = device;
         }
 
         // Persist device upserts so all device IDs are stable before the software-link pass.
@@ -212,7 +212,7 @@ public class StagedDeviceMergeService(
 
         foreach (var stagedDevice in stagedDevices)
         {
-            if (!deviceByExternalId.TryGetValue(stagedDevice.ExternalId, out var device))
+            if (!deviceByExternalId.TryGetValue((stagedDevice.SourceKey, stagedDevice.ExternalId), out var device))
             {
                 // Device was skipped or deactivated in Pass 1 — no software links to process.
                 continue;

--- a/src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs
+++ b/src/PatchHound.Infrastructure/Services/StagedDeviceMergeService.cs
@@ -81,6 +81,18 @@ public class StagedDeviceMergeService(
         var sourceSystems = await db
             .SourceSystems.ToDictionaryAsync(s => s.Key, StringComparer.Ordinal, ct);
 
+        // 5. Pre-load all existing devices for the staged external IDs to avoid N+1 SELECTs.
+        //    Key: (SourceSystemId, ExternalId) — handles runs that span multiple source systems.
+        var stagedExternalIds = stagedDevices.Select(d => d.ExternalId).Distinct().ToList();
+        var devicesByKey = await db.Devices
+            .IgnoreQueryFilters()
+            .Where(d => d.TenantId == tenantId && stagedExternalIds.Contains(d.ExternalId))
+            .ToDictionaryAsync(d => (d.SourceSystemId, d.ExternalId), d => d, ct);
+
+        // ── Pass 1: Upsert devices ──────────────────────────────────────────────────────────
+        // Collect Device entities by their ExternalId for the software-link pass below.
+        var deviceByExternalId = new Dictionary<string, Device>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var stagedDevice in stagedDevices)
         {
             var normalizedKey = stagedDevice.SourceKey.Trim().ToLowerInvariant();
@@ -104,15 +116,8 @@ public class StagedDeviceMergeService(
 
             // Pre-check to track created vs touched counts, and to determine
             // whether a stale+inactive device is new (skip) or existing (deactivate).
-            var deviceBefore = await db
-                .Devices.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(
-                    d =>
-                        d.TenantId == tenantId
-                        && d.SourceSystemId == sourceSystem.Id
-                        && d.ExternalId == stagedDevice.ExternalId,
-                    ct
-                );
+            // Uses the pre-loaded dictionary — no per-device SELECT.
+            devicesByKey.TryGetValue((sourceSystem.Id, stagedDevice.ExternalId), out var deviceBefore);
 
             if (IsStaleAndInactive(payload))
             {
@@ -159,6 +164,9 @@ public class StagedDeviceMergeService(
             if (deviceBefore is null)
             {
                 devicesCreated++;
+                // Add newly created device to the dictionary so subsequent staged entries
+                // with the same ExternalId find it without a DB round-trip.
+                devicesByKey[(sourceSystem.Id, stagedDevice.ExternalId)] = device;
             }
             else
             {
@@ -183,6 +191,33 @@ public class StagedDeviceMergeService(
             );
             device.SetActiveInTenant(true);
 
+            deviceByExternalId[stagedDevice.ExternalId] = device;
+        }
+
+        // Persist device upserts so all device IDs are stable before the software-link pass.
+        await db.SaveChangesAsync(ct);
+
+        // ── Pass 2: Upsert software links ───────────────────────────────────────────────────
+        // Pre-load all InstalledSoftware rows for devices touched in this run to avoid N+1 SELECTs.
+        var runDeviceIds = deviceByExternalId.Values.Select(d => d.Id).Distinct().ToList();
+        var existingInstalledSoftware = await db.InstalledSoftware
+            .IgnoreQueryFilters()
+            .Where(i => i.TenantId == tenantId && runDeviceIds.Contains(i.DeviceId))
+            .ToListAsync(ct);
+        var installedByKey = existingInstalledSoftware
+            .ToDictionary(
+                i => (i.DeviceId, i.SoftwareProductId, i.SourceSystemId, i.Version),
+                i => i
+            );
+
+        foreach (var stagedDevice in stagedDevices)
+        {
+            if (!deviceByExternalId.TryGetValue(stagedDevice.ExternalId, out var device))
+            {
+                // Device was skipped or deactivated in Pass 1 — no software links to process.
+                continue;
+            }
+
             if (
                 !linksByDeviceExternalId.TryGetValue(
                     stagedDevice.ExternalId,
@@ -192,6 +227,9 @@ public class StagedDeviceMergeService(
             {
                 continue;
             }
+
+            var normalizedSourceKey = stagedDevice.SourceKey.Trim().ToLowerInvariant();
+            var sourceSystem = sourceSystems[normalizedSourceKey];
 
             foreach (var link in deviceLinks)
             {
@@ -223,32 +261,24 @@ public class StagedDeviceMergeService(
                 );
 
                 var normalizedVersion = version?.Trim() ?? string.Empty;
-                var existing = await db
-                    .InstalledSoftware.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(
-                        i =>
-                            i.TenantId == tenantId
-                            && i.DeviceId == device.Id
-                            && i.SoftwareProductId == product.Id
-                            && i.SourceSystemId == sourceSystem.Id
-                            && i.Version == normalizedVersion,
-                        ct
-                    );
+                var installedKey = (device.Id, product.Id, sourceSystem.Id, normalizedVersion);
 
-                if (existing is null)
+                if (!installedByKey.TryGetValue(installedKey, out var existing))
                 {
                     var observedAt =
                         link.ObservedAt == default ? DateTimeOffset.UtcNow : link.ObservedAt;
-                    db.InstalledSoftware.Add(
-                        InstalledSoftware.Observe(
-                            tenantId: tenantId,
-                            deviceId: device.Id,
-                            softwareProductId: product.Id,
-                            sourceSystemId: sourceSystem.Id,
-                            version: normalizedVersion,
-                            at: observedAt
-                        )
+                    var newInstalled = InstalledSoftware.Observe(
+                        tenantId: tenantId,
+                        deviceId: device.Id,
+                        softwareProductId: product.Id,
+                        sourceSystemId: sourceSystem.Id,
+                        version: normalizedVersion,
+                        at: observedAt
                     );
+                    db.InstalledSoftware.Add(newInstalled);
+                    // Track the newly added row so subsequent links for the same
+                    // (device, product, source, version) tuple see it.
+                    installedByKey[installedKey] = newInstalled;
                     installedCreated++;
                 }
                 else

--- a/src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs
+++ b/src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs
@@ -45,4 +45,54 @@ public static class IngestionScheduleEvaluator
 
         return nextOccurrence.Value <= nowUtc.UtcDateTime;
     }
+
+    /// <summary>
+    /// Primitive-field overload for callers (e.g. <c>IngestionWorker</c>) that hold
+    /// denormalised schedule data rather than a full <see cref="TenantSourceConfiguration"/>.
+    /// Includes the active-run guard: returns <see langword="false"/> when
+    /// <paramref name="lastStartedAt"/> is later than <paramref name="lastCompletedAt"/>,
+    /// indicating a run is currently in progress.
+    /// </summary>
+    public static bool IsDue(
+        string sourceKey,
+        bool enabled,
+        string? syncSchedule,
+        DateTimeOffset? lastStartedAt,
+        DateTimeOffset? lastCompletedAt,
+        DateTimeOffset nowUtc)
+    {
+        if (!enabled || string.IsNullOrWhiteSpace(syncSchedule))
+        {
+            return false;
+        }
+
+        CronExpression expression;
+        try
+        {
+            expression = CronExpression.Parse(syncSchedule, CronFormat.Standard);
+        }
+        catch (CronFormatException)
+        {
+            return false;
+        }
+
+        var lastStarted = lastStartedAt?.ToUniversalTime();
+        var lastCompleted = lastCompletedAt?.ToUniversalTime();
+
+        // Active-run guard: a run is in progress when lastStartedAt > lastCompletedAt
+        if (lastStarted.HasValue && (!lastCompleted.HasValue || lastCompleted < lastStarted))
+        {
+            return false;
+        }
+
+        var referenceTime = lastStarted?.UtcDateTime ?? nowUtc.UtcDateTime.AddYears(-1);
+        var nextOccurrence = expression.GetNextOccurrence(referenceTime, !lastStarted.HasValue);
+
+        if (!nextOccurrence.HasValue)
+        {
+            return false;
+        }
+
+        return nextOccurrence.Value <= nowUtc.UtcDateTime;
+    }
 }

--- a/src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs
+++ b/src/PatchHound.Infrastructure/Tenants/IngestionScheduleEvaluator.cs
@@ -61,7 +61,7 @@ public static class IngestionScheduleEvaluator
         DateTimeOffset? lastCompletedAt,
         DateTimeOffset nowUtc)
     {
-        if (!enabled || string.IsNullOrWhiteSpace(syncSchedule))
+        if (!enabled || !TenantSourceCatalog.SupportsScheduling(sourceKey) || string.IsNullOrWhiteSpace(syncSchedule))
         {
             return false;
         }

--- a/src/PatchHound.Worker/IngestionWorker.cs
+++ b/src/PatchHound.Worker/IngestionWorker.cs
@@ -77,7 +77,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
                 runnableSources++;
             }
 
-            if (!isManualSync && !isDue)
+            if (!isManualSync && (!isDue || !HasConfiguredCredentials(source)))
             {
                 continue;
             }

--- a/src/PatchHound.Worker/IngestionWorker.cs
+++ b/src/PatchHound.Worker/IngestionWorker.cs
@@ -1,4 +1,3 @@
-using Cronos;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using PatchHound.Core.Interfaces;
@@ -64,7 +63,13 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
             }
 
             var isManualSync = IsManualSyncQueued(source);
-            var isDue = IsDue(source, now);
+            var isDue = IngestionScheduleEvaluator.IsDue(
+                source.SourceKey,
+                source.Enabled,
+                source.SyncSchedule,
+                source.LastStartedAt,
+                source.LastCompletedAt,
+                now);
 
             if (source.Enabled && HasConfiguredCredentials(source))
             {
@@ -147,6 +152,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
                 source.StoredCredentialId,
                 source.ManualRequestedAt,
                 source.LastStartedAt,
+                source.LastCompletedAt,
                 source.LinkedSourceKey
             ))
             .ToList();
@@ -247,38 +253,6 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
     private static bool SupportsManualSync(ScheduledSource source) =>
         TenantSourceCatalog.SupportsManualSync(source.SourceKey);
 
-    private static bool IsDue(ScheduledSource source, DateTimeOffset nowUtc)
-    {
-        if (!source.Enabled || !SupportsManualSync(source) || !HasConfiguredCredentials(source))
-        {
-            return false;
-        }
-
-        CronExpression expression;
-        try
-        {
-            expression = CronExpression.Parse(source.SyncSchedule, CronFormat.Standard);
-        }
-        catch (CronFormatException)
-        {
-            return false;
-        }
-
-        var lastStartedAt = source.LastStartedAt?.ToUniversalTime();
-        if (!lastStartedAt.HasValue)
-        {
-            var firstOccurrence = expression.GetNextOccurrence(
-                nowUtc.UtcDateTime.AddYears(-1),
-                true
-            );
-            return firstOccurrence.HasValue && firstOccurrence.Value <= nowUtc.UtcDateTime;
-        }
-
-        var nextOccurrence = expression.GetNextOccurrence(lastStartedAt.Value.UtcDateTime, false);
-
-        return nextOccurrence.HasValue && nextOccurrence.Value <= nowUtc.UtcDateTime;
-    }
-
     internal sealed record ScheduledSource(
         Guid Id,
         Guid TenantId,
@@ -294,6 +268,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
         Guid? StoredCredentialId,
         DateTimeOffset? ManualRequestedAt,
         DateTimeOffset? LastStartedAt,
+        DateTimeOffset? LastCompletedAt,
         string? LinkedSourceKey = null
     );
 }

--- a/src/PatchHound.Worker/IngestionWorker.cs
+++ b/src/PatchHound.Worker/IngestionWorker.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using PatchHound.Core.Entities;
 using PatchHound.Core.Interfaces;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Secrets;
@@ -171,7 +172,7 @@ public class IngestionWorker(IServiceScopeFactory scopeFactory, ILogger<Ingestio
                     setters
                         .SetProperty(item => item.ManualRequestedAt, (DateTimeOffset?)null)
                         .SetProperty(item => item.LastCompletedAt, DateTimeOffset.UtcNow)
-                        .SetProperty(item => item.LastStatus, "Failed")
+                        .SetProperty(item => item.LastStatus, IngestionRunStatuses.FailedRecoverable)
                         .SetProperty(
                             item => item.LastError,
                             "Manual sync skipped because the source is disabled or credentials are incomplete."

--- a/tests/PatchHound.Tests/Api/ScanRunnerControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/ScanRunnerControllerTests.cs
@@ -75,7 +75,7 @@ public class ScanRunnerControllerTests : IAsyncLifetime
         var stagedDeviceMerge = new StagedDeviceMergeService(_db, deviceResolver, softwareResolver);
         var projectionService = new NormalizedSoftwareProjectionService(_db);
         var validator = new AuthenticatedScanOutputValidator();
-        var ingestionService = new AuthenticatedScanIngestionService(_db, validator, stagedDeviceMerge, projectionService);
+        var ingestionService = new AuthenticatedScanIngestionService(_db, validator, stagedDeviceMerge, projectionService, new InMemoryIngestionBulkWriter(_db));
         var completionService = new ScanRunCompletionService(_db);
 
         _sut = new ScanRunnerController(_db, _secretStore, ingestionService, completionService);

--- a/tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/AuthenticatedScanIngestionServiceTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Entities.AuthenticatedScans;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.AuthenticatedScans;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.TestData;
+using Xunit;
+
+namespace PatchHound.Tests.Infrastructure.AuthenticatedScans;
+
+public class AuthenticatedScanIngestionServiceTests : IAsyncLifetime
+{
+    private PatchHoundDbContext _db = null!;
+    private AuthenticatedScanIngestionService _sut = null!;
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private ScanJob _job = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns(_tenantId);
+        tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new PatchHoundDbContext(options, TestServiceProviderFactory.Create(tenantContext));
+
+        // Seed minimal prerequisite data
+        var conn = ConnectionProfile.Create(_tenantId, "c", "", "h", 22, "u", "password", "p", null);
+        var runner = ScanRunner.Create(_tenantId, "r", "", "hash");
+        _db.ConnectionProfiles.Add(conn);
+        _db.ScanRunners.Add(runner);
+        var profile = ScanProfile.Create(_tenantId, "p", "", "", conn.Id, runner.Id, true);
+        _db.ScanProfiles.Add(profile);
+        var device = Device.Create(_tenantId, Guid.NewGuid(), $"ext-{Guid.NewGuid()}", "host", Criticality.Medium);
+        _db.Devices.Add(device);
+        var run = AuthenticatedScanRun.Start(_tenantId, profile.Id, "manual", null, DateTimeOffset.UtcNow);
+        _db.AuthenticatedScanRuns.Add(run);
+        _job = ScanJob.Create(_tenantId, run.Id, runner.Id, device.Id, conn.Id, "[]");
+        _db.ScanJobs.Add(_job);
+        await _db.SaveChangesAsync();
+
+        // Stub merge — no real merge logic needed for this test
+        var mergeService = Substitute.For<IStagedDeviceMergeService>();
+        mergeService
+            .MergeAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new StagedDeviceMergeSummary(0, 0, 0, 0));
+
+        // Use the in-memory bulk writer (load+remove+SaveChanges) since ExecuteDeleteAsync
+        // is not supported by the InMemory EF provider.
+        var bulkWriter = new InMemoryIngestionBulkWriter(_db);
+
+        // The constructor is internal; accessible here via InternalsVisibleTo("PatchHound.Tests").
+        _sut = new AuthenticatedScanIngestionService(
+            _db,
+            new AuthenticatedScanOutputValidator(),
+            mergeService,
+            new NormalizedSoftwareProjectionService(_db),
+            bulkWriter);
+    }
+
+    public ValueTask DisposeAsync() { _db.Dispose(); return ValueTask.CompletedTask; }
+
+    [Fact]
+    public async Task IngestAsync_AfterMerge_StagedDeviceRowsAreDeleted()
+    {
+        // Valid scan output with one software entry
+        var stdout = """{"software":[{"name":"nginx","vendor":"nginx","version":"1.24.0"}]}""";
+
+        await _sut.ProcessJobResultAsync(_job.Id, stdout, string.Empty, CancellationToken.None);
+
+        var remainingStagedDevices = await _db.StagedDevices
+            .IgnoreQueryFilters()
+            .CountAsync();
+        var remainingStagedLinks = await _db.StagedDeviceSoftwareInstallations
+            .IgnoreQueryFilters()
+            .CountAsync();
+
+        Assert.Equal(0, remainingStagedDevices);
+        Assert.Equal(0, remainingStagedLinks);
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/BackendEndToEndTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/AuthenticatedScans/BackendEndToEndTests.cs
@@ -86,7 +86,7 @@ public class BackendEndToEndTests : IAsyncLifetime
         var stagedDeviceMerge = new StagedDeviceMergeService(_db, deviceResolver, softwareResolver);
         var projectionService = new NormalizedSoftwareProjectionService(_db);
         var validator = new AuthenticatedScanOutputValidator();
-        var ingestionService = new AuthenticatedScanIngestionService(_db, validator, stagedDeviceMerge, projectionService);
+        var ingestionService = new AuthenticatedScanIngestionService(_db, validator, stagedDeviceMerge, projectionService, new InMemoryIngestionBulkWriter(_db));
 
         await ingestionService.ProcessJobResultAsync(job.Id, rawOutput, "", CancellationToken.None);
 
@@ -98,10 +98,10 @@ public class BackendEndToEndTests : IAsyncLifetime
         // Assert: result stored
         Assert.True(await _db.ScanJobResults.AnyAsync(r => r.ScanJobId == job.Id));
 
-        // Assert: software staged rows created via ingestion pipeline
-        var stagedSoftware = await _db.StagedDevices
+        // Assert: staged rows are cleaned up after merge (no orphaned staging rows)
+        var stagedSoftware = await _db.StagedDevices.IgnoreQueryFilters()
             .Where(s => s.TenantId == _tenantId && s.AssetType == AssetType.Software && s.SourceKey == "authenticated-scan")
             .ToListAsync();
-        Assert.Equal(2, stagedSoftware.Count);
+        Assert.Empty(stagedSoftware);
     }
 }

--- a/tests/PatchHound.Tests/Infrastructure/IngestionScheduleEvaluatorTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/IngestionScheduleEvaluatorTests.cs
@@ -56,4 +56,19 @@ public class IngestionScheduleEvaluatorTests
 
         due.Should().BeFalse();
     }
+
+    [Fact]
+    public void IsDue_WhenLastStartedAfterLastCompleted_ReturnsFalse()
+    {
+        // lastStartedAt > lastCompletedAt means a run is currently in progress
+        var now = DateTimeOffset.UtcNow;
+        var result = IngestionScheduleEvaluator.IsDue(
+            sourceKey: "microsoft-defender",
+            enabled: true,
+            syncSchedule: "0 */12 * * *", // every 12 hours
+            lastStartedAt: now.AddMinutes(-1),   // started 1 min ago
+            lastCompletedAt: now.AddHours(-13),  // completed 13 hours ago (before the new start)
+            nowUtc: now);
+        result.Should().BeFalse("a run is currently in progress");
+    }
 }

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionCheckpointWriterTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionCheckpointWriterTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class IngestionCheckpointWriterTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public IngestionCheckpointWriterTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    private IngestionCheckpointWriter CreateSut() => new(_db);
+
+    [Fact]
+    public async Task IsCheckpointCompletedAsync_BeforeCommit_ReturnsFalse()
+    {
+        var sut = CreateSut();
+        var result = await sut.IsCheckpointCompletedAsync(
+            Guid.NewGuid(), CheckpointPhases.AssetStaging, CancellationToken.None);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CommitCheckpointAsync_ThenIsCompleted_ReturnsTrue()
+    {
+        var runId = Guid.NewGuid();
+        var sut = CreateSut();
+        await sut.CommitCheckpointAsync(
+            runId, _tenantId, "defender",
+            CheckpointPhases.AssetStaging, 1, null, 10,
+            CheckpointStatuses.Completed, CancellationToken.None);
+
+        var result = await sut.IsCheckpointCompletedAsync(
+            runId, CheckpointPhases.AssetStaging, CancellationToken.None);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetCheckpointBatchNumberAsync_AfterCommit_ReturnsBatchNumber()
+    {
+        var runId = Guid.NewGuid();
+        var sut = CreateSut();
+        await sut.CommitCheckpointAsync(
+            runId, _tenantId, "defender",
+            CheckpointPhases.VulnerabilityStaging, 7, null, 50,
+            CheckpointStatuses.Running, CancellationToken.None);
+
+        var batch = await sut.GetCheckpointBatchNumberAsync(
+            runId, CheckpointPhases.VulnerabilityStaging, CancellationToken.None);
+        batch.Should().Be(7);
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Tests.Infrastructure;
 
@@ -50,5 +52,44 @@ public class IngestionLeaseManagerTests : IAsyncDisposable
 
         var second = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
         second.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CompleteIngestionRunAsync_OnFailure_ClearsStagedData()
+    {
+        // Arrange: acquire a lease and add a staged device for the run
+        var sut = CreateSut();
+        var acquired = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        acquired.Should().NotBeNull();
+
+        _db.StagedDevices.Add(StagedDevice.Create(
+            ingestionRunId: acquired!.Run.Id,
+            tenantId: _tenantId,
+            sourceKey: "defender",
+            externalId: "device-001",
+            name: "Device 001",
+            assetType: AssetType.Device,
+            payloadJson: "{}",
+            stagedAt: DateTimeOffset.UtcNow
+        ));
+        await _db.SaveChangesAsync();
+
+        // Act: complete as failure
+        await sut.CompleteIngestionRunAsync(
+            runId: acquired.Run.Id,
+            tenantId: _tenantId,
+            sourceKey: "defender",
+            succeeded: false,
+            error: "test failure",
+            vulnerabilityMergeSummary: new StagedVulnerabilityMergeSummary(0, 0, 0, 0, 0, 0),
+            assetMergeSummary: new StagedAssetMergeSummary(0, 0, 0, 0, 0),
+            deactivatedMachineCount: 0,
+            failureStatus: null,
+            ct: CancellationToken.None);
+
+        // Assert: staged device was cleaned up
+        var remaining = await _db.StagedDevices.IgnoreQueryFilters()
+            .Where(d => d.IngestionRunId == acquired.Run.Id).CountAsync();
+        remaining.Should().Be(0, "failed runs should also clear staged data");
     }
 }

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using PatchHound.Core.Entities;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class IngestionLeaseManagerTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public IngestionLeaseManagerTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+
+        // Seed the TenantSourceConfiguration row required by TryAcquireIngestionRunAsync
+        _db.TenantSourceConfigurations.Add(TenantSourceConfiguration.Create(
+            _tenantId,
+            sourceKey: "defender",
+            displayName: "Defender",
+            enabled: true,
+            syncSchedule: "0 * * * *"
+        ));
+        _db.SaveChanges();
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    private IngestionLeaseManager CreateSut() =>
+        new(_db, NullLogger<IngestionLeaseManager>.Instance);
+
+    [Fact]
+    public async Task TryAcquireIngestionRunAsync_WhenNoActiveRun_ReturnsRun()
+    {
+        var sut = CreateSut();
+        var result = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        result.Should().NotBeNull();
+        result!.Run.TenantId.Should().Be(_tenantId);
+        result.Resumed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireIngestionRunAsync_WhenAlreadyActive_ReturnsNull()
+    {
+        var sut = CreateSut();
+        var first = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        first.Should().NotBeNull();
+
+        var second = await sut.TryAcquireIngestionRunAsync(_tenantId, "defender", CancellationToken.None);
+        second.Should().BeNull();
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionLeaseManagerTests.cs
@@ -29,7 +29,7 @@ public class IngestionLeaseManagerTests : IAsyncDisposable
     public async ValueTask DisposeAsync() => await _db.DisposeAsync();
 
     private IngestionLeaseManager CreateSut() =>
-        new(_db, NullLogger<IngestionLeaseManager>.Instance);
+        new(_db, new InMemoryIngestionBulkWriter(_db), NullLogger<IngestionLeaseManager>.Instance);
 
     [Fact]
     public async Task TryAcquireIngestionRunAsync_WhenNoActiveRun_ReturnsRun()

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -65,6 +65,7 @@ public class IngestionServicePhase3Tests
             new IngestionCheckpointWriter(db),
             new IngestionStagingPipeline(db, new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance), new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(db)),
             new IngestionSnapshotLifecycle(db),
+            new InMemoryIngestionBulkWriter(db),
             NullLogger<IngestionService>.Instance);
 
         await ingestion.RunExposureDerivationAsync(tenantId, CancellationToken.None);

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -61,6 +61,7 @@ public class IngestionServicePhase3Tests
             new VulnerabilityResolver(db, NullLogger<VulnerabilityResolver>.Instance),
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
+            new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance),
             NullLogger<IngestionService>.Instance);
 
         await ingestion.RunExposureDerivationAsync(tenantId, CancellationToken.None);

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -348,6 +348,13 @@ public class IngestionServicePhase3Tests
             new ExposureAssessmentService(db, new EnvironmentalSeverityCalculator()),
             new RiskScoreService(db, NullLogger<RiskScoreService>.Instance),
             new VulnerabilityResolver(db, NullLogger<VulnerabilityResolver>.Instance),
+            normalizedSoftwareProjectionService: null,
+            remediationDecisionService: null,
+            new IngestionLeaseManager(db, new InMemoryIngestionBulkWriter(db), NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionCheckpointWriter(db),
+            new IngestionStagingPipeline(db, new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance), new IngestionLeaseManager(db, new InMemoryIngestionBulkWriter(db), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(db)),
+            new IngestionSnapshotLifecycle(db, new InMemoryIngestionBulkWriter(db)),
+            new InMemoryIngestionBulkWriter(db),
             NullLogger<IngestionService>.Instance);
 
     private static async Task<PatchHoundDbContext> CreateTenantDbAsync(Guid tenantId)

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -62,6 +62,7 @@ public class IngestionServicePhase3Tests
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
             new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionCheckpointWriter(db),
             NullLogger<IngestionService>.Instance);
 
         await ingestion.RunExposureDerivationAsync(tenantId, CancellationToken.None);

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -61,10 +61,10 @@ public class IngestionServicePhase3Tests
             new VulnerabilityResolver(db, NullLogger<VulnerabilityResolver>.Instance),
             normalizedSoftwareProjectionService: null,
             remediationDecisionService: null,
-            new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance),
+            new IngestionLeaseManager(db, new InMemoryIngestionBulkWriter(db), NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(db),
-            new IngestionStagingPipeline(db, new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance), new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(db)),
-            new IngestionSnapshotLifecycle(db),
+            new IngestionStagingPipeline(db, new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance), new IngestionLeaseManager(db, new InMemoryIngestionBulkWriter(db), NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(db)),
+            new IngestionSnapshotLifecycle(db, new InMemoryIngestionBulkWriter(db)),
             new InMemoryIngestionBulkWriter(db),
             NullLogger<IngestionService>.Instance);
 

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -63,6 +63,7 @@ public class IngestionServicePhase3Tests
             remediationDecisionService: null,
             new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(db),
+            new IngestionStagingPipeline(db, new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance), new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(db)),
             NullLogger<IngestionService>.Instance);
 
         await ingestion.RunExposureDerivationAsync(tenantId, CancellationToken.None);

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -64,6 +64,7 @@ public class IngestionServicePhase3Tests
             new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance),
             new IngestionCheckpointWriter(db),
             new IngestionStagingPipeline(db, new EnrichmentJobEnqueuer(db, NullLogger<EnrichmentJobEnqueuer>.Instance), new IngestionLeaseManager(db, NullLogger<IngestionLeaseManager>.Instance), new IngestionCheckpointWriter(db)),
+            new IngestionSnapshotLifecycle(db),
             NullLogger<IngestionService>.Instance);
 
         await ingestion.RunExposureDerivationAsync(tenantId, CancellationToken.None);

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs
@@ -22,7 +22,7 @@ public class IngestionStagingPipelineTests : IAsyncDisposable
     private IngestionStagingPipeline CreateSut() => new(
         _db,
         new EnrichmentJobEnqueuer(_db, NullLogger<EnrichmentJobEnqueuer>.Instance),
-        new IngestionLeaseManager(_db, NullLogger<IngestionLeaseManager>.Instance),
+        new IngestionLeaseManager(_db, new InMemoryIngestionBulkWriter(_db), NullLogger<IngestionLeaseManager>.Instance),
         new IngestionCheckpointWriter(_db)
     );
 

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionStagingPipelineTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class IngestionStagingPipelineTests : IAsyncDisposable
+{
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public IngestionStagingPipelineTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    private IngestionStagingPipeline CreateSut() => new(
+        _db,
+        new EnrichmentJobEnqueuer(_db, NullLogger<EnrichmentJobEnqueuer>.Instance),
+        new IngestionLeaseManager(_db, NullLogger<IngestionLeaseManager>.Instance),
+        new IngestionCheckpointWriter(_db)
+    );
+
+    private static IngestionResult MakeResult(string externalId, params string[] assetIds) =>
+        new(
+            ExternalId: externalId,
+            Title: "Test Vuln",
+            Description: "desc",
+            VendorSeverity: Severity.High,
+            CvssScore: null,
+            CvssVector: null,
+            PublishedDate: null,
+            AffectedAssets: assetIds
+                .Select(id => new IngestionAffectedAsset(id, id, AssetType.Device))
+                .ToList()
+        );
+
+    [Fact]
+    public async Task StageVulnerabilitiesAsync_EmptyResults_DoesNotWriteRows()
+    {
+        var sut = CreateSut();
+        var runId = Guid.NewGuid();
+
+        await sut.StageVulnerabilitiesAsync(runId, _tenantId, "test-source", [], 1, CancellationToken.None);
+
+        _db.StagedVulnerabilities.Should().BeEmpty();
+        _db.StagedVulnerabilityExposures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StageVulnerabilitiesAsync_WithResults_WritesExpectedRows()
+    {
+        var sut = CreateSut();
+        var runId = Guid.NewGuid();
+        var results = new List<IngestionResult> { MakeResult("CVE-2024-0001", "asset-1") };
+
+        await sut.StageVulnerabilitiesAsync(runId, _tenantId, "test-source", results, 1, CancellationToken.None);
+
+        _db.StagedVulnerabilities.Should().HaveCount(1);
+        _db.StagedVulnerabilityExposures.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void NormalizeResults_DuplicateExternalIds_DeduplicatesVulnerabilities()
+    {
+        var results = new List<IngestionResult>
+        {
+            MakeResult("CVE-2024-0001", "a1"),
+            MakeResult("CVE-2024-0001", "a2"),
+        };
+
+        var normalized = IngestionStagingPipeline.NormalizeResults(results);
+
+        normalized.Should().HaveCount(1);
+        normalized[0].AffectedAssets.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task StageAssetInventorySnapshotAsync_EmptySnapshot_DoesNotWriteRows()
+    {
+        var sut = CreateSut();
+        var runId = Guid.NewGuid();
+        var snapshot = new IngestionAssetInventorySnapshot([], []);
+
+        await sut.StageAssetInventorySnapshotAsync(runId, _tenantId, "test-source", snapshot, 1, CancellationToken.None);
+
+        _db.StagedDevices.Should().BeEmpty();
+        _db.StagedDeviceSoftwareInstallations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NormalizeAssetSnapshot_DuplicateAssetExternalIds_KeepsLast()
+    {
+        var snapshot = new IngestionAssetInventorySnapshot(
+            Assets:
+            [
+                new IngestionAsset("ext-1", "First", AssetType.Device),
+                new IngestionAsset("ext-1", "Second", AssetType.Device),
+            ],
+            DeviceSoftwareLinks: []
+        );
+
+        var normalized = IngestionStagingPipeline.NormalizeAssetSnapshot(snapshot);
+
+        normalized.Assets.Should().HaveCount(1);
+        normalized.Assets[0].Name.Should().Be("Second");
+    }
+
+    [Fact]
+    public void Chunk_SplitsCorrectly()
+    {
+        var items = Enumerable.Range(1, 10).ToList();
+
+        var chunks = IngestionStagingPipeline.Chunk(items, 3).ToList();
+
+        chunks.Should().HaveCount(4);
+        chunks[0].Should().HaveCount(3);
+        chunks[3].Should().HaveCount(1);
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/StagedDeviceMergeServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/StagedDeviceMergeServiceTests.cs
@@ -338,6 +338,52 @@ public class StagedDeviceMergeServiceTests : IAsyncLifetime
         afterReactivation.ActiveInTenant.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task MergeAsync_MultipleStagedDevices_AllMergedCorrectly()
+    {
+        // Arrange: stage 3 devices (no software links)
+        var runId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+
+        await SeedStagedDeviceAsync(
+            runId: runId,
+            tenantId: tenantId,
+            deviceExternalId: "multi-dev-001",
+            deviceName: "host-001",
+            healthStatus: "Active",
+            lastSeenAt: DateTimeOffset.UtcNow.AddMinutes(-5)
+        );
+        await SeedStagedDeviceAsync(
+            runId: runId,
+            tenantId: tenantId,
+            deviceExternalId: "multi-dev-002",
+            deviceName: "host-002",
+            healthStatus: "Active",
+            lastSeenAt: DateTimeOffset.UtcNow.AddMinutes(-5)
+        );
+        await SeedStagedDeviceAsync(
+            runId: runId,
+            tenantId: tenantId,
+            deviceExternalId: "multi-dev-003",
+            deviceName: "host-003",
+            healthStatus: "Active",
+            lastSeenAt: DateTimeOffset.UtcNow.AddMinutes(-5)
+        );
+
+        // Act
+        var summary = await _sut.MergeAsync(runId, tenantId, CancellationToken.None);
+
+        // Assert: 3 Device rows created in DB
+        summary.DevicesCreated.Should().Be(3);
+        summary.DevicesTouched.Should().Be(0);
+
+        var devices = await _db.Devices.IgnoreQueryFilters().ToListAsync();
+        devices.Should().HaveCount(3);
+        devices.Select(d => d.ExternalId).Should().BeEquivalentTo(
+            new[] { "multi-dev-001", "multi-dev-002", "multi-dev-003" });
+        devices.Should().OnlyContain(d => d.TenantId == tenantId);
+    }
+
     private async Task SeedStagedDeviceAsync(
         Guid runId,
         Guid tenantId,

--- a/tests/PatchHound.Tests/Worker/IngestionWorkerTests.cs
+++ b/tests/PatchHound.Tests/Worker/IngestionWorkerTests.cs
@@ -22,7 +22,8 @@ public class IngestionWorkerTests
             SyncSchedule: "0 * * * *",
             StoredCredentialId: Guid.NewGuid(),
             ManualRequestedAt: DateTimeOffset.UtcNow,
-            LastStartedAt: null
+            LastStartedAt: null,
+            LastCompletedAt: null
         );
 
         IngestionWorker.HasConfiguredCredentials(source).Should().BeTrue();


### PR DESCRIPTION
## Summary

- **Phase 0:** Replaced checkpoint phase/status magic strings with typed `CheckpointPhases` / `CheckpointStatuses` constants
- **Phase 1:** Decomposed 3121-line `IngestionService` into four focused collaborators: `IngestionLeaseManager`, `IngestionCheckpointWriter`, `IngestionStagingPipeline`, `IngestionSnapshotLifecycle` — each with their own test suite
- **Phase 2:** Introduced `IIngestionBulkWriter` (+ `PostgresIngestionBulkWriter` / `InMemoryIngestionBulkWriter`) to eliminate 12 scattered `IsInMemoryProvider()` branches; collapsed `IngestionService` to a single canonical constructor with `[ActivatorUtilitiesConstructor]`
- **Phase 3:** Removed dead `RekeyTenantSoftwareReferencesAsync` code; documented `IngestionStateCache` scoped lifetime
- **Phase 4:** Fixed staged-data cleanup to run unconditionally (not just on success); fixed `AuthenticatedScanIngestionService` to delete staged rows after merge; eliminated duplicate `IsDue` logic in `IngestionWorker` via new primitive-field overload on `IngestionScheduleEvaluator` (with active-run guard); eliminated N+1 SELECTs in `StagedDeviceMergeService` via pre-loaded dictionaries; bounded `ProcessStagedResultsAsync` exposure load
- **Phase 5:** Sealed ingestion exception types; switched device-activity refresh to `ExecuteUpdateAsync`; removed unused `IVulnerabilitySource.FetchCanonicalVulnerabilitiesAsync`

## Test Plan

- [x] All 746 tests passing (`dotnet test PatchHound.slnx -v minimal`)
- [x] New unit tests for `IngestionLeaseManager`, `IngestionCheckpointWriter`, `IngestionStagingPipeline`, `IngestionScheduleEvaluator`, `AuthenticatedScanIngestionService`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)