### PR TITLE
Calibrate risk scoring to align with TruRisk v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (10474 symbols, 85667 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (16008 symbols, 92097 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -101,44 +101,12 @@ This project is indexed by GitNexus as **PatchHound** (10474 symbols, 85667 rela
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
-## When Debugging
-
-1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
-2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/PatchHound/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
-- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
-- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
-
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
-| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
-| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
-| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
-| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
-| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -148,32 +116,6 @@ This project is indexed by GitNexus as **PatchHound** (10474 symbols, 85667 rela
 | `gitnexus://repo/PatchHound/clusters` | All functional areas |
 | `gitnexus://repo/PatchHound/processes` | All execution flows |
 | `gitnexus://repo/PatchHound/process/{name}` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. `gitnexus_impact` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. `gitnexus_detect_changes()` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-```bash
-npx gitnexus analyze
-```
-
-If the index previously included embeddings, preserve them by adding `--embeddings`:
-
-```bash
-npx gitnexus analyze --embeddings
-```
-
-To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (10474 symbols, 85667 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (16008 symbols, 92097 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -101,44 +101,12 @@ This project is indexed by GitNexus as **PatchHound** (10474 symbols, 85667 rela
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
-## When Debugging
-
-1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
-2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/PatchHound/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
-- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
-- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
-
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
-| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
-| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
-| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
-| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
-| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -148,32 +116,6 @@ This project is indexed by GitNexus as **PatchHound** (10474 symbols, 85667 rela
 | `gitnexus://repo/PatchHound/clusters` | All functional areas |
 | `gitnexus://repo/PatchHound/processes` | All execution flows |
 | `gitnexus://repo/PatchHound/process/{name}` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. `gitnexus_impact` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. `gitnexus_detect_changes()` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-```bash
-npx gitnexus analyze
-```
-
-If the index previously included embeddings, preserve them by adding `--embeddings`:
-
-```bash
-npx gitnexus analyze --embeddings
-```
-
-To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -534,7 +534,7 @@ Remediation posture changes the inputs before rollup.
 
 | Remediation state | Scoring behavior |
 |---|---|
-| Approved for patching, maintenance window not missed | Detection score is reduced by the remediation adjustment factor while work is on track |
+| Approved for patching, maintenance window not missed | The exposure's Environmental CVSS input is reduced by the remediation adjustment factor while work is on track. ThreatScore and exploit/urgency floors still apply. |
 | Approved for patching, maintenance window missed | No reduction |
 | Risk acceptance | Visibility only; no score reduction |
 | Alternate mitigation approved | Covered vulnerabilities are removed from active risk |

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,383 +1,591 @@
 # Scoring Reference
 
-All scores in PatchHound use the range **0–100** for sub-scores and **0–1000** for composite risk scores. Every number in this document comes directly from the scoring service implementations.
+PatchHound risk scoring uses two ranges:
+
+- **0-100** for vulnerability-level likelihood and detection-style sub-scores.
+- **0-1000** for displayed composite risk scores in dashboards, devices, software, remediation cases, teams, and tenant views.
+
+This document describes the **TruRisk-inspired v2 scoring model**. The goal is simple: a low fleet footprint can reduce business risk, but it must not hide emergency vulnerability urgency.
 
 ---
 
-## Overview
+## Risk Bands
 
-The scoring system has three layers that feed into each other bottom-up:
+All user-facing risk bands should use the same thresholds.
 
-```mermaid
-flowchart TB
-    subgraph L1["Layer 1 — Vulnerability intelligence"]
-        TA["Threat Score (0–100)\nper vulnerability definition"]
-        ES["Effective Severity / Score\nper vulnerability × asset pair"]
-    end
-
-    subgraph L2["Layer 2 — Episode risk"]
-        ER["Episode Risk Score (0–1000)\nper open vulnerability on an asset"]
-    end
-
-    subgraph L3["Layer 3 — Aggregate risk"]
-        DR["Device Risk Score (0–1000)"]
-        SR["Software Risk Score (0–1000)"]
-        DG["Device Group Risk Score (0–1000)"]
-        TR["Team Risk Score (0–1000)"]
-        TNT["Tenant Risk Score (0–1000)"]
-    end
-
-    TA --> ER
-    ES --> ER
-    ER --> DR
-    ER --> SR
-    DR --> DG
-    DR --> TR
-    DR --> TNT
-```
-
----
-
-## Layer 1a — Threat Score
-
-**Source:** `VulnerabilityThreatAssessmentService`  
-**Scope:** One record per `VulnerabilityDefinition` (global, not per tenant).
-
-The Threat Score expresses how dangerous a vulnerability is in isolation — independent of where it is installed.
-
-### Sub-scores
-
-| Sub-score | Weight | What it measures |
-|---|---|---|
-| Technical | 35% | CVSS severity and base score |
-| Exploit Likelihood | 25% | Known exploits, public exploits, ransomware, EPSS |
-| Threat Activity | 25% | Active alerts, malware/ransomware associations |
-| Recency | 15% | How recently the CVE was published |
-
-### Technical Score
-
-```
-If CVSS score present:  TechnicalScore = CVSS × 10       (clamped 0–100)
-Otherwise:
-  Critical → 95,  High → 75,  Medium → 50,  Low → 25
-```
-
-### Exploit Likelihood Score
-
-```
-+60  if KnownExploited (KEV tag, "exploit verified", "exploit in kit")
-+30  if PublicExploit (any "exploit" tag)
-+10  if RansomwareAssociation
-+0–20  EPSS score × 20  (clamped to 20)
-→ clamped to 0–100
-```
-
-### Threat Activity Score
-
-```
-+40  if ActiveAlert
-+30  if RansomwareAssociation
-+20  if MalwareAssociation
-+10  if KnownExploited
-→ clamped to 0–100
-```
-
-### Recency Score
-
-| CVE age | Score |
-|---|---|
-| ≤ 30 days | 80 |
-| ≤ 90 days | 60 |
-| ≤ 180 days | 40 |
-| > 180 days | 20 |
-| Unknown | 20 |
-
-### Final Threat Score formula
-
-```
-ThreatScore = (0.35 × Technical)
-            + (0.25 × ExploitLikelihood)
-            + (0.25 × ThreatActivity)
-            + (0.15 × Recency)
-```
-
----
-
-## Layer 1b — Effective Severity
-
-**Source:** `EnvironmentalSeverityCalculator`  
-**Scope:** One record per `VulnerabilityDefinition` × `Asset` pair.
-
-When an asset has a **Security Profile** assigned, the vendor CVSS vector is re-evaluated using the profile's environmental overrides (modified attack vector, modified impact metrics, CIA requirements). The result is an `EffectiveScore` (0–10) and `EffectiveSeverity` that may be higher or lower than the vendor baseline.
-
-```mermaid
-flowchart LR
-    VD["Vendor CVSS vector\n(AV/AC/PR/UI/S/C/I/A)"]
-    SP["Security Profile\n(MAV/MAC/MPR/MUI/MS/MC/MI/MA\n+ CR/IR/AR requirements)"]
-    ENV["CVSS 3.1 Environmental\ncalculation"]
-    ES2["EffectiveScore (0–10)\nEffectiveSeverity"]
-
-    VD --> ENV
-    SP --> ENV
-    ENV --> ES2
-```
-
-If no Security Profile is assigned, `EffectiveScore` = vendor CVSS score and `EffectiveSeverity` = vendor severity.
-
-### Severity bands (CVSS)
-
-| Score | Severity |
-|---|---|
-| ≥ 9.0 | Critical |
-| ≥ 7.0 | High |
-| ≥ 4.0 | Medium |
-| < 4.0 | Low |
-
----
-
-## Layer 2 — Episode Risk Score
-
-**Source:** `VulnerabilityEpisodeRiskAssessmentService`  
-**Scope:** One record per open `VulnerabilityAssetEpisode`.
-
-This is the core per-instance risk score. It combines threat intelligence, asset context, and operational status.
-
-```mermaid
-flowchart TB
-    TS["ThreatScore (0–100)"]
-    CS["ContextScore (0–100)"]
-    OS["OperationalScore (0–100)"]
-    ERS["EpisodeRiskScore = 10 × (0.45·T + 0.40·C + 0.15·O)\nclamped 0–1000"]
-    RB["RiskBand"]
-
-    TS -->|"45%"| ERS
-    CS -->|"40%"| ERS
-    OS -->|"15%"| ERS
-    ERS --> RB
-```
-
-### Threat component (ThreatScore)
-
-Uses `VulnerabilityThreatAssessment.ThreatScore` directly (see Layer 1a).  
-Fallback chain if no threat assessment exists:
-1. `VulnerabilityAssetAssessment.EffectiveScore × 10`
-2. `VulnerabilityDefinition.CvssScore × 10`
-3. Severity lookup: Critical→95, High→75, Medium→50, Low→25
-
-### Context component (ContextScore)
-
-Measures how attractive and exposed the specific asset is.
-
-```
-AssetCriticality:   Critical→100, High→80, Medium→55, Low→30
-DeviceValue:        High→100, Normal→60, Low→30
-ExposureLevel:      High→100, Medium→70, Low→40, Unknown→50
-DeviceRiskScore:    High→95, Medium→65, Low→35, Unknown→50
-
-EffectiveSeverity from VulnerabilityAssetAssessment:
-  If EffectiveScore present: EffectiveScore × 10
-  Else: Critical→95, High→75, Medium→50, Low→25
-
-ContextScore = (0.35 × avg(AssetCriticality, DeviceValue))
-             + (0.25 × EffectiveSeverityScore)
-             + (0.20 × ExposureLevel)
-             + (0.20 × DeviceRiskScore)
-clamped 0–100
-```
-
-### Operational component (OperationalScore)
-
-Measures the urgency introduced by remediation workflow state. Starts at **40**, then adjustments are applied:
-
-```
-Base:  40
-
-+15  if asset has no owner (no OwnerUserId, OwnerTeamId, or FallbackTeamId)
-
-With a RemediationDecision present:
-  PendingApproval:       +10
-  RiskAcceptance:        −20
-  AlternateMitigation:    +0
-  ApprovedForPatching:   +10 (no task), +10 (Pending task), +5 (InProgress task), +0 (Completed)
-  PatchingDeferred:      +15
-  ApprovedForPatching + overdue task: additional +20
-
-Without a RemediationDecision:
-  +10 (no decision at all)
-  −20 if a legacy RiskAcceptance exists
-
-clamped 0–100
-```
-
-### Risk Band thresholds
-
-| EpisodeRiskScore | RiskBand |
-|---|---|
-| ≥ 900 | Critical |
-| ≥ 750 | High |
-| ≥ 500 | Medium |
-| > 0 | Low |
+| Score | Band |
+|---:|---|
+| 850-1000 | Critical |
+| 700-849.99 | High |
+| 500-699.99 | Medium |
+| 1-499.99 | Low |
 | 0 | None |
 
----
+```mermaid
+flowchart LR
+    S["Composite score\n0-1000"]
+    N["0\nNone"]
+    L["1-499\nLow"]
+    M["500-699\nMedium"]
+    H["700-849\nHigh"]
+    C["850-1000\nCritical"]
 
-## Layer 3 — Aggregate Risk Scores
-
-All aggregate scores follow the same structural pattern: **max score + top-N average + capped count bonuses**, clamped to 0–1000.
-
-### Device Risk Score
-
-**Source:** `RiskScoreService.BuildAssetRiskResults`  
-**Input:** All unresolved `EpisodeRiskScore` values for the device.
-
+    S --> N
+    S --> L
+    S --> M
+    S --> H
+    S --> C
 ```
-MaxEpisodeRisk   = highest single episode score
-TopThreeAverage  = average of top-3 episode scores
-
-DeviceRiskScore =  0.70 × MaxEpisodeRisk
-                +  0.20 × TopThreeAverage
-                +  min(CriticalCount × 35, 120)
-                +  min(HighCount    × 15,  60)
-                +  min(MediumCount  ×  5,  20)
-                +  min(LowCount     ×  1,   5)
-clamped 0–1000
-```
-
-### Software Risk Score
-
-**Source:** `RiskScoreService.CalculateSoftwareScoresAsync`  
-**Input:** Episode risk scores for all device episodes linked to a `TenantSoftware`.
-
-```
-SoftwareRiskScore =  0.65 × MaxEpisodeRisk
-                  +  0.20 × TopThreeAverage
-                  +  min(CriticalCount × 30, 120)
-                  +  min(HighCount     × 12,  48)
-                  +  min(MediumCount   ×  4,  16)
-                  +  min(LowCount      ×  1,   6)
-clamped 0–1000
-```
-
-### Device Group Risk Score
-
-**Source:** `RiskScoreService.CalculateDeviceGroupScoresAsync`  
-**Input:** Device Risk Scores of all devices in the group.
-
-```
-MaxAssetRisk     = highest DeviceRiskScore in the group
-TopThreeAverage  = average of top-3 DeviceRiskScores
-
-DeviceGroupRiskScore =  0.55 × MaxAssetRisk
-                     +  0.25 × TopThreeAverage
-                     +  min(CriticalCount × 8,  120)
-                     +  min(HighCount     × 3,   60)
-                     +  min(MediumCount   × 1,   20)
-                     +  min(LowCount      × 0.25,  8)
-clamped 0–1000
-```
-
-*Note: counts here are summed episode counts across all devices in the group.*
-
-### Team Risk Score
-
-**Source:** `RiskScoreService.CalculateTeamScoresAsync`  
-**Input:** Device Risk Scores of all devices owned (or fallback-owned) by the team.
-
-```
-TeamRiskScore =  0.60 × MaxAssetRisk
-             +   0.25 × TopThreeAverage
-             +   min(CriticalCount × 10, 150)
-             +   min(HighCount     ×  4,  72)
-             +   min(MediumCount   ×  1,  20)
-             +   min(LowCount      × 0.25,  8)
-clamped 0–1000
-```
-
-### Tenant Risk Score
-
-**Source:** `RiskScoreService.CalculateTenantRisk`  
-**Input:** All Device Risk Scores for the tenant.
-
-```
-TopFiveAverage   = average of top-5 DeviceRiskScores
-CriticalAssets   = devices with score ≥ 900
-HighAssets       = devices with score 750–899
-MediumAssets     = devices with score 500–749
-LowAssets        = devices with score 1–499
-
-TenantRiskScore =  0.55 × MaxAssetRisk
-               +   0.30 × TopFiveAverage
-               +   min(CriticalAssets × 18, 90)
-               +   min(HighAssets     ×  8, 40)
-               +   min(MediumAssets   ×  2, 10)
-               +   min(LowAssets      × 0.5, 5)
-clamped 0–1000
-```
-
-### Asset risk bands (used for tenant-level asset counting)
-
-| DeviceRiskScore | Band |
-|---|---|
-| ≥ 900 | Critical |
-| 750–899 | High |
-| 500–749 | Medium |
-| 1–499 | Low |
 
 ---
 
-## How the scores relate
+## Big Picture
+
+The v2 model follows the same idea as risk-based vulnerability management tools such as Qualys TruRisk:
+
+```text
+Risk = likelihood x impact
+```
+
+PatchHound calculates likelihood per open exposure, then rolls it up through the asset, software, team, and tenant views.
+
+```mermaid
+flowchart TB
+    subgraph Inputs["Inputs"]
+        CVSS["Environmental CVSS\n0-10"]
+        TI["Threat intelligence\nThreatScore, KEV, exploit, EPSS,\nransomware, malware, active alert"]
+        URG["Patch urgency\nEmergency patch recommendation"]
+        ASSET["Asset context\nDevice criticality\nBusiness labels\nAffected device count"]
+        REM["Remediation posture\nApproved patching\nAlternate mitigation\nRisk acceptance"]
+    end
+
+    DET["DetectionScore\n0-100"]
+    EXP["Open exposure risk input"]
+
+    DEV["DeviceRiskScore\n0-1000"]
+    SW["SoftwareRiskScore\n0-1000\nused by remediation cases"]
+    GROUP["DeviceGroupRiskScore\n0-1000"]
+    TEAM["TeamRiskScore\n0-1000"]
+    TENANT["TenantRiskScore\n0-1000\nshown on dashboards"]
+
+    CVSS --> DET
+    TI --> DET
+    URG --> DET
+    DET --> EXP
+    ASSET --> EXP
+    REM --> EXP
+
+    EXP --> DEV
+    EXP --> SW
+    DEV --> GROUP
+    DEV --> TEAM
+    DEV --> TENANT
+```
+
+---
+
+## Step 1 - Detection Score
+
+Each open device-vulnerability exposure gets a **DetectionScore** from `0-100`.
+
+The score starts with the best available vulnerability signal:
+
+```text
+DetectionScore = max(
+  EnvironmentalCvss * 10,
+  ThreatAssessment.ThreatScore,
+  urgencyFloor,
+  threatIntelFloor,
+  severityFallback
+)
+```
+
+### Floors
+
+Floors prevent important real-world signals from being averaged away.
+
+| Signal | DetectionScore floor |
+|---|---:|
+| Emergency patch recommended | 95 |
+| Known exploited, active alert, ransomware, or malware association | 95 |
+| Public exploit | 80 |
+| EPSS >= 0.50 | 80 |
+| Critical severity with no stronger signal | 90 |
+| High severity with no stronger signal | 70 |
+| Medium severity with no stronger signal | 40 |
+| Low severity with no stronger signal | 10 |
+
+```mermaid
+flowchart TD
+    A["Open exposure"]
+    B["Environmental CVSS x 10"]
+    C["ThreatAssessment.ThreatScore"]
+    D["Urgency and threat-intel floors"]
+    E["Severity fallback"]
+    F["DetectionScore = max(all inputs)"]
+
+    A --> B
+    A --> C
+    A --> D
+    A --> E
+    B --> F
+    C --> F
+    D --> F
+    E --> F
+```
+
+### Example
+
+| Input | Value |
+|---|---:|
+| Environmental CVSS | 8.1 |
+| ThreatScore | 72 |
+| Public exploit | yes |
+| Emergency patch | no |
+
+```text
+Environmental signal = 8.1 * 10 = 81
+Threat signal        = 72
+Public exploit floor = 80
+
+DetectionScore = max(81, 72, 80) = 81
+```
+
+If the same vulnerability has an emergency patch recommendation:
+
+```text
+Emergency floor = 95
+
+DetectionScore = max(81, 72, 80, 95) = 95
+```
+
+---
+
+## Step 2 - Asset Impact
+
+Asset impact answers: "How important is the affected device?"
+
+PatchHound uses the device `Criticality` and active business labels.
+
+### Device Criticality Multiplier
+
+| Device criticality | Multiplier |
+|---|---:|
+| Critical | 1.35 |
+| High | 1.20 |
+| Medium | 1.00 |
+| Low | 0.85 |
+
+### Business Label Multiplier
+
+When a device has multiple active labels, the highest active label weight wins.
+
+| Business label weight category | Multiplier |
+|---|---:|
+| Critical | 2.00 |
+| Sensitive | 1.50 |
+| Normal | 1.00 |
+| Informational | 0.50 |
 
 ```mermaid
 flowchart LR
-    CVE["CVE / VulnerabilityDefinition"]
-    TA2["ThreatScore\n(0–100)"]
-    SP2["Security Profile\n(CVSS environmental overrides)"]
-    EFF["EffectiveScore / EffectiveSeverity"]
-    DEV["Device (Criticality, Exposure,\nDeviceValue, DeviceRiskSignal)"]
-    OP["Remediation Decision\n/ Patching Task state"]
+    D["Device"]
+    C["Criticality multiplier"]
+    B["Highest active\nbusiness label multiplier"]
+    I["Impact multiplier"]
 
-    ERS2["EpisodeRiskScore\n(0–1000)"]
-    DRS["DeviceRiskScore\n(0–1000)"]
-    SRS["SoftwareRiskScore\n(0–1000)"]
-    DGRS["DeviceGroupRiskScore\n(0–1000)"]
-    TRS["TeamRiskScore\n(0–1000)"]
-    TNT2["TenantRiskScore\n(0–1000)"]
-
-    CVE --> TA2
-    CVE --> EFF
-    SP2 --> EFF
-    TA2 -->|"45% of episode"| ERS2
-    EFF -->|"feeds ContextScore\n40% of episode"| ERS2
-    DEV -->|"feeds ContextScore\n40% of episode"| ERS2
-    OP  -->|"15% of episode"| ERS2
-
-    ERS2 --> DRS
-    ERS2 --> SRS
-    DRS --> DGRS
-    DRS --> TRS
-    DRS --> TNT2
+    D --> C
+    D --> B
+    C --> I
+    B --> I
 ```
-
-### Key relationships
-
-- **ThreatScore feeds EpisodeRiskScore** at 45% weight. It is the single largest driver of episode risk.
-- **EffectiveScore (via Security Profile) feeds both ContextScore and ThreatScore fallback.** A Security Profile can raise or lower the effective CVSS score for a specific environment, which flows into both the Context sub-score (25% weight inside ContextScore) and as the fallback ThreatScore when no threat assessment exists.
-- **DeviceRiskScore is a rollup of EpisodeRiskScores.** It does not re-enter the episode calculation — it is a one-way aggregation.
-- **All group/team/tenant scores aggregate from DeviceRiskScores**, not directly from episodes. They inherit the episode band counts (Critical/High/Medium/Low) as bonus multipliers.
-- **Operational state (Remediation Decisions, Patching Tasks) only affects the episode layer** (15% weight). It does not directly modify any aggregate score — but resolving episodes (setting `ResolvedAt`) removes them from all aggregate calculations entirely.
 
 ---
 
-## What triggers recalculation
+## Step 3 - Device Risk Score
+
+The device score is based on all open exposures on that device.
+
+```text
+BaseComponent      = MaxDetectionScore * 6.5
+CountComponent     = CriticalCount * 45
+                   + HighCount     * 12
+                   + MediumCount   * 3
+                   + LowCount      * 1
+
+RawDeviceScore     = BaseComponent + CountComponent
+DeviceRiskScore    = RawDeviceScore
+                   * DeviceCriticalityMultiplier
+                   * BusinessLabelMultiplier
+
+Final score is clamped to 0-1000.
+```
+
+Risk floors are applied after the numeric score:
+
+| Condition | Minimum device score |
+|---|---:|
+| Any emergency, known exploited, active alert, ransomware, or malware exposure | 700 |
+| Any critical exposure | 500 |
+| 10 or more high exposures | 500 |
+
+```mermaid
+flowchart TD
+    E["Open exposures on device"]
+    M["Max DetectionScore"]
+    C["Severity counts"]
+    BASE["BaseComponent\nMaxDetectionScore * 6.5"]
+    COUNT["CountComponent\ncritical/high/medium/low bonuses"]
+    IMPACT["Apply device criticality\nand business label"]
+    FLOOR["Apply risk floors"]
+    SCORE["DeviceRiskScore\n0-1000"]
+
+    E --> M
+    E --> C
+    M --> BASE
+    C --> COUNT
+    BASE --> IMPACT
+    COUNT --> IMPACT
+    IMPACT --> FLOOR
+    FLOOR --> SCORE
+```
+
+### Example - One Emergency Critical On A High-Value Device
+
+Input:
+
+| Signal | Value |
+|---|---:|
+| DetectionScore | 95 |
+| Critical exposures | 1 |
+| High exposures | 0 |
+| Device criticality | High, multiplier 1.20 |
+| Business label | Normal, multiplier 1.00 |
+
+Calculation:
+
+```text
+BaseComponent  = 95 * 6.5 = 617.5
+CountComponent = 1 * 45 = 45
+Raw score      = 617.5 + 45 = 662.5
+Impact score   = 662.5 * 1.20 * 1.00 = 795
+
+Emergency floor = at least 700
+Final score     = max(795, 700) = 795
+Band            = High
+```
+
+The old model could make this look low because CVSS-scale values were too small for a 0-1000 band. The v2 model keeps the score in the right range.
+
+---
+
+## Step 4 - Software Risk Score
+
+The software score is used by software pages and remediation cases. It asks: "How risky is this software product for this tenant right now?"
+
+Inputs:
+
+- All open exposures linked to the software product.
+- Number of affected devices.
+- Number of affected high-value devices.
+- Detection scores and severity counts.
+- Emergency and threat-intel floors.
+
+```text
+BaseComponent       = MaxDetectionScore * 6.5
+CountComponent      = CriticalCount * 45
+                    + HighCount     * 12
+                    + MediumCount   * 3
+                    + LowCount      * 1
+
+BreadthComponent    = 0 when only 1 device is affected
+                    = min(log10(AffectedDeviceCount) * 80, 180)
+
+HighValueComponent  = HighValueDeviceCount * 25
+
+SoftwareRiskScore   = BaseComponent
+                    + CountComponent
+                    + BreadthComponent
+                    + HighValueComponent
+
+Final score is clamped to 0-1000.
+```
+
+Risk floors:
+
+| Condition | Minimum software score |
+|---|---:|
+| Any emergency, known exploited, active alert, ransomware, or malware exposure | 700 |
+| Any critical exposure | 500 |
+| 10 or more high exposures | 500 |
+
+```mermaid
+flowchart TD
+    SW["Software product"]
+    OPEN["Open exposures"]
+    DET["Max DetectionScore"]
+    CNT["Severity counts"]
+    BREADTH["Affected device count"]
+    HV["High-value affected devices"]
+    FLOORS["Emergency and threat floors"]
+    SCORE["SoftwareRiskScore\nused by remediation cases"]
+
+    SW --> OPEN
+    OPEN --> DET
+    OPEN --> CNT
+    OPEN --> BREADTH
+    OPEN --> HV
+    DET --> SCORE
+    CNT --> SCORE
+    BREADTH --> SCORE
+    HV --> SCORE
+    FLOORS --> SCORE
+```
+
+### Example - The Reported Case
+
+Scenario:
+
+- One affected device.
+- 60 open vulnerabilities.
+- 1 critical vulnerability with emergency patch recommended.
+- 49 high vulnerabilities.
+- 10 medium/low vulnerabilities omitted from this example for simplicity.
+
+Assumptions:
+
+- Emergency critical vulnerability has `DetectionScore = 95`.
+- High vulnerabilities have `DetectionScore >= 70`.
+- One affected device means no breadth bonus.
+- The device is not high-value, so no high-value bonus.
+
+Calculation:
+
+```text
+MaxDetectionScore = 95
+CriticalCount     = 1
+HighCount         = 49
+AffectedDevices   = 1
+HighValueDevices  = 0
+
+BaseComponent      = 95 * 6.5 = 617.5
+CountComponent     = (1 * 45) + (49 * 12)
+                   = 45 + 588
+                   = 633
+BreadthComponent   = 0
+HighValueComponent = 0
+
+Raw score          = 617.5 + 633 = 1250.5
+Clamped score      = 1000
+Emergency floor    = at least 700
+Final score        = 1000
+Band               = Critical
+```
+
+If the same case had only the single emergency critical vulnerability and no other findings:
+
+```text
+BaseComponent      = 95 * 6.5 = 617.5
+CountComponent     = 1 * 45 = 45
+Raw score          = 662.5
+Emergency floor    = at least 700
+Final score        = 700
+Band               = High
+```
+
+So yes, one affected device reduces fleet exposure. It does **not** reduce emergency urgency below High.
+
+### Example - Broad High Severity Without Emergency
+
+Scenario:
+
+- 20 affected devices.
+- 12 high vulnerabilities.
+- MaxDetectionScore = 75.
+- 4 high-value devices.
+
+```text
+BaseComponent       = 75 * 6.5 = 487.5
+CountComponent      = 12 * 12 = 144
+BreadthComponent    = log10(20) * 80 = 104.08
+HighValueComponent  = 4 * 25 = 100
+
+Raw score           = 487.5 + 144 + 104.08 + 100 = 835.58
+Final score         = 835.58
+Band                = High
+```
+
+---
+
+## Step 5 - Rollup Scores
+
+Rollups are based on the scores beneath them. They do not re-score vulnerabilities from scratch.
+
+```mermaid
+flowchart TB
+    EXP["Open exposure inputs"]
+    DEV["DeviceRiskScore"]
+    SW["SoftwareRiskScore"]
+    DG["DeviceGroupRiskScore"]
+    TEAM["TeamRiskScore"]
+    TENANT["TenantRiskScore"]
+    DASH["Dashboard overall risk"]
+    CASE["Remediation case risk"]
+
+    EXP --> DEV
+    EXP --> SW
+    DEV --> DG
+    DEV --> TEAM
+    DEV --> TENANT
+    TENANT --> DASH
+    SW --> CASE
+```
+
+### Device Group Risk
+
+```text
+DeviceGroupRiskScore =
+    0.55 * MaxDeviceRiskScore
+  + 0.25 * AverageTopThreeDeviceRiskScores
+  + min(CriticalEpisodeCount * 8, 120)
+  + min(HighEpisodeCount     * 3, 60)
+  + min(MediumEpisodeCount   * 1, 20)
+  + min(LowEpisodeCount      * 0.25, 8)
+```
+
+### Team Risk
+
+```text
+TeamRiskScore =
+    0.60 * MaxDeviceRiskScore
+  + 0.25 * AverageTopThreeDeviceRiskScores
+  + min(CriticalEpisodeCount * 10, 150)
+  + min(HighEpisodeCount     * 4, 72)
+  + min(MediumEpisodeCount   * 1, 20)
+  + min(LowEpisodeCount      * 0.25, 8)
+```
+
+### Tenant Risk
+
+The tenant/dashboard score asks: "How risky is the tenant overall?"
+
+```text
+TenantRiskScore =
+    0.55 * MaxDeviceRiskScore
+  + 0.30 * AverageTopFiveDeviceRiskScores
+  + min(CriticalAssetCount * 18, 90)
+  + min(HighAssetCount     * 8, 40)
+  + min(MediumAssetCount   * 2, 10)
+  + min(LowAssetCount      * 0.5, 5)
+```
+
+Asset band counts use the shared thresholds:
+
+| Device score | Asset count bucket |
+|---:|---|
+| >= 850 | CriticalAssetCount |
+| 700-849.99 | HighAssetCount |
+| 500-699.99 | MediumAssetCount |
+| 1-499.99 | LowAssetCount |
+
+### Example - Dashboard Overall Risk
+
+Assume a tenant has these top device scores:
+
+| Device | Score | Band |
+|---|---:|---|
+| Device A | 795 | High |
+| Device B | 620 | Medium |
+| Device C | 520 | Medium |
+| Device D | 120 | Low |
+| Device E | 0 | None |
+
+```text
+MaxDeviceRiskScore          = 795
+AverageTopFiveDeviceScores  = (795 + 620 + 520 + 120 + 0) / 5
+                             = 411
+
+CriticalAssetCount = 0
+HighAssetCount     = 1
+MediumAssetCount   = 2
+LowAssetCount      = 1
+
+TenantRiskScore =
+    0.55 * 795
+  + 0.30 * 411
+  + min(0 * 18, 90)
+  + min(1 * 8, 40)
+  + min(2 * 2, 10)
+  + min(1 * 0.5, 5)
+
+= 437.25 + 123.30 + 0 + 8 + 4 + 0.5
+= 573.05
+
+Band = Medium
+```
+
+This is intentionally lower than the highest individual device score because the dashboard is a tenant-level exposure score. However, it is no longer artificially tiny when the top devices contain real high-risk exposures.
+
+---
+
+## Remediation Effects
+
+Remediation posture changes the inputs before rollup.
+
+| Remediation state | Scoring behavior |
+|---|---|
+| Approved for patching, maintenance window not missed | Detection score is reduced by the remediation adjustment factor while work is on track |
+| Approved for patching, maintenance window missed | No reduction |
+| Risk acceptance | Visibility only; no score reduction |
+| Alternate mitigation approved | Covered vulnerabilities are removed from active risk |
+| Exposure resolved | Exposure is removed from device, software, team, group, and tenant rollups |
+
+```mermaid
+flowchart TD
+    E["Open exposure"]
+    D["DetectionScore"]
+    PATCH["Approved patching\ninside maintenance window"]
+    MISS["Maintenance window missed"]
+    ACCEPT["Risk acceptance"]
+    ALT["Approved alternate mitigation"]
+    RES["Resolved exposure"]
+    ACTIVE["Included in active risk"]
+    REDUCED["Included with reduced score"]
+    REMOVED["Removed from active risk"]
+
+    E --> D
+    D --> PATCH --> REDUCED
+    D --> MISS --> ACTIVE
+    D --> ACCEPT --> ACTIVE
+    D --> ALT --> REMOVED
+    D --> RES --> REMOVED
+```
+
+---
+
+## What Triggers Recalculation
 
 | Event | Scores recalculated |
 |---|---|
-| Ingestion / vulnerability scan processed | Episode risk for affected assets |
-| Remediation Decision created or approved | Episode risk for affected software/assets |
-| Patching Task status changed | Episode risk for affected software/assets |
-| Risk Acceptance approved | Episode risk for affected assets |
-| Security Profile updated | Effective Severity for all linked assets → Episode risk |
-| `RiskRefreshService.RefreshForAssetsAsync` called | Device, Group, Team, Tenant risk |
-| `RiskScoreService.RecalculateForTenantAsync` called | All Layer 3 scores for the tenant + daily snapshot |
+| Ingestion or vulnerability scan processed | Exposure inputs, device/software scores, rollups |
+| Threat intelligence refreshed | Detection scores and all affected rollups |
+| Vulnerability patch assessment created or updated | Detection floors and all affected rollups |
+| Security profile updated | Environmental CVSS and all affected rollups |
+| Device criticality or business labels changed | Device score and rollups |
+| Remediation decision approved | Affected device/software scores and rollups |
+| Patching task status or maintenance window changes | Affected device/software scores and rollups |
+| Exposure resolved | Exposure removed from active rollups |
+| `RiskScoreService.RecalculateForTenantAsync` called | All tenant Layer 3 scores and daily snapshot |
 
-Daily snapshots of the Tenant Risk Score are retained for 30 days.
+Daily tenant risk snapshots are retained for trend views. After a scoring-version change, existing tenants need recalculation so stored scores move from the old calculation version to the new one.
+
+---
+
+## Design Principles
+
+- **Emergency urgency cannot be hidden by small affected-device count.**
+- **One affected device still matters less than broad tenant exposure.**
+- **Threat intelligence can raise risk above CVSS-only severity.**
+- **Critical business assets increase impact.**
+- **Risk acceptance is not remediation and does not reduce risk.**
+- **Approved alternate mitigation and resolved exposures reduce active risk because they remove exposure from the active set.**

--- a/docs/superpowers/plans/2026-05-14-risk-scoring-trurisk-calibration.md
+++ b/docs/superpowers/plans/2026-05-14-risk-scoring-trurisk-calibration.md
@@ -1,0 +1,460 @@
+# TruRisk-Inspired Risk Scoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recalibrate PatchHound risk scoring so dashboard, device, software, team, tenant, and remediation-case scores use a consistent 0-1000 model that reflects vulnerability likelihood, business impact, exposure breadth, and emergency urgency.
+
+**Architecture:** Extract pure scoring formulas from `RiskScoreService` into a focused core scoring model, then have `RiskScoreService` feed it enriched exposure inputs. Preserve existing persisted score entities and API DTOs in the first pass, but update `CalculationVersion` and `FactorsJson` so every UI can explain why scores changed. Use Qualys TruRisk as inspiration, not a literal clone: PatchHound will use available `ExposureAssessment`, `ThreatAssessment`, `VulnerabilityPatchAssessment`, device `Criticality`, and business-label weights.
+
+**Tech Stack:** C#/.NET, EF Core, xUnit, FluentAssertions, NSubstitute, PatchHound existing test-data builders.
+
+---
+
+## Background And Risk
+
+GitNexus impact analysis reports this as high-risk shared behavior:
+
+- `RiskScoreService`: CRITICAL, 107 direct dependents, 279 total impacted symbols.
+- `CalculateTenantRisk`: CRITICAL, affects dashboard summary, risk-score API, refresh flows, ingestion snapshots.
+- `CalculateSoftwareScoresAsync`: CRITICAL, affects remediation cases, software views, dashboards, refresh flows.
+- `BuildAssetRiskResults`: HIGH, affects device, group, team, tenant rollups.
+
+Current root cause:
+
+- Device/software formulas mix CVSS-scale values (`0-10`) with a `0-1000` display band (`500/750/900`).
+- High exposure count caps are too low (`60` for software, `60` for device), so 49 high findings barely move a score.
+- `AffectedDeviceCount` is not part of `SoftwareRiskScore.OverallScore`.
+- Emergency patch recommendations and threat-intel flags are not part of the displayed risk score.
+- Dashboard overall risk is derived from the same under-scaled device scores, so it also appears low.
+
+Qualys model references:
+
+- TruRisk combines asset criticality, detection/vulnerability risk scores, severity weighting, count weighting, and external exposure into a capped `0-1000` score.
+- QDS/QVS are `1-100` likelihood-style scores based on CVSS plus threat intelligence such as EPSS, CISA KEV, exploit maturity, malware/ransomware, active exploitation, and trending indicators.
+- Newer TruRisk uses a max detection score and count bonuses, with external assets weighted higher.
+
+---
+
+## Target Model
+
+Use one internal detection score per open exposure:
+
+```csharp
+DetectionScore = max(
+    EnvironmentalCvss * 10,
+    ThreatAssessment.ThreatScore,
+    urgencyFloor,
+    threatIntelFloor)
+```
+
+Floors:
+
+```csharp
+Emergency patch recommended: 95
+Known exploited, active alert, ransomware, malware: 95
+Public exploit: 80
+EPSS >= 0.50: 80
+Vendor severity Critical with no threat record: 90
+Vendor severity High with no threat record: 70
+```
+
+Asset criticality multiplier:
+
+```csharp
+Critical = 1.35m
+High = 1.20m
+Medium = 1.00m
+Low = 0.85m
+```
+
+Business label multiplier remains as today:
+
+```csharp
+Critical label = 2.0m
+Sensitive label = 1.5m
+Normal label = 1.0m
+Informational label = 0.5m
+```
+
+Risk bands should be centralized:
+
+```csharp
+Critical >= 850
+High     >= 700
+Medium   >= 500
+Low      >  0
+None     == 0
+```
+
+This aligns with Qualys-style bands and avoids today’s mismatch where `124` appears Low despite critical/high findings.
+
+---
+
+## Files
+
+- Create: `src/PatchHound.Core/Services/RiskScoring/RiskBand.cs`
+- Create: `src/PatchHound.Core/Services/RiskScoring/RiskScoringModels.cs`
+- Create: `src/PatchHound.Core/Services/RiskScoring/PatchHoundRiskScoringEngine.cs`
+- Modify: `src/PatchHound.Infrastructure/Services/RiskScoreService.cs`
+- Modify: `src/PatchHound.Api/Services/ApprovalTaskQueryService.cs`
+- Modify: `src/PatchHound.Api/Services/RemediationDecisionQueryService.cs`
+- Modify: `src/PatchHound.Api/Services/DeviceDetailQueryService.cs`
+- Modify: `src/PatchHound.Api/Controllers/DashboardController.cs`
+- Modify: frontend risk-band helpers only if text/colors assume old `900/750/500` thresholds.
+- Test: `tests/PatchHound.Tests/Core/RiskScoring/PatchHoundRiskScoringEngineTests.cs`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTruRiskCalibrationTests.cs`
+- Update existing tests that assert exact old scores.
+
+---
+
+### Task 1: Add Central Risk Bands
+
+**Files:**
+- Create: `src/PatchHound.Core/Services/RiskScoring/RiskBand.cs`
+- Test: `tests/PatchHound.Tests/Core/RiskScoring/PatchHoundRiskScoringEngineTests.cs`
+
+- [ ] **Step 1: Write failing band tests**
+
+```csharp
+[Theory]
+[InlineData(0, "None")]
+[InlineData(1, "Low")]
+[InlineData(499.99, "Low")]
+[InlineData(500, "Medium")]
+[InlineData(700, "High")]
+[InlineData(850, "Critical")]
+public void RiskBand_FromScore_UsesUnifiedTruRiskInspiredThresholds(decimal score, string expected)
+{
+    RiskBand.FromScore(score).Should().Be(expected);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests\PatchHound.Tests\PatchHound.Tests.csproj --filter "FullyQualifiedName~PatchHoundRiskScoringEngineTests" -v minimal`
+
+Expected: fails because `RiskBand` does not exist.
+
+- [ ] **Step 3: Implement `RiskBand`**
+
+```csharp
+namespace PatchHound.Core.Services.RiskScoring;
+
+public static class RiskBand
+{
+    public const decimal MediumThreshold = 500m;
+    public const decimal HighThreshold = 700m;
+    public const decimal CriticalThreshold = 850m;
+
+    public static string FromScore(decimal score) => score switch
+    {
+        >= CriticalThreshold => "Critical",
+        >= HighThreshold => "High",
+        >= MediumThreshold => "Medium",
+        > 0m => "Low",
+        _ => "None",
+    };
+}
+```
+
+- [ ] **Step 4: Run the band tests**
+
+Expected: pass.
+
+---
+
+### Task 2: Add Pure Detection And Score Model
+
+**Files:**
+- Create: `src/PatchHound.Core/Services/RiskScoring/RiskScoringModels.cs`
+- Create: `src/PatchHound.Core/Services/RiskScoring/PatchHoundRiskScoringEngine.cs`
+- Test: `tests/PatchHound.Tests/Core/RiskScoring/PatchHoundRiskScoringEngineTests.cs`
+
+- [ ] **Step 1: Add failing tests for emergency and high-volume cases**
+
+```csharp
+[Fact]
+public void CalculateSoftwareRisk_EmergencyCriticalAndManyHighs_IsAtLeastHigh()
+{
+    var inputs = new List<RiskExposureInput>
+    {
+        RiskExposureInput.Critical(Guid.NewGuid(), Guid.NewGuid(), 9.8m, isEmergency: true),
+    };
+    inputs.AddRange(Enumerable.Range(0, 49)
+        .Select(_ => RiskExposureInput.High(Guid.NewGuid(), Guid.NewGuid(), 7.5m)));
+
+    var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(inputs, affectedDeviceCount: 1, highValueDeviceCount: 0);
+
+    result.OverallScore.Should().BeGreaterThanOrEqualTo(700m);
+    result.RiskBand.Should().Be("High");
+}
+
+[Fact]
+public void CalculateAssetRisk_SingleCriticalOnHighCriticalityAsset_IsAtLeastMedium()
+{
+    var input = RiskExposureInput.Critical(Guid.NewGuid(), Guid.NewGuid(), 9.5m, assetCriticality: Criticality.High);
+
+    var result = PatchHoundRiskScoringEngine.CalculateAssetRisk([input], businessLabelWeight: 1m);
+
+    result.OverallScore.Should().BeGreaterThanOrEqualTo(500m);
+}
+```
+
+- [ ] **Step 2: Implement model records**
+
+```csharp
+namespace PatchHound.Core.Services.RiskScoring;
+
+public sealed record RiskExposureInput(
+    Guid DeviceId,
+    Guid VulnerabilityId,
+    decimal EnvironmentalCvss,
+    Severity VendorSeverity,
+    Criticality AssetCriticality,
+    decimal? ThreatScore,
+    decimal? EpssScore,
+    bool KnownExploited,
+    bool PublicExploit,
+    bool ActiveAlert,
+    bool HasRansomwareAssociation,
+    bool HasMalwareAssociation,
+    bool IsEmergencyPatchRecommended
+);
+
+public sealed record RiskScoreResult(
+    decimal OverallScore,
+    decimal MaxDetectionScore,
+    int CriticalCount,
+    int HighCount,
+    int MediumCount,
+    int LowCount,
+    string RiskBand,
+    string FactorsJson
+);
+```
+
+- [ ] **Step 3: Implement scoring engine**
+
+Use:
+
+```csharp
+baseComponent = maxDetectionScore * 6.5m * severityGate;
+countComponent = criticalCount * 45m + highCount * 12m + mediumCount * 3m + lowCount * 1m;
+breadthComponent = affectedDeviceCount <= 1 ? 0m : Math.Min((decimal)Math.Log10(affectedDeviceCount) * 80m, 180m);
+highValueComponent = highValueDeviceCount * 25m;
+score = Math.Clamp(Math.Round((baseComponent + countComponent + breadthComponent + highValueComponent) * impactMultiplier, 2), 0m, 1000m);
+```
+
+Apply floors after the numeric score:
+
+```csharp
+if (inputs.Any(i => i.IsEmergencyPatchRecommended || i.KnownExploited || i.ActiveAlert || i.HasRansomwareAssociation))
+    score = Math.Max(score, 700m);
+if (inputs.Any(i => i.VendorSeverity == Severity.Critical))
+    score = Math.Max(score, 500m);
+if (inputs.Count(i => i.VendorSeverity == Severity.High) >= 10)
+    score = Math.Max(score, 500m);
+```
+
+- [ ] **Step 4: Run pure scoring tests**
+
+Expected: pass.
+
+---
+
+### Task 3: Feed Enriched Inputs From `RiskScoreService`
+
+**Files:**
+- Modify: `src/PatchHound.Infrastructure/Services/RiskScoreService.cs`
+- Test: `tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTruRiskCalibrationTests.cs`
+
+- [ ] **Step 1: Run impact check before editing**
+
+Run GitNexus: `impact({ repo: "PatchHound", target: "RiskScoreService", direction: "upstream" })`
+
+Expected: CRITICAL. Proceed because this plan explicitly covers dependent score surfaces and tests.
+
+- [ ] **Step 2: Add failing integration tests**
+
+Test cases:
+
+```csharp
+RecalculateForTenantAsync_EmergencyCriticalSoftwareCase_ScoresAtLeastHigh
+RecalculateForTenantAsync_DashboardTenantRisk_IncreasesWhenAssetScoresIncrease
+RecalculateForTenantAsync_AffectedDeviceBreadth_IncreasesSoftwareScore
+RecalculateForTenantAsync_KnownExploitedThreatAssessment_AppliesHighFloor
+```
+
+The emergency test must seed:
+
+- one software product
+- one affected device
+- one critical vulnerability with `VulnerabilityPatchAssessment.UrgencyTier = "emergency"`
+- forty-nine high vulnerabilities on the same software product/device
+
+Expected:
+
+```csharp
+score.OverallScore.Should().BeGreaterThanOrEqualTo(700m);
+RiskBand.FromScore(score.OverallScore).Should().Be("High");
+```
+
+- [ ] **Step 3: Replace private formula bodies with engine calls**
+
+In `CalculateAssetScoresAsync`, select device criticality, threat assessment fields, and patch assessment urgency into the exposure rows. Convert each open exposure into `RiskExposureInput`, call `PatchHoundRiskScoringEngine.CalculateAssetRisk`, then persist its fields.
+
+In `CalculateSoftwareScoresAsync`, include the same enriched inputs, group by software product, call `PatchHoundRiskScoringEngine.CalculateSoftwareRisk`, and persist:
+
+- `OverallScore = result.OverallScore`
+- `MaxExposureScore = result.MaxDetectionScore`
+- count fields from result
+- `FactorsJson = result.FactorsJson`
+
+Set:
+
+```csharp
+public const string CalculationVersion = "2-trurisk-inspired";
+```
+
+- [ ] **Step 4: Keep remediation adjustment behavior**
+
+For approved patching inside a valid maintenance window, reduce `DetectionScore` by `RemediationAdjustmentFactor`, not just raw CVSS. Do not reduce risk acceptance. Continue excluding approved alternate mitigations.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```powershell
+dotnet test tests\PatchHound.Tests\PatchHound.Tests.csproj --filter "FullyQualifiedName~RiskScoreServiceTruRiskCalibrationTests|FullyQualifiedName~RiskScoreServiceCanonicalTests|FullyQualifiedName~RiskScoreRemediationTests|FullyQualifiedName~BusinessLabelRiskWeightTests" -v minimal
+```
+
+Expected: pass.
+
+---
+
+### Task 4: Centralize API Risk Band Resolution
+
+**Files:**
+- Modify: `src/PatchHound.Api/Services/ApprovalTaskQueryService.cs`
+- Modify: `src/PatchHound.Api/Services/RemediationDecisionQueryService.cs`
+- Modify: `src/PatchHound.Api/Services/DeviceDetailQueryService.cs`
+- Modify: `src/PatchHound.Api/Controllers/DashboardController.cs`
+- Test: relevant API tests already asserting risk bands.
+
+- [ ] **Step 1: Replace duplicated thresholds**
+
+Replace local `ResolveRiskBand` or switch expressions using `900/750/500` with:
+
+```csharp
+RiskBand.FromScore(score)
+```
+
+For dashboard executive wording, map `Medium` to existing UI term only if product wants to preserve `"Elevated"`:
+
+```csharp
+private static string DescribeRiskLevel(decimal score) =>
+    RiskBand.FromScore(score) == "Medium" ? "Elevated" : RiskBand.FromScore(score);
+```
+
+- [ ] **Step 2: Run API tests**
+
+Run:
+
+```powershell
+dotnet test tests\PatchHound.Tests\PatchHound.Tests.csproj --filter "FullyQualifiedName~DashboardControllerExecutiveSummaryTests|FullyQualifiedName~DevicesControllerTests|FullyQualifiedName~RemediationDecisionListTests|FullyQualifiedName~TeamsControllerTests" -v minimal
+```
+
+Expected: pass after updating exact-score assertions to band/relative assertions where needed.
+
+---
+
+### Task 5: Update Frontend Threshold Helpers
+
+**Files:**
+- Modify frontend components found by `rg -n "score >= 900|score >= 750|score >= 500" frontend/src`
+
+- [ ] **Step 1: Replace hardcoded thresholds with shared helper**
+
+Create or update a frontend helper:
+
+```ts
+export function riskBand(score: number | null | undefined) {
+  if (!score || score <= 0) return 'none'
+  if (score >= 850) return 'critical'
+  if (score >= 700) return 'high'
+  if (score >= 500) return 'medium'
+  return 'low'
+}
+```
+
+- [ ] **Step 2: Update affected components**
+
+Replace local threshold logic in dashboard, devices, and software components with the helper.
+
+- [ ] **Step 3: Run frontend checks**
+
+Run:
+
+```powershell
+cd frontend
+npm run lint
+npm run typecheck
+npm test
+```
+
+Expected: pass.
+
+---
+
+### Task 6: Verification And Migration Notes
+
+**Files:**
+- Modify: `docs/testing-conventions.md` only if adding scoring-test guidance is desired.
+
+- [ ] **Step 1: Run backend focused suite**
+
+Run:
+
+```powershell
+dotnet test tests\PatchHound.Tests\PatchHound.Tests.csproj --filter "FullyQualifiedName~RiskScoreService|FullyQualifiedName~RiskScoreController|FullyQualifiedName~DashboardController|FullyQualifiedName~RemediationDecision|FullyQualifiedName~ApprovalTask" -v minimal
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run build**
+
+Run:
+
+```powershell
+dotnet build PatchHound.slnx
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run GitNexus change detection before commit**
+
+Run:
+
+```text
+detect_changes({ repo: "PatchHound", scope: "all" })
+```
+
+Expected: affected symbols are limited to scoring engine, `RiskScoreService`, risk-band consumers, and tests.
+
+- [ ] **Step 4: Operational recalculation**
+
+After deploy, run tenant risk recalculation for existing tenants because persisted `DeviceRiskScores`, `SoftwareRiskScores`, `DeviceGroupRiskScores`, `TeamRiskScores`, and `TenantRiskScoreSnapshots` contain old-version values. Historical snapshots should either keep their old values with `CalculationVersion = "1"` context, or be backfilled if product wants trend continuity.
+
+---
+
+## Acceptance Criteria
+
+- A remediation case with 1 critical emergency vulnerability and 49 high vulnerabilities no longer appears as Low.
+- Dashboard overall risk increases proportionally when high-risk device/software scores increase.
+- One affected device can still reduce fleet-wide exposure, but it cannot hide emergency urgency.
+- Scores remain capped at `1000`.
+- Business-label weighting still works.
+- Approved patching still reduces active risk during a valid maintenance window.
+- Risk acceptance remains visibility-only and does not reduce score.
+- Alternate mitigation still removes covered vulnerabilities from active risk.
+- All score band labels use centralized thresholds.

--- a/frontend/src/components/features/dashboard/CisoExecutiveOverview.tsx
+++ b/frontend/src/components/features/dashboard/CisoExecutiveOverview.tsx
@@ -6,6 +6,7 @@ import { MetricInfoTooltip } from '@/components/features/dashboard/MetricInfoToo
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { RISK_SCORE_RANGES, riskGaugeBand as deriveRiskGaugeBand } from '@/lib/risk-scoring'
 import { cn } from '@/lib/utils'
 import type { LucideIcon } from 'lucide-react'
 
@@ -36,7 +37,7 @@ const riskGaugeBands: Array<{
   {
     band: 'contained',
     label: 'Contained',
-    range: '0-499',
+    range: RISK_SCORE_RANGES.low,
     colorClass: 'text-chart-3',
     borderClass: 'border-chart-3',
     fill: 'var(--color-chart-3)',
@@ -44,7 +45,7 @@ const riskGaugeBands: Array<{
   {
     band: 'elevated',
     label: 'Elevated',
-    range: '500-749',
+    range: RISK_SCORE_RANGES.medium,
     colorClass: 'text-chart-2',
     borderClass: 'border-chart-2',
     fill: 'var(--color-chart-2)',
@@ -52,7 +53,7 @@ const riskGaugeBands: Array<{
   {
     band: 'high',
     label: 'High',
-    range: '750-899',
+    range: RISK_SCORE_RANGES.high,
     colorClass: 'text-tone-warning-foreground',
     borderClass: 'border-tone-warning-border',
     fill: 'var(--color-tone-warning-foreground)',
@@ -60,7 +61,7 @@ const riskGaugeBands: Array<{
   {
     band: 'critical',
     label: 'Critical',
-    range: '900-1000',
+    range: RISK_SCORE_RANGES.critical,
     colorClass: 'text-destructive',
     borderClass: 'border-destructive',
     fill: 'var(--color-destructive)',
@@ -176,13 +177,6 @@ function getTrendDirection(trends: TrendData) {
   }
 }
 
-function riskGaugeBand(score: number): RiskGaugeBand {
-  if (score >= 900) return 'critical'
-  if (score >= 750) return 'high'
-  if (score >= 500) return 'elevated'
-  return 'contained'
-}
-
 function normalizeRiskLevel(level: string | undefined): RiskGaugeBand {
   const normalized = level?.toLowerCase()
   if (normalized === 'critical' || normalized === 'high' || normalized === 'elevated' || normalized === 'contained') {
@@ -193,7 +187,7 @@ function normalizeRiskLevel(level: string | undefined): RiskGaugeBand {
 }
 
 function riskGaugeBandMeta(score: number) {
-  return riskGaugeBands.find((band) => band.band === riskGaugeBand(score)) ?? riskGaugeBands[0]
+  return riskGaugeBands.find((band) => band.band === deriveRiskGaugeBand(score)) ?? riskGaugeBands[0]
 }
 
 function describeExecutiveTrend(exposure: ExecutiveExposureSummary | null | undefined) {

--- a/frontend/src/components/features/dashboard/DeviceGroupRiskDetailDialog.tsx
+++ b/frontend/src/components/features/dashboard/DeviceGroupRiskDetailDialog.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { fetchDeviceGroupRiskDetail } from '@/api/risk-score.functions'
 import type { DeviceGroupRiskDetail, RiskAssetScoreSummary } from '@/api/risk-score.schemas'
 import { Link } from '@tanstack/react-router'
+import { riskScoreBadgeClass } from '@/lib/risk-scoring'
 
 type DeviceGroupRiskDetailDialogProps = {
   deviceGroupName: string | null
@@ -214,23 +215,7 @@ function RiskMetric({
 }
 
 function riskBand(score: number) {
-  if (score >= 900) {
-    return {
-      badgeClass: 'border-destructive/25 bg-destructive/10 text-destructive',
-    }
-  }
-  if (score >= 750) {
-    return {
-      badgeClass:
-        'border-tone-warning-border bg-tone-warning text-tone-warning-foreground',
-    }
-  }
-  if (score >= 500) {
-    return {
-      badgeClass: 'border-chart-2/25 bg-chart-2/10 text-chart-2',
-    }
-  }
   return {
-    badgeClass: 'border-border/70 bg-background/40 text-muted-foreground',
+    badgeClass: riskScoreBadgeClass(score),
   }
 }

--- a/frontend/src/components/features/dashboard/RiskScoreCard.tsx
+++ b/frontend/src/components/features/dashboard/RiskScoreCard.tsx
@@ -8,6 +8,7 @@ import { Sparkline } from '@/components/features/dashboard/Sparkline'
 import { fetchRiskScoreSummary, recalculateRiskScores } from '@/api/risk-score.functions'
 import type { RiskScoreSummary } from '@/api/risk-score.schemas'
 import { useTenantScope } from '@/components/layout/tenant-scope'
+import { riskScoreBand } from '@/lib/risk-scoring'
 import { MetricInfoTooltip } from './MetricInfoTooltip'
 import { RiskScoreDetailDialog } from './RiskScoreDetailDialog'
 
@@ -344,7 +345,9 @@ function formatUtcTimestamp(value: string) {
 }
 
 function riskPosture(score: number) {
-  if (score >= 900) {
+  const band = riskScoreBand(score)
+
+  if (band === 'critical') {
     return {
       label: 'Critical pressure',
       verdict: 'Needs immediate attention',
@@ -359,7 +362,7 @@ function riskPosture(score: number) {
       sparkColor: 'var(--color-destructive)',
     }
   }
-  if (score >= 750) {
+  if (band === 'high') {
     return {
       label: 'High pressure',
       verdict: 'Serious exposure needs attention',
@@ -374,7 +377,7 @@ function riskPosture(score: number) {
       sparkColor: 'var(--color-tone-warning-foreground)',
     }
   }
-  if (score >= 500) {
+  if (band === 'medium') {
     return {
       label: 'Elevated',
       verdict: 'Watch closely and reduce pressure',

--- a/frontend/src/components/features/dashboard/RiskScoreDetailDialog.tsx
+++ b/frontend/src/components/features/dashboard/RiskScoreDetailDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { InsetPanel } from '@/components/ui/inset-panel'
 import type { RiskAssetEpisodeDriver, RiskAssetScoreSummary, RiskScoreSummary } from '@/api/risk-score.schemas'
+import { riskScoreBadgeClass } from '@/lib/risk-scoring'
 
 type RiskScoreDetailDialogProps = {
   open: boolean
@@ -178,23 +179,7 @@ function DriverFactor({ label, value }: { label: string; value: number }) {
 }
 
 function riskBand(score: number) {
-  if (score >= 900) {
-    return {
-      badgeClass: 'border-destructive/25 bg-destructive/10 text-destructive',
-    }
-  }
-  if (score >= 750) {
-    return {
-      badgeClass:
-        'border-tone-warning-border bg-tone-warning text-tone-warning-foreground',
-    }
-  }
-  if (score >= 500) {
-    return {
-      badgeClass: 'border-chart-2/25 bg-chart-2/10 text-chart-2',
-    }
-  }
   return {
-    badgeClass: 'border-border/70 bg-background/40 text-muted-foreground',
+    badgeClass: riskScoreBadgeClass(score),
   }
 }

--- a/frontend/src/components/features/devices/DeviceDetailPane.tsx
+++ b/frontend/src/components/features/devices/DeviceDetailPane.tsx
@@ -17,6 +17,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { InsetPanel } from '@/components/ui/inset-panel'
+import { riskDetectionScoreTone, riskScoreTone } from '@/lib/risk-scoring'
 
 // Phase 1 canonical cleanup (Task 15): device-native detail pane.
 // Vulnerability list, software inventory and software CPE binding
@@ -38,20 +39,24 @@ function MetricCard({
 }: {
   label: string
   value: string | number
-  tone?: 'default' | 'danger' | 'warning' | 'success'
+  tone?: 'default' | 'danger' | 'warning' | 'info' | 'success' | 'neutral'
 }) {
   const toneClasses = {
     default: 'border-border/70 bg-background',
     danger: 'border-tone-danger-border bg-tone-danger',
     warning: 'border-tone-warning-border bg-tone-warning',
+    info: 'border-tone-info-border bg-tone-info',
     success: 'border-tone-success-border bg-tone-success',
+    neutral: 'border-border/70 bg-background',
   }
 
   const valueToneClasses = {
     default: 'text-foreground',
     danger: 'text-tone-danger-foreground',
     warning: 'text-tone-warning-foreground',
+    info: 'text-tone-info-foreground',
     success: 'text-tone-success-foreground',
+    neutral: 'text-foreground',
   }
 
   return (
@@ -187,12 +192,12 @@ export function DeviceDetailPane({
                     <MetricCard
                       label="Device risk"
                       value={device.risk.overallScore.toFixed(0)}
-                      tone={device.risk.riskBand === 'Critical' ? 'danger' : device.risk.riskBand === 'High' ? 'warning' : 'default'}
+                      tone={riskScoreTone(device.risk.overallScore)}
                     />
                     <MetricCard
                       label="Max episode"
                       value={device.risk.maxEpisodeRiskScore.toFixed(0)}
-                      tone={device.risk.maxEpisodeRiskScore >= 900 ? 'danger' : device.risk.maxEpisodeRiskScore >= 750 ? 'warning' : 'default'}
+                      tone={riskDetectionScoreTone(device.risk.maxEpisodeRiskScore, device.risk.overallScore)}
                     />
                     <MetricCard
                       label="Open episodes"

--- a/frontend/src/components/features/devices/DeviceDetailPane.tsx
+++ b/frontend/src/components/features/devices/DeviceDetailPane.tsx
@@ -17,7 +17,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { InsetPanel } from '@/components/ui/inset-panel'
-import { riskDetectionScoreTone, riskScoreTone } from '@/lib/risk-scoring'
+import { riskScoreTone } from '@/lib/risk-scoring'
 
 // Phase 1 canonical cleanup (Task 15): device-native detail pane.
 // Vulnerability list, software inventory and software CPE binding
@@ -197,7 +197,7 @@ export function DeviceDetailPane({
                     <MetricCard
                       label="Max episode"
                       value={device.risk.maxEpisodeRiskScore.toFixed(0)}
-                      tone={riskDetectionScoreTone(device.risk.maxEpisodeRiskScore, device.risk.overallScore)}
+                      tone={riskScoreTone(device.risk.maxEpisodeRiskScore)}
                     />
                     <MetricCard
                       label="Open episodes"

--- a/frontend/src/components/features/devices/DeviceManagementTable.tsx
+++ b/frontend/src/components/features/devices/DeviceManagementTable.tsx
@@ -26,6 +26,7 @@ import { Button } from '@/components/ui/button'
 import { Link } from '@tanstack/react-router'
 import { ExternalLinkIcon, SearchIcon } from "lucide-react";
 import { WorkbenchFilterDrawer, WorkbenchFilterSection } from '@/components/ui/workbench-filter-drawer'
+import { riskScoreTone } from '@/lib/risk-scoring'
 import { toneBadge } from '@/lib/tone-classes'
 
 // Phase 1 canonical cleanup (Task 15): device-native management table.
@@ -470,14 +471,7 @@ export function DeviceManagementTable({
           const score = row.original.currentRiskScore;
           if (score == null)
             return <span className="text-muted-foreground">—</span>;
-          const tone =
-            score >= 900
-              ? "danger"
-              : score >= 750
-                ? "warning"
-                : score >= 500
-                  ? "info"
-                  : "success";
+          const tone = riskScoreTone(score);
           return (
             <span className={`font-medium tabular-nums ${toneBadge(tone)}`}>
               {score.toFixed(0)}

--- a/frontend/src/components/features/software/SoftwareRiskDetailDialog.tsx
+++ b/frontend/src/components/features/software/SoftwareRiskDetailDialog.tsx
@@ -13,6 +13,7 @@ import { InsetPanel } from '@/components/ui/inset-panel'
 import { Skeleton } from '@/components/ui/skeleton'
 import { fetchSoftwareRiskDetail } from '@/api/risk-score.functions'
 import type { RiskAssetScoreSummary } from '@/api/risk-score.schemas'
+import { riskScoreBadgeClass } from '@/lib/risk-scoring'
 
 type SoftwareRiskDetailDialogProps = {
   softwareProductId: string | null
@@ -139,14 +140,5 @@ function RiskMetric({
 }
 
 function riskBand(score: number) {
-  if (score >= 900) {
-    return { badgeClass: 'border-destructive/25 bg-destructive/10 text-destructive' }
-  }
-  if (score >= 750) {
-    return { badgeClass: 'border-tone-warning-border bg-tone-warning text-tone-warning-foreground' }
-  }
-  if (score >= 500) {
-    return { badgeClass: 'border-chart-2/25 bg-chart-2/10 text-chart-2' }
-  }
-  return { badgeClass: 'border-border/70 bg-background/40 text-muted-foreground' }
+  return { badgeClass: riskScoreBadgeClass(score) }
 }

--- a/frontend/src/components/features/software/SoftwareTable.tsx
+++ b/frontend/src/components/features/software/SoftwareTable.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/select'
 import { WorkbenchFilterDrawer, WorkbenchFilterSection } from '@/components/ui/workbench-filter-drawer'
 import { formatDate, startCase } from '@/lib/formatting'
+import { riskScoreTone } from '@/lib/risk-scoring'
 import { toneText } from '@/lib/tone-classes'
 import { SearchIcon } from 'lucide-react'
 
@@ -192,7 +193,7 @@ export function SoftwareTable({
           const score = row.original.currentRiskScore
           const softwareProductId = row.original.softwareProductId
           if (score == null) return <span className="text-muted-foreground">—</span>
-          const tone = score >= 900 ? 'danger' : score >= 750 ? 'warning' : score >= 500 ? 'info' : 'success'
+          const tone = riskScoreTone(score)
           if (!softwareProductId) {
             return <span className={`font-medium tabular-nums ${toneText(tone)}`}>{score.toFixed(0)}</span>
           }

--- a/frontend/src/components/features/vulnerabilities/VulnerabilityDetail.test.tsx
+++ b/frontend/src/components/features/vulnerabilities/VulnerabilityDetail.test.tsx
@@ -90,23 +90,24 @@ const vulnerabilityFixture: VulnerabilityDetailModel = {
 }
 
 describe('VulnerabilityDetail tabs', () => {
-  it('uses shared tab semantics and lazily mounts tab content', () => {
+  it('uses shared tab semantics for secondary content', () => {
     render(<VulnerabilityDetail vulnerability={vulnerabilityFixture} />)
 
     expect(screen.getByRole('tab', { name: /Exposure/i })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: /Patch Assessment/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /References/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Audit Timeline/i })).toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: /Patch Assessment/i })).not.toBeInTheDocument()
     expect(screen.getByText('Exposure timeline')).toBeInTheDocument()
-    expect(screen.queryByText('Patch Priority Assessment')).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('tab', { name: /Patch Assessment/i }))
-
     expect(screen.getByText('Patch Priority Assessment')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /References/i }))
+
+    expect(screen.getByText('References 1')).toBeInTheDocument()
   })
 
   it('requests a patch assessment for the displayed CVE', () => {
     render(<VulnerabilityDetail vulnerability={vulnerabilityFixture} />)
 
-    fireEvent.click(screen.getByRole('tab', { name: /Patch Assessment/i }))
     fireEvent.click(screen.getByRole('button', { name: /Request assessment/i }))
 
     expect(requestVulnerabilityAssessment).toHaveBeenCalledWith({

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -34,13 +34,21 @@ const sidebarStorageKey = "patchhound:sidebar-collapsed";
 
 function getInitialSidebarCollapsed(): boolean {
   if (typeof window === "undefined") return false;
-  return window.sessionStorage.getItem(sidebarStorageKey) === "true";
+  try {
+    return window.sessionStorage.getItem(sidebarStorageKey) === "true";
+  } catch {
+    return false;
+  }
 }
 
 function isGlassTheme(): boolean {
   if (typeof window === "undefined") return false;
-  const stored = window.localStorage.getItem(themeStorageKey) ?? "";
-  return stored.startsWith("liquid-glass");
+  try {
+    const stored = window.localStorage.getItem(themeStorageKey) ?? "";
+    return stored.startsWith("liquid-glass");
+  } catch {
+    return false;
+  }
 }
 
 type AppShellProps = {

--- a/frontend/src/lib/risk-scoring.test.ts
+++ b/frontend/src/lib/risk-scoring.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RISK_SCORE_RANGES,
+  riskDetectionScoreTone,
+  riskGaugeBand,
+  riskScoreBand,
+  riskScoreTone,
+} from './risk-scoring'
+
+describe('risk scoring helpers', () => {
+  it('maps v2 score bands at the documented thresholds', () => {
+    expect(riskScoreBand(499)).toBe('low')
+    expect(riskScoreBand(500)).toBe('medium')
+    expect(riskScoreBand(699)).toBe('medium')
+    expect(riskScoreBand(700)).toBe('high')
+    expect(riskScoreBand(849)).toBe('high')
+    expect(riskScoreBand(850)).toBe('critical')
+  })
+
+  it('exposes UI gauge bands and visible ranges for v2 thresholds', () => {
+    expect(riskGaugeBand(500)).toBe('elevated')
+    expect(riskGaugeBand(700)).toBe('high')
+    expect(riskGaugeBand(850)).toBe('critical')
+    expect(RISK_SCORE_RANGES.high).toBe('700-849')
+    expect(RISK_SCORE_RANGES.critical).toBe('850-1000')
+  })
+
+  it('prefers overall v2 risk when toning detection scores', () => {
+    expect(riskDetectionScoreTone(99, 510)).toBe('info')
+    expect(riskDetectionScoreTone(95)).toBe('danger')
+    expect(riskDetectionScoreTone(80)).toBe('warning')
+    expect(riskScoreTone(850)).toBe('danger')
+  })
+})

--- a/frontend/src/lib/risk-scoring.ts
+++ b/frontend/src/lib/risk-scoring.ts
@@ -1,0 +1,57 @@
+import type { Tone } from '@/lib/tone-classes'
+
+export type RiskScoreBand = 'low' | 'medium' | 'high' | 'critical'
+export type RiskGaugeBand = 'contained' | 'elevated' | 'high' | 'critical'
+
+export const RISK_SCORE_THRESHOLDS = {
+  medium: 500,
+  high: 700,
+  critical: 850,
+} as const
+
+export const RISK_SCORE_RANGES = {
+  low: '0-499',
+  medium: '500-699',
+  high: '700-849',
+  critical: '850-1000',
+} as const
+
+export function riskScoreBand(score: number): RiskScoreBand {
+  if (score >= RISK_SCORE_THRESHOLDS.critical) return 'critical'
+  if (score >= RISK_SCORE_THRESHOLDS.high) return 'high'
+  if (score >= RISK_SCORE_THRESHOLDS.medium) return 'medium'
+  return 'low'
+}
+
+export function riskGaugeBand(score: number): RiskGaugeBand {
+  const band = riskScoreBand(score)
+  if (band === 'low') return 'contained'
+  if (band === 'medium') return 'elevated'
+  return band
+}
+
+export function riskScoreTone(score: number): Tone {
+  const band = riskScoreBand(score)
+  if (band === 'critical') return 'danger'
+  if (band === 'high') return 'warning'
+  if (band === 'medium') return 'info'
+  return 'success'
+}
+
+export function riskScoreBadgeClass(score: number): string {
+  const band = riskScoreBand(score)
+  if (band === 'critical') return 'border-destructive/25 bg-destructive/10 text-destructive'
+  if (band === 'high') return 'border-tone-warning-border bg-tone-warning text-tone-warning-foreground'
+  if (band === 'medium') return 'border-chart-2/25 bg-chart-2/10 text-chart-2'
+  return 'border-border/70 bg-background/40 text-muted-foreground'
+}
+
+export function riskDetectionScoreTone(detectionScore: number, overallRiskScore?: number | null): Tone {
+  if (typeof overallRiskScore === 'number') {
+    return riskScoreTone(overallRiskScore)
+  }
+
+  if (detectionScore >= 95) return 'danger'
+  if (detectionScore >= 80) return 'warning'
+  return 'neutral'
+}

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -8,6 +8,7 @@ using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Core.Services;
+using PatchHound.Core.Services.RiskScoring;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
 
@@ -1882,14 +1883,17 @@ public class DashboardController : ControllerBase
             .FirstOrDefault();
     }
 
-    private static string DescribeRiskLevel(decimal score) =>
-        score switch
+    private static string DescribeRiskLevel(decimal score)
+    {
+        var riskBand = RiskBand.FromScore(score);
+
+        return riskBand switch
         {
-            >= 900m => "Critical",
-            >= 750m => "High",
-            >= 500m => "Elevated",
-            _ => "Contained",
+            "Medium" => "Elevated",
+            "Low" or "None" => "Contained",
+            _ => riskBand,
         };
+    }
 
     private static string DescribeScoreTrend(decimal? delta)
     {

--- a/src/PatchHound.Api/Services/ApprovalTaskQueryService.cs
+++ b/src/PatchHound.Api/Services/ApprovalTaskQueryService.cs
@@ -4,6 +4,7 @@ using PatchHound.Api.Models.ApprovalTasks;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Services;
+using PatchHound.Core.Services.RiskScoring;
 using PatchHound.Infrastructure.Data;
 
 namespace PatchHound.Api.Services;
@@ -172,7 +173,7 @@ public class ApprovalTaskQueryService(
             if (softwareScore is not null)
             {
                 riskScore = (double)softwareScore.OverallScore;
-                riskBand = ResolveRiskBand(softwareScore.OverallScore);
+                riskBand = RiskBand.FromScore(softwareScore.OverallScore);
             }
         }
 
@@ -508,9 +509,6 @@ public class ApprovalTaskQueryService(
         }
         return result;
     }
-
-    private static string ResolveRiskBand(decimal score) =>
-        score >= 900m ? "Critical" : score >= 750m ? "High" : score >= 500m ? "Medium" : "Low";
 
     private static string NormalizeVersionKey(string? version)        => string.IsNullOrWhiteSpace(version) ? string.Empty : version.Trim();
 

--- a/src/PatchHound.Api/Services/DeviceDetailQueryService.cs
+++ b/src/PatchHound.Api/Services/DeviceDetailQueryService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Models.Assets;
 using PatchHound.Api.Models.Devices;
 using PatchHound.Core.Entities;
+using PatchHound.Core.Services.RiskScoring;
 using PatchHound.Infrastructure.Data;
 
 namespace PatchHound.Api.Services;
@@ -132,7 +133,7 @@ public class DeviceDetailQueryService
             : new DeviceRiskDetailDto(
                 deviceRiskScore.OverallScore,
                 deviceRiskScore.MaxEpisodeRiskScore,
-                ResolveRiskBand(deviceRiskScore.OverallScore),
+                RiskBand.FromScore(deviceRiskScore.OverallScore),
                 deviceRiskScore.OpenEpisodeCount,
                 deviceRiskScore.CriticalCount,
                 deviceRiskScore.HighCount,
@@ -195,14 +196,4 @@ public class DeviceDetailQueryService
         );
     }
 
-    private static string ResolveRiskBand(decimal score)
-    {
-        if (score >= 900m)
-            return "Critical";
-        if (score >= 750m)
-            return "High";
-        if (score >= 500m)
-            return "Medium";
-        return "Low";
-    }
 }

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -7,6 +7,7 @@ using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Core.Models;
 using PatchHound.Core.Services;
+using PatchHound.Core.Services.RiskScoring;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
 
@@ -313,14 +314,7 @@ public class RemediationDecisionQueryService(
             if (riskScoresByCaseId.TryGetValue(rc.Id, out var risk))
             {
                 riskScore = (double)risk.OverallScore;
-                riskBand = risk.OverallScore switch
-                {
-                    >= 900m => "Critical",
-                    >= 750m => "High",
-                    >= 500m => "Medium",
-                    > 0m => "Low",
-                    _ => "None",
-                };
+                riskBand = RiskBand.FromScore(risk.OverallScore);
             }
 
             string? slaStatus = null;

--- a/src/PatchHound.Core/Services/RiskScoring/PatchHoundRiskScoringEngine.cs
+++ b/src/PatchHound.Core/Services/RiskScoring/PatchHoundRiskScoringEngine.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Services.RiskScoring;
+
+public static class PatchHoundRiskScoringEngine
+{
+    public static RiskScoreResult CalculateSoftwareRisk(
+        IReadOnlyCollection<RiskExposureInput> exposures,
+        int affectedDeviceCount,
+        int highValueDeviceCount)
+    {
+        var metrics = CalculateExposureMetrics(exposures);
+        if (metrics.ExposureCount == 0)
+        {
+            return BuildResult(0m, metrics, CreateFactors(("BaseComponent", "No exposure detections.", 0m)));
+        }
+
+        var baseComponent = metrics.MaxDetectionScore * 6.5m;
+        var countComponent = CalculateCountComponent(metrics);
+        var breadthComponent = affectedDeviceCount <= 1
+            ? 0m
+            : Math.Min((decimal)Math.Log10(affectedDeviceCount) * 80m, 180m);
+        var highValueComponent = Math.Max(highValueDeviceCount, 0) * 25m;
+
+        var numericScore = baseComponent
+            + countComponent
+            + breadthComponent
+            + highValueComponent;
+        var score = ApplyFloors(numericScore, metrics);
+
+        var factorsJson = CreateFactors(
+            ("BaseComponent", "Highest detection score scaled to the PatchHound 0-1000 score range.", baseComponent),
+            ("CountComponent", "Severity count pressure from critical, high, medium, and low detections.", countComponent),
+            ("BreadthComponent", "Logarithmic affected-device breadth contribution.", breadthComponent),
+            ("HighValueDeviceComponent", "Additional contribution from high-value affected devices.", highValueComponent),
+            ("FloorAdjustedScore", "Score after mandatory threat and severity floors.", score));
+
+        return BuildResult(score, metrics, factorsJson);
+    }
+
+    public static RiskScoreResult CalculateAssetRisk(
+        IReadOnlyCollection<RiskExposureInput> exposures,
+        decimal businessLabelWeight)
+    {
+        var metrics = CalculateExposureMetrics(exposures);
+        if (metrics.ExposureCount == 0)
+        {
+            return BuildResult(0m, metrics, CreateFactors(("BaseComponent", "No exposure detections.", 0m)));
+        }
+
+        var baseComponent = metrics.MaxDetectionScore * 6.5m;
+        var countComponent = CalculateCountComponent(metrics);
+        var criticalityMultiplier = exposures.Max(exposure => GetAssetCriticalityMultiplier(exposure.AssetCriticality));
+        var businessMultiplier = Math.Max(businessLabelWeight, 0m);
+        var impactMultiplier = criticalityMultiplier * businessMultiplier;
+        var numericScore = (baseComponent + countComponent) * impactMultiplier;
+        var score = ApplyFloors(numericScore, metrics);
+
+        var factorsJson = CreateFactors(
+            ("BaseComponent", "Highest detection score scaled to the PatchHound 0-1000 score range.", baseComponent),
+            ("CountComponent", "Severity count pressure from critical, high, medium, and low detections.", countComponent),
+            ("AssetCriticalityMultiplier", "Asset criticality impact multiplier.", criticalityMultiplier),
+            ("BusinessLabelWeight", "Business-label impact multiplier.", businessMultiplier),
+            ("FloorAdjustedScore", "Score after mandatory threat and severity floors.", score));
+
+        return BuildResult(score, metrics, factorsJson);
+    }
+
+    private static ExposureMetrics CalculateExposureMetrics(IReadOnlyCollection<RiskExposureInput> exposures)
+    {
+        var maxDetectionScore = 0m;
+        var criticalCount = 0;
+        var highCount = 0;
+        var mediumCount = 0;
+        var lowCount = 0;
+        var hasUrgentThreat = false;
+
+        foreach (var exposure in exposures)
+        {
+            maxDetectionScore = Math.Max(maxDetectionScore, CalculateDetectionScore(exposure));
+            hasUrgentThreat |= IsUrgentThreat(exposure);
+
+            switch (exposure.VendorSeverity)
+            {
+                case Severity.Critical:
+                    criticalCount++;
+                    break;
+                case Severity.High:
+                    highCount++;
+                    break;
+                case Severity.Medium:
+                    mediumCount++;
+                    break;
+                case Severity.Low:
+                    lowCount++;
+                    break;
+            }
+        }
+
+        return new ExposureMetrics(
+            exposures.Count,
+            maxDetectionScore,
+            criticalCount,
+            highCount,
+            mediumCount,
+            lowCount,
+            hasUrgentThreat);
+    }
+
+    private static decimal CalculateDetectionScore(RiskExposureInput exposure)
+    {
+        var score = Math.Max(ClampPercent(exposure.EnvironmentalCvss * 10m), SeverityFallback(exposure.VendorSeverity));
+
+        if (exposure.ThreatScore.HasValue)
+        {
+            score = Math.Max(score, ClampPercent(exposure.ThreatScore.Value));
+        }
+
+        if (IsUrgentThreat(exposure))
+        {
+            score = Math.Max(score, 95m);
+        }
+
+        if (exposure.PublicExploit || exposure.EpssScore >= 0.50m)
+        {
+            score = Math.Max(score, 80m);
+        }
+
+        return score;
+    }
+
+    private static decimal CalculateCountComponent(ExposureMetrics metrics) =>
+        metrics.CriticalCount * 45m
+        + metrics.HighCount * 12m
+        + metrics.MediumCount * 3m
+        + metrics.LowCount;
+
+    private static decimal ApplyFloors(decimal numericScore, ExposureMetrics metrics)
+    {
+        var score = numericScore;
+
+        if (metrics.HasUrgentThreat)
+        {
+            score = Math.Max(score, RiskBand.HighThreshold);
+        }
+
+        if (metrics.CriticalCount > 0)
+        {
+            score = Math.Max(score, RiskBand.MediumThreshold);
+        }
+
+        if (metrics.HighCount >= 10)
+        {
+            score = Math.Max(score, RiskBand.MediumThreshold);
+        }
+
+        return ClampScore(score);
+    }
+
+    private static bool IsUrgentThreat(RiskExposureInput exposure) =>
+        exposure.IsEmergencyPatchRecommended
+        || exposure.KnownExploited
+        || exposure.ActiveAlert
+        || exposure.HasRansomwareAssociation
+        || exposure.HasMalwareAssociation;
+
+    private static decimal SeverityFallback(Severity severity) => severity switch
+    {
+        Severity.Critical => 90m,
+        Severity.High => 70m,
+        Severity.Medium => 40m,
+        Severity.Low => 10m,
+        _ => 0m,
+    };
+
+    private static decimal GetAssetCriticalityMultiplier(Criticality criticality) => criticality switch
+    {
+        Criticality.Critical => 1.35m,
+        Criticality.High => 1.20m,
+        Criticality.Medium => 1.00m,
+        Criticality.Low => 0.85m,
+        _ => 1.00m,
+    };
+
+    private static decimal ClampPercent(decimal score) => Math.Clamp(score, 0m, 100m);
+
+    private static decimal ClampScore(decimal score) => Math.Clamp(Math.Round(score, 1), 0m, 1000m);
+
+    private static RiskScoreResult BuildResult(decimal score, ExposureMetrics metrics, string factorsJson) =>
+        new(
+            score,
+            Math.Round(metrics.MaxDetectionScore, 1),
+            metrics.CriticalCount,
+            metrics.HighCount,
+            metrics.MediumCount,
+            metrics.LowCount,
+            RiskBand.FromScore(score),
+            factorsJson);
+
+    private static string CreateFactors(params (string Name, string Description, decimal Impact)[] factors) =>
+        JsonSerializer.Serialize(
+            factors.Select(factor => new RiskContributionFactor(
+                factor.Name,
+                factor.Description,
+                Math.Round(factor.Impact, 3))));
+
+    private sealed record ExposureMetrics(
+        int ExposureCount,
+        decimal MaxDetectionScore,
+        int CriticalCount,
+        int HighCount,
+        int MediumCount,
+        int LowCount,
+        bool HasUrgentThreat);
+}

--- a/src/PatchHound.Core/Services/RiskScoring/RiskBand.cs
+++ b/src/PatchHound.Core/Services/RiskScoring/RiskBand.cs
@@ -1,0 +1,17 @@
+namespace PatchHound.Core.Services.RiskScoring;
+
+public static class RiskBand
+{
+    public const decimal MediumThreshold = 500m;
+    public const decimal HighThreshold = 700m;
+    public const decimal CriticalThreshold = 850m;
+
+    public static string FromScore(decimal score) => score switch
+    {
+        >= CriticalThreshold => "Critical",
+        >= HighThreshold => "High",
+        >= MediumThreshold => "Medium",
+        > 0m => "Low",
+        _ => "None",
+    };
+}

--- a/src/PatchHound.Core/Services/RiskScoring/RiskScoringModels.cs
+++ b/src/PatchHound.Core/Services/RiskScoring/RiskScoringModels.cs
@@ -1,0 +1,174 @@
+using PatchHound.Core.Enums;
+
+namespace PatchHound.Core.Services.RiskScoring;
+
+public sealed record RiskExposureInput(
+    Guid DeviceId,
+    Guid VulnerabilityId,
+    decimal EnvironmentalCvss,
+    Severity VendorSeverity,
+    Criticality AssetCriticality,
+    decimal? ThreatScore,
+    decimal? EpssScore,
+    bool KnownExploited,
+    bool PublicExploit,
+    bool ActiveAlert,
+    bool HasRansomwareAssociation,
+    bool HasMalwareAssociation,
+    bool IsEmergencyPatchRecommended
+)
+{
+    public static RiskExposureInput Critical(
+        Guid deviceId,
+        Guid vulnerabilityId,
+        decimal environmentalCvss,
+        Criticality assetCriticality = Criticality.Medium,
+        decimal? threatScore = null,
+        decimal? epssScore = null,
+        bool knownExploited = false,
+        bool publicExploit = false,
+        bool activeAlert = false,
+        bool hasRansomwareAssociation = false,
+        bool hasMalwareAssociation = false,
+        bool isEmergency = false) =>
+        Create(
+            deviceId,
+            vulnerabilityId,
+            environmentalCvss,
+            Severity.Critical,
+            assetCriticality,
+            threatScore,
+            epssScore,
+            knownExploited,
+            publicExploit,
+            activeAlert,
+            hasRansomwareAssociation,
+            hasMalwareAssociation,
+            isEmergency);
+
+    public static RiskExposureInput High(
+        Guid deviceId,
+        Guid vulnerabilityId,
+        decimal environmentalCvss,
+        Criticality assetCriticality = Criticality.Medium,
+        decimal? threatScore = null,
+        decimal? epssScore = null,
+        bool knownExploited = false,
+        bool publicExploit = false,
+        bool activeAlert = false,
+        bool hasRansomwareAssociation = false,
+        bool hasMalwareAssociation = false,
+        bool isEmergency = false) =>
+        Create(
+            deviceId,
+            vulnerabilityId,
+            environmentalCvss,
+            Severity.High,
+            assetCriticality,
+            threatScore,
+            epssScore,
+            knownExploited,
+            publicExploit,
+            activeAlert,
+            hasRansomwareAssociation,
+            hasMalwareAssociation,
+            isEmergency);
+
+    public static RiskExposureInput Medium(
+        Guid deviceId,
+        Guid vulnerabilityId,
+        decimal environmentalCvss,
+        Criticality assetCriticality = Criticality.Medium,
+        decimal? threatScore = null,
+        decimal? epssScore = null,
+        bool knownExploited = false,
+        bool publicExploit = false,
+        bool activeAlert = false,
+        bool hasRansomwareAssociation = false,
+        bool hasMalwareAssociation = false,
+        bool isEmergency = false) =>
+        Create(
+            deviceId,
+            vulnerabilityId,
+            environmentalCvss,
+            Severity.Medium,
+            assetCriticality,
+            threatScore,
+            epssScore,
+            knownExploited,
+            publicExploit,
+            activeAlert,
+            hasRansomwareAssociation,
+            hasMalwareAssociation,
+            isEmergency);
+
+    public static RiskExposureInput Low(
+        Guid deviceId,
+        Guid vulnerabilityId,
+        decimal environmentalCvss,
+        Criticality assetCriticality = Criticality.Medium,
+        decimal? threatScore = null,
+        decimal? epssScore = null,
+        bool knownExploited = false,
+        bool publicExploit = false,
+        bool activeAlert = false,
+        bool hasRansomwareAssociation = false,
+        bool hasMalwareAssociation = false,
+        bool isEmergency = false) =>
+        Create(
+            deviceId,
+            vulnerabilityId,
+            environmentalCvss,
+            Severity.Low,
+            assetCriticality,
+            threatScore,
+            epssScore,
+            knownExploited,
+            publicExploit,
+            activeAlert,
+            hasRansomwareAssociation,
+            hasMalwareAssociation,
+            isEmergency);
+
+    private static RiskExposureInput Create(
+        Guid deviceId,
+        Guid vulnerabilityId,
+        decimal environmentalCvss,
+        Severity vendorSeverity,
+        Criticality assetCriticality,
+        decimal? threatScore,
+        decimal? epssScore,
+        bool knownExploited,
+        bool publicExploit,
+        bool activeAlert,
+        bool hasRansomwareAssociation,
+        bool hasMalwareAssociation,
+        bool isEmergency) =>
+        new(
+            deviceId,
+            vulnerabilityId,
+            environmentalCvss,
+            vendorSeverity,
+            assetCriticality,
+            threatScore,
+            epssScore,
+            knownExploited,
+            publicExploit,
+            activeAlert,
+            hasRansomwareAssociation,
+            hasMalwareAssociation,
+            isEmergency);
+}
+
+public sealed record RiskScoreResult(
+    decimal OverallScore,
+    decimal MaxDetectionScore,
+    int CriticalCount,
+    int HighCount,
+    int MediumCount,
+    int LowCount,
+    string RiskBand,
+    string FactorsJson
+);
+
+public sealed record RiskContributionFactor(string Name, string Description, decimal Impact);

--- a/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
+++ b/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
@@ -519,7 +519,7 @@ public class RiskScoreService(
                 return new AssetRiskResult(
                     group.Key,
                     result.OverallScore,
-                    result.MaxDetectionScore,
+                    ScaleDetectionScoreToComposite(result.MaxDetectionScore),
                     result.CriticalCount,
                     result.HighCount,
                     result.MediumCount,
@@ -616,7 +616,7 @@ public class RiskScoreService(
                 return new SoftwareRiskResult(
                     group.Key,
                     result.OverallScore,
-                    result.MaxDetectionScore,
+                    ScaleDetectionScoreToComposite(result.MaxDetectionScore),
                     result.CriticalCount,
                     result.HighCount,
                     result.MediumCount,
@@ -640,13 +640,9 @@ public class RiskScoreService(
             return [];
         }
 
-        var assessments = await dbContext.ThreatAssessments.AsNoTracking()
+        return await dbContext.ThreatAssessments.AsNoTracking()
             .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
-            .ToListAsync(ct);
-
-        return assessments
-            .GroupBy(item => item.VulnerabilityId)
-            .ToDictionary(item => item.Key, item => item.OrderByDescending(assessment => assessment.CalculatedAt).First());
+            .ToDictionaryAsync(item => item.VulnerabilityId, ct);
     }
 
     private async Task<HashSet<Guid>> LoadEmergencyPatchVulnerabilityIdsAsync(
@@ -705,6 +701,9 @@ public class RiskScoreService(
                 emergencyPatchVulnerabilityIds.Contains(vulnerabilityId))
         );
     }
+
+    private static decimal ScaleDetectionScoreToComposite(decimal detectionScore) =>
+        Math.Clamp(Math.Round(detectionScore * 10m, 1), 0m, 1000m);
 
     private async Task<List<DeviceGroupRiskResult>> CalculateDeviceGroupScoresAsync(
         Guid tenantId,

--- a/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
+++ b/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
@@ -1,9 +1,10 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using PatchHound.Core.Constants;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
-using PatchHound.Core.Services;
+using PatchHound.Core.Services.RiskScoring;
 using PatchHound.Infrastructure.Data;
 
 namespace PatchHound.Infrastructure.Services;
@@ -13,7 +14,7 @@ public class RiskScoreService(
     ILogger<RiskScoreService> logger
 )
 {
-    public const string CalculationVersion = "1";
+    public const string CalculationVersion = "2-trurisk-inspired";
 
     /// <summary>
     /// Multiplier applied to an exposure's environmental CVSS when an active, approved
@@ -399,10 +400,10 @@ public class RiskScoreService(
             .ToList();
         var maxAsset = ordered[0].OverallScore;
         var topFiveAverage = ordered.Take(5).Average(item => item.OverallScore);
-        var criticalAssetCount = ordered.Count(item => item.OverallScore >= 900m);
-        var highAssetCount = ordered.Count(item => item.OverallScore >= 750m && item.OverallScore < 900m);
-        var mediumAssetCount = ordered.Count(item => item.OverallScore >= 500m && item.OverallScore < 750m);
-        var lowAssetCount = ordered.Count(item => item.OverallScore > 0m && item.OverallScore < 500m);
+        var criticalAssetCount = ordered.Count(item => item.OverallScore >= RiskBand.CriticalThreshold);
+        var highAssetCount = ordered.Count(item => item.OverallScore >= RiskBand.HighThreshold && item.OverallScore < RiskBand.CriticalThreshold);
+        var mediumAssetCount = ordered.Count(item => item.OverallScore >= RiskBand.MediumThreshold && item.OverallScore < RiskBand.HighThreshold);
+        var lowAssetCount = ordered.Count(item => item.OverallScore > 0m && item.OverallScore < RiskBand.MediumThreshold);
 
         var score = Math.Clamp(
             Math.Round(
@@ -454,43 +455,30 @@ public class RiskScoreService(
             .Select(d => d.SoftwareProductId)
             .ToHashSet();
 
-        var episodeScores = await dbContext.ExposureAssessments.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.Exposure.Status == ExposureStatus.Open)
+        var exposureRows = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
+            .Where(item => item.TenantId == tenantId && item.Status == ExposureStatus.Open)
             .Where(item => !dbContext.ApprovedVulnerabilityRemediations.Any(remediation =>
                 remediation.TenantId == tenantId
                 && remediation.Outcome == RemediationOutcome.AlternateMitigation
-                && remediation.VulnerabilityId == item.Exposure.VulnerabilityId))
+                && remediation.VulnerabilityId == item.VulnerabilityId))
             .Select(item => new
             {
-                AssetId = item.Exposure.DeviceId,
-                EpisodeRiskScore = item.EnvironmentalCvss,
-                SoftwareProductId = item.Exposure.SoftwareProductId,
-                RiskBand = item.EnvironmentalCvss >= 9.0m
-                    ? "Critical"
-                    : item.EnvironmentalCvss >= 7.0m
-                        ? "High"
-                        : item.EnvironmentalCvss >= 4.0m
-                            ? "Medium"
-                            : "Low",
+                item.DeviceId,
+                item.VulnerabilityId,
+                item.SoftwareProductId,
+                DeviceCriticality = item.Device.Criticality,
+                VendorSeverity = item.Vulnerability.VendorSeverity,
+                VulnerabilityCvss = item.Vulnerability.CvssScore,
+                AssessmentScore = dbContext.ExposureAssessments
+                    .Where(assessment => assessment.DeviceVulnerabilityExposureId == item.Id)
+                    .Select(assessment => (decimal?)assessment.EnvironmentalCvss)
+                    .FirstOrDefault(),
             })
             .ToListAsync(ct);
 
-        // Apply the remediation adjustment to episodes covered by an active decision.
-        var adjusted = episodeScores.Select(item =>
-        {
-            var score = item.EpisodeRiskScore;
-            var hasReduction = item.SoftwareProductId.HasValue
-                               && reducedSoftwareProductIds.Contains(item.SoftwareProductId.Value);
-            if (hasReduction)
-                score = Math.Round(score * RemediationAdjustmentFactor, 2);
-
-            var band = score >= 9.0m ? "Critical"
-                : score >= 7.0m ? "High"
-                : score >= 4.0m ? "Medium"
-                : "Low";
-
-            return (item.AssetId, EpisodeRiskScore: score, RiskBand: band, HasReduction: hasReduction);
-        });
+        var vulnerabilityIds = exposureRows.Select(item => item.VulnerabilityId).Distinct().ToList();
+        var threatAssessments = await LoadThreatAssessmentsAsync(vulnerabilityIds, ct);
+        var emergencyPatchVulnerabilityIds = await LoadEmergencyPatchVulnerabilityIdsAsync(vulnerabilityIds, ct);
 
         // Load the highest active business-label weight per device. The CASE expression
         // translates to SQL so aggregation happens server-side — only one row per device
@@ -509,82 +497,35 @@ public class RiskScoreService(
             })
             .ToDictionaryAsync(item => item.DeviceId, item => item.MaxWeight, ct);
 
-        return BuildAssetRiskResults(
-            adjusted.Select(item => (item.AssetId, item.EpisodeRiskScore, item.RiskBand, item.HasReduction)),
-            deviceLabelWeights
-        );
-    }
-
-    private static List<AssetRiskResult> BuildAssetRiskResults(
-        IEnumerable<(Guid AssetId, decimal EpisodeRiskScore, string RiskBand, bool HasReduction)> episodeScores,
-        Dictionary<Guid, decimal>? deviceLabelWeights = null
-    )
-    {
-        return episodeScores
+        return exposureRows
+            .Select(item => BuildExposureInput(
+                item.DeviceId,
+                item.VulnerabilityId,
+                item.SoftwareProductId,
+                item.AssessmentScore ?? item.VulnerabilityCvss ?? 0m,
+                item.VendorSeverity,
+                item.DeviceCriticality,
+                threatAssessments,
+                emergencyPatchVulnerabilityIds,
+                reducedSoftwareProductIds))
             .GroupBy(item => item.AssetId)
             .Select(group =>
             {
-                var orderedScores = group
-                    .Select(item => item.EpisodeRiskScore)
-                    .OrderByDescending(score => score)
-                    .ToList();
-                var maxEpisodeRisk = orderedScores.FirstOrDefault();
-                var topThreeAverage = orderedScores.Take(3).DefaultIfEmpty(0m).Average();
-                var criticalCount = group.Count(item => item.RiskBand == "Critical");
-                var highCount = group.Count(item => item.RiskBand == "High");
-                var mediumCount = group.Count(item => item.RiskBand == "Medium");
-                var lowCount = group.Count(item => item.RiskBand == "Low");
-                var reducedCount = group.Count(item => item.HasReduction);
-
-                // Clamp the unweighted score first so the multiplier applies to the
-                // same value reported as the asset's pre-label "base" risk.
-                var baseScore = Math.Clamp(
-                    Math.Round(
-                        (0.7m * maxEpisodeRisk)
-                        + (0.2m * topThreeAverage)
-                        + Math.Min(criticalCount * 35m, 120m)
-                        + Math.Min(highCount * 15m, 60m)
-                        + Math.Min(mediumCount * 5m, 20m)
-                        + Math.Min(lowCount * 1m, 5m),
-                        2),
-                    0m,
-                    1000m);
-
-                var labelWeight = deviceLabelWeights?.GetValueOrDefault(group.Key, 1.0m) ?? 1.0m;
-                var overallScore = Math.Clamp(Math.Round(baseScore * labelWeight, 2), 0m, 1000m);
-
-                var factors = new List<RiskFactor>
-                {
-                    new("MaxEpisodeRisk", "Highest unresolved episode risk on the asset.", maxEpisodeRisk),
-                    new("TopThreeAverage", "Average of the top three unresolved episode risks.", Math.Round(topThreeAverage, 2)),
-                    new("CriticalEpisodes", $"{criticalCount} critical-risk episodes.", Math.Min(criticalCount * 35m, 120m)),
-                    new("HighEpisodes", $"{highCount} high-risk episodes.", Math.Min(highCount * 15m, 60m)),
-                    new("MediumEpisodes", $"{mediumCount} medium-risk episodes.", Math.Min(mediumCount * 5m, 20m)),
-                    new("LowEpisodes", $"{lowCount} low-risk episodes.", Math.Min(lowCount * 1m, 5m)),
-                };
-
-                if (reducedCount > 0)
-                    factors.Add(new("RemediationReduction",
-                        $"{reducedCount} episode(s) score reduced by active remediation decision (factor {RemediationAdjustmentFactor}).",
-                        -reducedCount));
-
-                if (labelWeight != 1.0m)
-                    factors.Add(new("BusinessLabelWeight",
-                        $"Asset score multiplied by business label weight {labelWeight}x.",
-                        Math.Round(overallScore - baseScore, 2)));
-
-                var factorsJson = JsonSerializer.Serialize(factors);
+                var labelWeight = deviceLabelWeights.GetValueOrDefault(group.Key, 1.0m);
+                var result = PatchHoundRiskScoringEngine.CalculateAssetRisk(
+                    group.Select(item => item.Input).ToList(),
+                    labelWeight);
 
                 return new AssetRiskResult(
                     group.Key,
-                    overallScore,
-                    maxEpisodeRisk,
-                    criticalCount,
-                    highCount,
-                    mediumCount,
-                    lowCount,
+                    result.OverallScore,
+                    result.MaxDetectionScore,
+                    result.CriticalCount,
+                    result.HighCount,
+                    result.MediumCount,
+                    result.LowCount,
                     group.Count(),
-                    factorsJson
+                    result.FactorsJson
                 );
             })
             .OrderByDescending(item => item.OverallScore)
@@ -596,8 +537,27 @@ public class RiskScoreService(
         CancellationToken ct
     )
     {
+        var now = DateTimeOffset.UtcNow;
+        var activeDecisions = await dbContext.RemediationDecisions.AsNoTracking()
+            .Where(d => d.TenantId == tenantId && d.ApprovalStatus == DecisionApprovalStatus.Approved)
+            .Select(d => new
+            {
+                SoftwareProductId = d.RemediationCase.SoftwareProductId,
+                d.Outcome,
+                d.MaintenanceWindowDate,
+            })
+            .ToListAsync(ct);
+        var reducedSoftwareProductIds = activeDecisions
+            .Where(d =>
+                d.Outcome == RemediationOutcome.ApprovedForPatching
+                && !(d.MaintenanceWindowDate.HasValue && d.MaintenanceWindowDate.Value < now))
+            .Select(d => d.SoftwareProductId)
+            .ToHashSet();
+
         var exposures = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
-            .Where(item => item.TenantId == tenantId && item.SoftwareProductId != null)
+            .Where(item => item.TenantId == tenantId
+                && item.SoftwareProductId != null
+                && item.Status == ExposureStatus.Open)
             .Where(item => !dbContext.ApprovedVulnerabilityRemediations.Any(remediation =>
                 remediation.TenantId == tenantId
                 && remediation.Outcome == RemediationOutcome.AlternateMitigation
@@ -607,102 +567,143 @@ public class RiskScoreService(
                 item.Id,
                 item.DeviceId,
                 SoftwareProductId = item.SoftwareProductId!.Value,
-                item.Status,
-                VulnId = item.VulnerabilityId,
-                VulnExternalId = item.Vulnerability.ExternalId,
-                VulnSeverity = item.Vulnerability.VendorSeverity,
-                VulnCvssScore = item.Vulnerability.CvssScore,
+                item.VulnerabilityId,
+                DeviceCriticality = item.Device.Criticality,
+                VendorSeverity = item.Vulnerability.VendorSeverity,
+                VulnerabilityCvss = item.Vulnerability.CvssScore,
                 AssessmentScore = dbContext.ExposureAssessments
-                    .Where(a => a.DeviceVulnerabilityExposureId == item.Id)
-                    .Select(a => (decimal?)a.EnvironmentalCvss)
+                    .Where(assessment => assessment.DeviceVulnerabilityExposureId == item.Id)
+                    .Select(assessment => (decimal?)assessment.EnvironmentalCvss)
                     .FirstOrDefault(),
             })
             .ToListAsync(ct);
 
-        var allDeviceIds = exposures.Select(e => e.DeviceId).Distinct().ToList();
-        var highValueDeviceIds = (await dbContext.Devices.AsNoTracking()
-            .Where(d => allDeviceIds.Contains(d.Id)
-                && (d.Criticality == Criticality.High || d.Criticality == Criticality.Critical))
-            .Select(d => d.Id)
-            .ToListAsync(ct))
-            .ToHashSet();
+        var vulnerabilityIds = exposures.Select(item => item.VulnerabilityId).Distinct().ToList();
+        var threatAssessments = await LoadThreatAssessmentsAsync(vulnerabilityIds, ct);
+        var emergencyPatchVulnerabilityIds = await LoadEmergencyPatchVulnerabilityIdsAsync(vulnerabilityIds, ct);
 
         return exposures
             .GroupBy(item => item.SoftwareProductId)
             .Select(group =>
             {
-                var openExposures = group.Where(e => e.Status == ExposureStatus.Open).ToList();
-
-                // Use assessment score; fall back to vulnerability CVSS when no assessment exists.
-                var scores = openExposures
-                    .Select(e => e.AssessmentScore ?? e.VulnCvssScore ?? 0m)
-                    .OrderByDescending(s => s)
+                var openExposures = group.ToList();
+                var inputs = openExposures
+                    .Select(item => BuildExposureInput(
+                        item.DeviceId,
+                        item.VulnerabilityId,
+                        item.SoftwareProductId,
+                        item.AssessmentScore ?? item.VulnerabilityCvss ?? 0m,
+                        item.VendorSeverity,
+                        item.DeviceCriticality,
+                        threatAssessments,
+                        emergencyPatchVulnerabilityIds,
+                        reducedSoftwareProductIds).Input)
                     .ToList();
-                var maxScore = scores.FirstOrDefault();
-                var topThreeAvg = scores.Take(3).DefaultIfEmpty(0m).Average();
-                var criticalCount = openExposures.Count(e => (e.AssessmentScore ?? e.VulnCvssScore ?? 0m) >= 9.0m);
-                var highCount = openExposures.Count(e => { var s = e.AssessmentScore ?? e.VulnCvssScore ?? 0m; return s >= 7.0m && s < 9.0m; });
-                var mediumCount = openExposures.Count(e => { var s = e.AssessmentScore ?? e.VulnCvssScore ?? 0m; return s >= 4.0m && s < 7.0m; });
-                var lowCount = openExposures.Count(e => { var s = e.AssessmentScore ?? e.VulnCvssScore ?? 0m; return s > 0m && s < 4.0m; });
-                var affectedDeviceIds = openExposures.Select(e => e.DeviceId).Distinct().ToList();
+                var affectedDeviceIds = openExposures.Select(item => item.DeviceId).Distinct().ToList();
                 var affectedDeviceCount = affectedDeviceIds.Count;
-                var highValueDeviceCount = affectedDeviceIds.Count(id => highValueDeviceIds.Contains(id));
-
-                var overallScore = Math.Clamp(
-                    Math.Round(
-                        (0.7m * maxScore)
-                        + (0.2m * topThreeAvg)
-                        + Math.Min(criticalCount * 35m, 120m)
-                        + Math.Min(highCount * 15m, 60m)
-                        + Math.Min(mediumCount * 5m, 20m)
-                        + Math.Min(lowCount * 1m, 5m),
-                        2),
-                    0m,
-                    1000m);
-
-                // Impact score uses the same ExposureImpactCalculator as the detail view,
-                // keyed on unique vulnerabilities so count/device weighting is consistent.
-                var uniqueVulns = openExposures
-                    .GroupBy(e => e.VulnId)
-                    .Select(g => new ExposureImpactCalculator.SoftwareVulnerabilityInput(
-                        g.First().VulnSeverity,
-                        g.First().VulnCvssScore,
-                        g.First().VulnExternalId))
-                    .ToList();
-                var impactScore = ExposureImpactCalculator.CalculateSoftwareImpact(
-                    new ExposureImpactCalculator.SoftwareImpactInput(
-                        group.Key,
-                        affectedDeviceCount,
-                        highValueDeviceCount,
-                        uniqueVulns))
-                    .ImpactScore;
-
-                var factorsJson = JsonSerializer.Serialize(new List<RiskFactor>
-                {
-                    new("MaxExposureScore", "Highest open exposure score for this software product.", maxScore),
-                    new("TopThreeAverage", "Average of the top three open exposure scores.", Math.Round(topThreeAvg, 2)),
-                    new("CriticalExposures", $"{criticalCount} critical-risk open exposures.", Math.Min(criticalCount * 35m, 120m)),
-                    new("HighExposures", $"{highCount} high-risk open exposures.", Math.Min(highCount * 15m, 60m)),
-                    new("MediumExposures", $"{mediumCount} medium-risk open exposures.", Math.Min(mediumCount * 5m, 20m)),
-                    new("LowExposures", $"{lowCount} low-risk open exposures.", Math.Min(lowCount * 1m, 5m)),
-                });
+                var highValueDeviceCount = openExposures
+                    .GroupBy(item => item.DeviceId)
+                    .Count(deviceGroup =>
+                    {
+                        var criticality = deviceGroup.First().DeviceCriticality;
+                        return criticality == Criticality.High || criticality == Criticality.Critical;
+                    });
+                var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+                    inputs,
+                    affectedDeviceCount,
+                    highValueDeviceCount);
 
                 return new SoftwareRiskResult(
                     group.Key,
-                    overallScore,
-                    impactScore,
-                    criticalCount,
-                    highCount,
-                    mediumCount,
-                    lowCount,
+                    result.OverallScore,
+                    result.MaxDetectionScore,
+                    result.CriticalCount,
+                    result.HighCount,
+                    result.MediumCount,
+                    result.LowCount,
                     affectedDeviceCount,
                     openExposures.Count,
-                    factorsJson
+                    result.FactorsJson
                 );
             })
             .Where(r => r.OpenExposureCount > 0)
             .OrderByDescending(r => r.OverallScore)
             .ToList();
+    }
+
+    private async Task<Dictionary<Guid, ThreatAssessment>> LoadThreatAssessmentsAsync(
+        IReadOnlyCollection<Guid> vulnerabilityIds,
+        CancellationToken ct)
+    {
+        if (vulnerabilityIds.Count == 0)
+        {
+            return [];
+        }
+
+        var assessments = await dbContext.ThreatAssessments.AsNoTracking()
+            .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
+            .ToListAsync(ct);
+
+        return assessments
+            .GroupBy(item => item.VulnerabilityId)
+            .ToDictionary(item => item.Key, item => item.OrderByDescending(assessment => assessment.CalculatedAt).First());
+    }
+
+    private async Task<HashSet<Guid>> LoadEmergencyPatchVulnerabilityIdsAsync(
+        IReadOnlyCollection<Guid> vulnerabilityIds,
+        CancellationToken ct)
+    {
+        if (vulnerabilityIds.Count == 0)
+        {
+            return [];
+        }
+
+        var ids = await dbContext.VulnerabilityPatchAssessments.AsNoTracking()
+            .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId)
+                && item.UrgencyTier == PatchUrgencyTier.Emergency)
+            .Select(item => item.VulnerabilityId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        return ids.ToHashSet();
+    }
+
+    private static (Guid AssetId, RiskExposureInput Input) BuildExposureInput(
+        Guid deviceId,
+        Guid vulnerabilityId,
+        Guid? softwareProductId,
+        decimal environmentalCvss,
+        Severity vendorSeverity,
+        Criticality deviceCriticality,
+        IReadOnlyDictionary<Guid, ThreatAssessment> threatAssessments,
+        IReadOnlySet<Guid> emergencyPatchVulnerabilityIds,
+        IReadOnlySet<Guid> reducedSoftwareProductIds)
+    {
+        var adjustedCvss = environmentalCvss;
+        if (softwareProductId.HasValue && reducedSoftwareProductIds.Contains(softwareProductId.Value))
+        {
+            adjustedCvss = Math.Round(adjustedCvss * RemediationAdjustmentFactor, 2);
+        }
+
+        threatAssessments.TryGetValue(vulnerabilityId, out var threat);
+
+        return (
+            deviceId,
+            new RiskExposureInput(
+                deviceId,
+                vulnerabilityId,
+                adjustedCvss,
+                vendorSeverity,
+                deviceCriticality,
+                threat?.ThreatScore,
+                threat?.EpssScore,
+                threat?.KnownExploited ?? false,
+                threat?.PublicExploit ?? false,
+                threat?.ActiveAlert ?? false,
+                threat?.HasRansomwareAssociation ?? false,
+                threat?.HasMalwareAssociation ?? false,
+                emergencyPatchVulnerabilityIds.Contains(vulnerabilityId))
+        );
     }
 
     private async Task<List<DeviceGroupRiskResult>> CalculateDeviceGroupScoresAsync(

--- a/tests/PatchHound.Tests/Core/RiskScoring/PatchHoundRiskScoringEngineTests.cs
+++ b/tests/PatchHound.Tests/Core/RiskScoring/PatchHoundRiskScoringEngineTests.cs
@@ -1,0 +1,226 @@
+using System.Text.Json;
+using FluentAssertions;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Services.RiskScoring;
+
+namespace PatchHound.Tests.Core.RiskScoring;
+
+public class PatchHoundRiskScoringEngineTests
+{
+    [Theory]
+    [InlineData(0, "None")]
+    [InlineData(1, "Low")]
+    [InlineData(499.99, "Low")]
+    [InlineData(500, "Medium")]
+    [InlineData(700, "High")]
+    [InlineData(850, "Critical")]
+    public void RiskBand_FromScore_UsesUnifiedTruRiskInspiredThresholds(decimal score, string expected)
+    {
+        RiskBand.FromScore(score).Should().Be(expected);
+    }
+
+    [Fact]
+    public void CalculateSoftwareRisk_EmergencyCriticalAndManyHighs_IsCritical()
+    {
+        var deviceId = Guid.NewGuid();
+        var inputs = new List<RiskExposureInput>
+        {
+            RiskExposureInput.Critical(deviceId, Guid.NewGuid(), 9.8m, isEmergency: true),
+        };
+        inputs.AddRange(Enumerable.Range(0, 49)
+            .Select(_ => RiskExposureInput.High(deviceId, Guid.NewGuid(), 7.5m)));
+
+        var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            inputs,
+            affectedDeviceCount: 1,
+            highValueDeviceCount: 0);
+
+        result.OverallScore.Should().Be(1000m);
+        result.RiskBand.Should().Be("Critical");
+    }
+
+    [Fact]
+    public void CalculateAssetRisk_SingleCriticalOnHighCriticalityAsset_IsAtLeastMedium()
+    {
+        var input = RiskExposureInput.Critical(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            9.5m,
+            assetCriticality: Criticality.High);
+
+        var result = PatchHoundRiskScoringEngine.CalculateAssetRisk([input], businessLabelWeight: 1m);
+
+        result.OverallScore.Should().BeGreaterThanOrEqualTo(500m);
+    }
+
+    [Fact]
+    public void CalculateSoftwareRisk_ZeroExposures_ReturnsNoneWithValidFactors()
+    {
+        var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            [],
+            affectedDeviceCount: 0,
+            highValueDeviceCount: 0);
+
+        result.OverallScore.Should().Be(0m);
+        result.RiskBand.Should().Be("None");
+        result.MaxDetectionScore.Should().Be(0m);
+        result.CriticalCount.Should().Be(0);
+        result.HighCount.Should().Be(0);
+        result.MediumCount.Should().Be(0);
+        result.LowCount.Should().Be(0);
+
+        var factors = DeserializeFactors(result.FactorsJson);
+        factors.Should().ContainSingle(factor =>
+            factor.Name == "BaseComponent"
+            && factor.Description.Length > 0
+            && factor.Impact == 0m);
+    }
+
+    [Fact]
+    public void CalculateSoftwareRisk_KnownExploitedLowCvss_AppliesUrgentThreatFloor()
+    {
+        var input = RiskExposureInput.Low(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0.1m,
+            knownExploited: true);
+
+        var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            [input],
+            affectedDeviceCount: 1,
+            highValueDeviceCount: 0);
+
+        result.OverallScore.Should().BeGreaterThanOrEqualTo(700m);
+        result.RiskBand.Should().Be("High");
+    }
+
+    [Fact]
+    public void CalculateSoftwareRisk_PublicExploitOrHighEpss_RaisesDetectionScore()
+    {
+        var publicExploit = RiskExposureInput.Low(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0.1m,
+            publicExploit: true);
+        var highEpss = RiskExposureInput.Low(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0.1m,
+            epssScore: 0.50m);
+
+        var publicExploitResult = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            [publicExploit],
+            affectedDeviceCount: 1,
+            highValueDeviceCount: 0);
+        var highEpssResult = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            [highEpss],
+            affectedDeviceCount: 1,
+            highValueDeviceCount: 0);
+
+        publicExploitResult.MaxDetectionScore.Should().BeGreaterThanOrEqualTo(80m);
+        highEpssResult.MaxDetectionScore.Should().BeGreaterThanOrEqualTo(80m);
+    }
+
+    [Fact]
+    public void CalculateAssetRisk_CriticalityAndBusinessLabelMultipliers_IncreaseScore()
+    {
+        var vulnerabilityId = Guid.NewGuid();
+        var lowCriticality = RiskExposureInput.High(
+            Guid.NewGuid(),
+            vulnerabilityId,
+            7.0m,
+            assetCriticality: Criticality.Low);
+        var criticalCriticality = lowCriticality with { AssetCriticality = Criticality.Critical };
+        var mediumCriticality = lowCriticality with { AssetCriticality = Criticality.Medium };
+
+        var lowCriticalityResult = PatchHoundRiskScoringEngine.CalculateAssetRisk(
+            [lowCriticality],
+            businessLabelWeight: 1m);
+        var criticalCriticalityResult = PatchHoundRiskScoringEngine.CalculateAssetRisk(
+            [criticalCriticality],
+            businessLabelWeight: 1m);
+        var baseBusinessResult = PatchHoundRiskScoringEngine.CalculateAssetRisk(
+            [mediumCriticality],
+            businessLabelWeight: 1m);
+        var weightedBusinessResult = PatchHoundRiskScoringEngine.CalculateAssetRisk(
+            [mediumCriticality],
+            businessLabelWeight: 1.5m);
+
+        criticalCriticalityResult.OverallScore.Should().BeGreaterThan(lowCriticalityResult.OverallScore);
+        weightedBusinessResult.OverallScore.Should().BeGreaterThan(baseBusinessResult.OverallScore);
+    }
+
+    [Fact]
+    public void CalculateSoftwareRisk_ExtremeInputs_ClampsScoreAt1000()
+    {
+        var deviceId = Guid.NewGuid();
+        var inputs = Enumerable.Range(0, 200)
+            .Select(_ => RiskExposureInput.Critical(deviceId, Guid.NewGuid(), 10m, isEmergency: true))
+            .ToList();
+
+        var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            inputs,
+            affectedDeviceCount: 10000,
+            highValueDeviceCount: 1000);
+
+        result.OverallScore.Should().Be(1000m);
+        result.RiskBand.Should().Be("Critical");
+    }
+
+    [Fact]
+    public void CalculateSoftwareRisk_FactorsJson_UsesStableSoftwareComponentNames()
+    {
+        var input = RiskExposureInput.High(Guid.NewGuid(), Guid.NewGuid(), 7.5m);
+
+        var result = PatchHoundRiskScoringEngine.CalculateSoftwareRisk(
+            [input],
+            affectedDeviceCount: 10,
+            highValueDeviceCount: 2);
+
+        var factors = DeserializeFactors(result.FactorsJson);
+
+        factors.Should().OnlyContain(factor =>
+            !string.IsNullOrWhiteSpace(factor.Name)
+            && !string.IsNullOrWhiteSpace(factor.Description));
+        factors.Select(factor => factor.Name).Should().BeEquivalentTo(
+            "BaseComponent",
+            "CountComponent",
+            "BreadthComponent",
+            "HighValueDeviceComponent",
+            "FloorAdjustedScore");
+        factors.Select(factor => factor.Impact).Should().OnlyContain(impact => impact >= 0m);
+    }
+
+    [Fact]
+    public void CalculateAssetRisk_FactorsJson_UsesStableAssetComponentNames()
+    {
+        var input = RiskExposureInput.High(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            7.5m,
+            assetCriticality: Criticality.High);
+
+        var result = PatchHoundRiskScoringEngine.CalculateAssetRisk([input], businessLabelWeight: 1.25m);
+
+        var factors = DeserializeFactors(result.FactorsJson);
+
+        factors.Should().OnlyContain(factor =>
+            !string.IsNullOrWhiteSpace(factor.Name)
+            && !string.IsNullOrWhiteSpace(factor.Description));
+        factors.Select(factor => factor.Name).Should().BeEquivalentTo(
+            "BaseComponent",
+            "CountComponent",
+            "AssetCriticalityMultiplier",
+            "BusinessLabelWeight",
+            "FloorAdjustedScore");
+        factors.Select(factor => factor.Impact).Should().OnlyContain(impact => impact >= 0m);
+    }
+
+    private static IReadOnlyList<RiskContributionFactor> DeserializeFactors(string factorsJson)
+    {
+        var factors = JsonSerializer.Deserialize<List<RiskContributionFactor>>(factorsJson);
+
+        factors.Should().NotBeNull();
+        return factors!;
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/BusinessLabelRiskWeightTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/BusinessLabelRiskWeightTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
+using PatchHound.Core.Services.RiskScoring;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Tests.Infrastructure;
 
@@ -105,7 +106,8 @@ public class BusinessLabelRiskWeightTests : IAsyncDisposable
 
         var weightedScore = _db.DeviceRiskScores.Single(s => s.DeviceId == seed.DeviceA.Id).OverallScore;
         var expected = Math.Clamp(Math.Round(baselineScore * 0.5m, 2), 0m, 1000m);
-        weightedScore.Should().Be(expected);
+        weightedScore.Should().Be(Math.Max(expected, RiskBand.MediumThreshold));
+        weightedScore.Should().BeLessThan(baselineScore);
     }
 
     [Fact]

--- a/tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTruRiskCalibrationTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTruRiskCalibrationTests.cs
@@ -1,0 +1,261 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PatchHound.Core.Constants;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Services.RiskScoring;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.Infrastructure;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class RiskScoreServiceTruRiskCalibrationTests : IAsyncDisposable
+{
+    private static readonly Guid SourceSystemId = Guid.NewGuid();
+
+    private readonly Guid _tenantId;
+    private readonly global::PatchHound.Infrastructure.Data.PatchHoundDbContext _db;
+
+    public RiskScoreServiceTruRiskCalibrationTests()
+    {
+        _db = TestDbContextFactory.CreateTenantContext(out _tenantId);
+    }
+
+    public async ValueTask DisposeAsync() => await _db.DisposeAsync();
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_EmergencyCriticalSoftwareCase_ScoresCriticalOrAtLeastHigh()
+    {
+        var product = SoftwareProduct.Create("Contoso", "Emergency Agent", null);
+        var device = Device.Create(_tenantId, SourceSystemId, "emergency-device", "Emergency Device", Criticality.Critical);
+        await _db.AddRangeAsync(product, device);
+        await _db.SaveChangesAsync();
+
+        var critical = Vulnerability.Create(
+            "nvd",
+            "CVE-2026-TRU-0001",
+            "Emergency critical",
+            "desc",
+            Severity.Critical,
+            9.8m,
+            null,
+            DateTimeOffset.UtcNow);
+        await SeedExposureAsync(product, device, critical, 9.8m);
+        _db.VulnerabilityPatchAssessments.Add(CreatePatchAssessment(critical.Id, PatchUrgencyTier.Emergency));
+
+        foreach (var index in Enumerable.Range(0, 49))
+        {
+            var high = Vulnerability.Create(
+                "nvd",
+                $"CVE-2026-TRU-H{index:0000}",
+                $"High {index}",
+                "desc",
+                Severity.High,
+                7.5m,
+                null,
+                DateTimeOffset.UtcNow);
+            await SeedExposureAsync(product, device, high, 7.5m);
+        }
+
+        await _db.SaveChangesAsync();
+
+        await RecalculateAsync();
+
+        var score = await _db.SoftwareRiskScores.SingleAsync(item => item.SoftwareProductId == product.Id);
+        score.OverallScore.Should().BeGreaterThanOrEqualTo(850m);
+        RiskBand.FromScore(score.OverallScore).Should().Be("Critical");
+        score.CalculationVersion.Should().Be("2-trurisk-inspired");
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_AffectedDeviceBreadth_IncreasesSoftwareScore()
+    {
+        var narrowProduct = SoftwareProduct.Create("Contoso", "Narrow Agent", null);
+        var broadProduct = SoftwareProduct.Create("Contoso", "Broad Agent", null);
+        await _db.AddRangeAsync(narrowProduct, broadProduct);
+        await _db.SaveChangesAsync();
+
+        var narrowDevice = Device.Create(_tenantId, SourceSystemId, "narrow-device", "Narrow Device", Criticality.Medium);
+        await _db.Devices.AddAsync(narrowDevice);
+        await SeedExposureAsync(narrowProduct, narrowDevice, CreateHighVulnerability("NARROW"), 7.5m);
+
+        foreach (var index in Enumerable.Range(0, 8))
+        {
+            var device = Device.Create(
+                _tenantId,
+                SourceSystemId,
+                $"broad-device-{index}",
+                $"Broad Device {index}",
+                Criticality.Medium);
+            await _db.Devices.AddAsync(device);
+            await SeedExposureAsync(broadProduct, device, CreateHighVulnerability($"BROAD-{index}"), 7.5m);
+        }
+
+        await _db.SaveChangesAsync();
+
+        await RecalculateAsync();
+
+        var narrowScore = await _db.SoftwareRiskScores.SingleAsync(item => item.SoftwareProductId == narrowProduct.Id);
+        var broadScore = await _db.SoftwareRiskScores.SingleAsync(item => item.SoftwareProductId == broadProduct.Id);
+
+        broadScore.AffectedDeviceCount.Should().BeGreaterThan(narrowScore.AffectedDeviceCount);
+        broadScore.OverallScore.Should().BeGreaterThan(narrowScore.OverallScore);
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_KnownExploitedThreatAssessment_AppliesHighFloor()
+    {
+        var product = SoftwareProduct.Create("Contoso", "Known Exploited Agent", null);
+        var device = Device.Create(_tenantId, SourceSystemId, "kev-device", "Known Exploited Device", Criticality.Low);
+        var vulnerability = Vulnerability.Create(
+            "nvd",
+            "CVE-2026-TRU-KEV",
+            "Known exploited low CVSS",
+            "desc",
+            Severity.Low,
+            2.1m,
+            null,
+            DateTimeOffset.UtcNow);
+
+        await _db.AddRangeAsync(product, device);
+        await SeedExposureAsync(product, device, vulnerability, 2.1m);
+        _db.ThreatAssessments.Add(ThreatAssessment.Create(
+            vulnerability.Id,
+            threatScore: 20m,
+            technicalScore: 20m,
+            exploitLikelihoodScore: 20m,
+            threatActivityScore: 20m,
+            epssScore: 0.05m,
+            knownExploited: true,
+            publicExploit: false,
+            activeAlert: false,
+            hasRansomwareAssociation: false,
+            hasMalwareAssociation: false,
+            factorsJson: "[]",
+            calculationVersion: "test"));
+        await _db.SaveChangesAsync();
+
+        await RecalculateAsync();
+
+        var score = await _db.SoftwareRiskScores.SingleAsync(item => item.SoftwareProductId == product.Id);
+        score.OverallScore.Should().BeGreaterThanOrEqualTo(700m);
+        RiskBand.FromScore(score.OverallScore).Should().Be("High");
+    }
+
+    [Fact]
+    public async Task RecalculateForTenantAsync_DashboardTenantRisk_IncreasesWhenAssetScoresIncrease()
+    {
+        var product = SoftwareProduct.Create("Contoso", "Dashboard Agent", null);
+        var device = Device.Create(_tenantId, SourceSystemId, "dashboard-device", "Dashboard Device", Criticality.Medium);
+        await _db.AddRangeAsync(product, device);
+        await SeedExposureAsync(product, device, CreateLowVulnerability("DASH-LOW"), 2.0m);
+        await _db.SaveChangesAsync();
+
+        await RecalculateAsync();
+        var baselineRisk = await GetTenantRiskScoreAsync();
+
+        await SeedExposureAsync(product, device, CreateHighVulnerability("DASH-HIGH"), 8.7m);
+        await _db.SaveChangesAsync();
+
+        await RecalculateAsync();
+        var elevatedRisk = await GetTenantRiskScoreAsync();
+
+        elevatedRisk.Should().BeGreaterThan(baselineRisk);
+    }
+
+    private async Task RecalculateAsync()
+    {
+        var service = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        await service.RecalculateForTenantAsync(_tenantId, CancellationToken.None);
+    }
+
+    private async Task<decimal> GetTenantRiskScoreAsync()
+    {
+        var service = new RiskScoreService(_db, Substitute.For<ILogger<RiskScoreService>>());
+        return (await service.GetTenantRiskAsync(_tenantId, CancellationToken.None)).OverallScore;
+    }
+
+    private async Task<DeviceVulnerabilityExposure> SeedExposureAsync(
+        SoftwareProduct product,
+        Device device,
+        Vulnerability vulnerability,
+        decimal environmentalCvss)
+    {
+        _db.Vulnerabilities.Add(vulnerability);
+        await _db.SaveChangesAsync();
+
+        var now = DateTimeOffset.UtcNow;
+        var installedSoftware = InstalledSoftware.Observe(
+            _tenantId,
+            device.Id,
+            product.Id,
+            SourceSystemId,
+            "1.0.0",
+            now);
+        _db.InstalledSoftware.Add(installedSoftware);
+        await _db.SaveChangesAsync();
+
+        var exposure = DeviceVulnerabilityExposure.Observe(
+            _tenantId,
+            device.Id,
+            vulnerability.Id,
+            product.Id,
+            installedSoftware.Id,
+            "1.0.0",
+            ExposureMatchSource.Product,
+            now);
+        _db.DeviceVulnerabilityExposures.Add(exposure);
+        await _db.SaveChangesAsync();
+
+        _db.ExposureAssessments.Add(ExposureAssessment.Create(
+            _tenantId,
+            exposure.Id,
+            null,
+            vulnerability.CvssScore ?? environmentalCvss,
+            environmentalCvss,
+            "test exposure",
+            now));
+
+        return exposure;
+    }
+
+    private static Vulnerability CreateHighVulnerability(string suffix) =>
+        Vulnerability.Create(
+            "nvd",
+            $"CVE-2026-TRU-{suffix}",
+            $"High {suffix}",
+            "desc",
+            Severity.High,
+            7.5m,
+            null,
+            DateTimeOffset.UtcNow);
+
+    private static Vulnerability CreateLowVulnerability(string suffix) =>
+        Vulnerability.Create(
+            "nvd",
+            $"CVE-2026-TRU-{suffix}",
+            $"Low {suffix}",
+            "desc",
+            Severity.Low,
+            2.0m,
+            null,
+            DateTimeOffset.UtcNow);
+
+    private static VulnerabilityPatchAssessment CreatePatchAssessment(Guid vulnerabilityId, string urgencyTier) =>
+        VulnerabilityPatchAssessment.Create(
+            vulnerabilityId,
+            recommendation: "Patch",
+            confidence: "High",
+            summary: "summary",
+            urgencyTier,
+            urgencyTargetSla: "24h",
+            urgencyReason: "test",
+            similarVulnerabilities: "[]",
+            compensatingControlsUntilPatched: "[]",
+            references: "[]",
+            aiProfileName: "test",
+            rawOutput: null,
+            assessedAt: DateTimeOffset.UtcNow);
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTruRiskCalibrationTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/RiskScoreServiceTruRiskCalibrationTests.cs
@@ -65,6 +65,7 @@ public class RiskScoreServiceTruRiskCalibrationTests : IAsyncDisposable
 
         var score = await _db.SoftwareRiskScores.SingleAsync(item => item.SoftwareProductId == product.Id);
         score.OverallScore.Should().BeGreaterThanOrEqualTo(850m);
+        score.MaxExposureScore.Should().Be(980m);
         RiskBand.FromScore(score.OverallScore).Should().Be("Critical");
         score.CalculationVersion.Should().Be("2-trurisk-inspired");
     }
@@ -141,6 +142,7 @@ public class RiskScoreServiceTruRiskCalibrationTests : IAsyncDisposable
 
         var score = await _db.SoftwareRiskScores.SingleAsync(item => item.SoftwareProductId == product.Id);
         score.OverallScore.Should().BeGreaterThanOrEqualTo(700m);
+        score.MaxExposureScore.Should().Be(950m);
         RiskBand.FromScore(score.OverallScore).Should().Be("High");
     }
 


### PR DESCRIPTION
## Summary

- Explain what changed
This pull request focuses on centralizing and standardizing risk score logic across the frontend dashboard and device components. The main improvements involve replacing hardcoded risk score banding and styling with utility functions from `@/lib/risk-scoring`, ensuring consistent risk classification, color/tone usage, and badge styling. Additionally, some documentation updates were made to reflect current project indexing and to streamline usage instructions.

**Frontend risk score logic standardization:**

* Replaced all hardcoded risk score banding and badge class logic in `CisoExecutiveOverview.tsx`, `DeviceGroupRiskDetailDialog.tsx`, and `RiskScoreDetailDialog.tsx` with imports from `@/lib/risk-scoring` (e.g., `riskScoreBand`, `riskScoreBadgeClass`, `riskGaugeBand`, `riskScoreTone`). This ensures consistent risk band calculation and styling across components. [[1]](diffhunk://#diff-69f84d9ae35543de6f838777c26a1b9c36ffa0bc9a1402f6397b65ae5f8aa4d3R9) [[2]](diffhunk://#diff-69f84d9ae35543de6f838777c26a1b9c36ffa0bc9a1402f6397b65ae5f8aa4d3L39-R64) [[3]](diffhunk://#diff-69f84d9ae35543de6f838777c26a1b9c36ffa0bc9a1402f6397b65ae5f8aa4d3L179-L185) [[4]](diffhunk://#diff-69f84d9ae35543de6f838777c26a1b9c36ffa0bc9a1402f6397b65ae5f8aa4d3L196-R190) [[5]](diffhunk://#diff-d97d2ca519261d0719553efc4299638d8fb23939abbd09d4525cc467e30a3028R24) [[6]](diffhunk://#diff-d97d2ca519261d0719553efc4299638d8fb23939abbd09d4525cc467e30a3028L217-R219) [[7]](diffhunk://#diff-b81e7ef7c0928ae77216b16f225c87205b0a7683669521b9c1eab446c538b99eR11) [[8]](diffhunk://#diff-b81e7ef7c0928ae77216b16f225c87205b0a7683669521b9c1eab446c538b99eL347-R350) [[9]](diffhunk://#diff-b81e7ef7c0928ae77216b16f225c87205b0a7683669521b9c1eab446c538b99eL362-R365) [[10]](diffhunk://#diff-b81e7ef7c0928ae77216b16f225c87205b0a7683669521b9c1eab446c538b99eL377-R380) [[11]](diffhunk://#diff-54e452d1a7b215a59e81351bbc9f8b9d84203a8a611f82e303554c5d5bc38809R13) [[12]](diffhunk://#diff-54e452d1a7b215a59e81351bbc9f8b9d84203a8a611f82e303554c5d5bc38809L181-R183) [[13]](diffhunk://#diff-b3294ec92036ba92d5ecfb01b42ef37785aabf27cfe6be850ae563edfb1974afR20) [[14]](diffhunk://#diff-b3294ec92036ba92d5ecfb01b42ef37785aabf27cfe6be850ae563edfb1974afL190-R200) [[15]](diffhunk://#diff-2b82af8871ad897864a284799d3c5c946422e5293fdd84ee7fc669c5004aac44R29)

* Updated `MetricCard` in `DeviceDetailPane.tsx` to support new tone variants (`info`, `neutral`) and to use risk score tone helpers for device risk and episode risk, improving visual clarity and consistency. [[1]](diffhunk://#diff-b3294ec92036ba92d5ecfb01b42ef37785aabf27cfe6be850ae563edfb1974afL41-R59) [[2]](diffhunk://#diff-b3294ec92036ba92d5ecfb01b42ef37785aabf27cfe6be850ae563edfb1974afL190-R200)

**Documentation updates:**

* Updated `AGENTS.md` and `CLAUDE.md` to reflect the current GitNexus index symbol/relationship counts and removed several redundant or overly detailed sections (debugging, refactoring, self-check, and index maintenance instructions), streamlining the onboarding and usage documentation. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L92-R92) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L104-L142) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L152-L177)

These changes improve maintainability, reduce duplication, and ensure a unified risk scoring experience throughout the frontend.
- Explain why it changed

## Validation

- [ ] `dotnet test PatchHound.slnx -v minimal`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

## Notes

- Configuration changes:
- Operational impact:
- Screenshots or recordings for UI work:
