### PR TITLE
[codex] Fix Defender applicability version ranges

### DIFF
--- a/src/PatchHound.Infrastructure/Migrations/20260518120000_RemoveBrokenDefenderApplicabilityRanges.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260518120000_RemoveBrokenDefenderApplicabilityRanges.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using PatchHound.Infrastructure.Data;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    [DbContext(typeof(PatchHoundDbContext))]
+    [Migration("20260518120000_RemoveBrokenDefenderApplicabilityRanges")]
+    public partial class RemoveBrokenDefenderApplicabilityRanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                DELETE FROM "VulnerabilityApplicabilities"
+                WHERE (
+                    "Source" = 'microsoft-defender'
+                    OR (
+                        "Source" = 'Unknown'
+                        AND EXISTS (
+                            SELECT 1
+                            FROM "Vulnerabilities" v
+                            WHERE v."Id" = "VulnerabilityApplicabilities"."VulnerabilityId"
+                              AND v."Source" = 'microsoft-defender'
+                        )
+                    )
+                  )
+                  AND "VersionStartIncluding" IS NULL
+                  AND "VersionStartExcluding" IS NULL;
+                """);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Migrations/20260519120000_AddExactVersionStringMatch.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260519120000_AddExactVersionStringMatch.cs
@@ -1,0 +1,148 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using PatchHound.Infrastructure.Data;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    [DbContext(typeof(PatchHoundDbContext))]
+    [Migration("20260519120000_AddExactVersionStringMatch")]
+    public partial class AddExactVersionStringMatch : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION patchhound_version_matches(
+                    installed text,
+                    start_inc text,
+                    start_exc text,
+                    end_inc   text,
+                    end_exc   text)
+                RETURNS boolean
+                LANGUAGE plpgsql
+                IMMUTABLE
+                PARALLEL SAFE
+                AS $fn$
+                DECLARE
+                    has_predicate boolean := (start_inc IS NOT NULL AND btrim(start_inc) <> '')
+                                          OR (start_exc IS NOT NULL AND btrim(start_exc) <> '')
+                                          OR (end_inc   IS NOT NULL AND btrim(end_inc)   <> '')
+                                          OR (end_exc   IS NOT NULL AND btrim(end_exc)   <> '');
+                    has_exact_inclusive_bounds boolean := start_inc IS NOT NULL
+                                                       AND btrim(start_inc) <> ''
+                                                       AND end_inc IS NOT NULL
+                                                       AND btrim(end_inc) <> ''
+                                                       AND lower(btrim(start_inc)) = lower(btrim(end_inc))
+                                                       AND (start_exc IS NULL OR btrim(start_exc) = '')
+                                                       AND (end_exc IS NULL OR btrim(end_exc) = '');
+                    v int[];
+                    b int[];
+                BEGIN
+                    IF NOT has_predicate THEN
+                        RETURN true;
+                    END IF;
+
+                    IF has_exact_inclusive_bounds
+                       AND (installed IS NULL
+                            OR btrim(installed) = ''
+                            OR installed !~ '^[0-9]+(\.[0-9]+){1,3}$'
+                            OR start_inc !~ '^[0-9]+(\.[0-9]+){1,3}$') THEN
+                        RETURN installed IS NOT NULL
+                            AND lower(btrim(installed)) = lower(btrim(start_inc));
+                    END IF;
+
+                    IF installed IS NULL
+                       OR btrim(installed) = ''
+                       OR installed !~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        RETURN true;
+                    END IF;
+                    v := string_to_array(installed, '.')::int[];
+
+                    IF start_inc IS NOT NULL AND start_inc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(start_inc, '.')::int[];
+                        IF v < b THEN RETURN false; END IF;
+                    END IF;
+
+                    IF start_exc IS NOT NULL AND start_exc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(start_exc, '.')::int[];
+                        IF v <= b THEN RETURN false; END IF;
+                    END IF;
+
+                    IF end_inc IS NOT NULL AND end_inc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(end_inc, '.')::int[];
+                        IF v > b THEN RETURN false; END IF;
+                    END IF;
+
+                    IF end_exc IS NOT NULL AND end_exc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(end_exc, '.')::int[];
+                        IF v >= b THEN RETURN false; END IF;
+                    END IF;
+
+                    RETURN true;
+                END;
+                $fn$;
+                """);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION patchhound_version_matches(
+                    installed text,
+                    start_inc text,
+                    start_exc text,
+                    end_inc   text,
+                    end_exc   text)
+                RETURNS boolean
+                LANGUAGE plpgsql
+                IMMUTABLE
+                PARALLEL SAFE
+                AS $fn$
+                DECLARE
+                    has_predicate boolean := (start_inc IS NOT NULL AND btrim(start_inc) <> '')
+                                          OR (start_exc IS NOT NULL AND btrim(start_exc) <> '')
+                                          OR (end_inc   IS NOT NULL AND btrim(end_inc)   <> '')
+                                          OR (end_exc   IS NOT NULL AND btrim(end_exc)   <> '');
+                    v int[];
+                    b int[];
+                BEGIN
+                    IF NOT has_predicate THEN
+                        RETURN true;
+                    END IF;
+
+                    IF installed IS NULL
+                       OR btrim(installed) = ''
+                       OR installed !~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        RETURN true;
+                    END IF;
+                    v := string_to_array(installed, '.')::int[];
+
+                    IF start_inc IS NOT NULL AND start_inc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(start_inc, '.')::int[];
+                        IF v < b THEN RETURN false; END IF;
+                    END IF;
+
+                    IF start_exc IS NOT NULL AND start_exc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(start_exc, '.')::int[];
+                        IF v <= b THEN RETURN false; END IF;
+                    END IF;
+
+                    IF end_inc IS NOT NULL AND end_inc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(end_inc, '.')::int[];
+                        IF v > b THEN RETURN false; END IF;
+                    END IF;
+
+                    IF end_exc IS NOT NULL AND end_exc ~ '^[0-9]+(\.[0-9]+){1,3}$' THEN
+                        b := string_to_array(end_exc, '.')::int[];
+                        IF v >= b THEN RETURN false; END IF;
+                    END IF;
+
+                    RETURN true;
+                END;
+                $fn$;
+                """);
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/DefenderVulnerabilityEnrichmentRunner.cs
+++ b/src/PatchHound.Infrastructure/Services/DefenderVulnerabilityEnrichmentRunner.cs
@@ -231,15 +231,12 @@ public class DefenderVulnerabilityEnrichmentRunner(
 
         var applicabilities = entries
             .Where(e => !string.IsNullOrWhiteSpace(e.ProductName))
-            .Select(e => new VulnerabilityApplicabilityInput(
-                SoftwareProductId: null,
-                CpeCriteria: BuildCpeCriteria(e),
-                Vulnerable: true,
-                VersionStartIncluding: null,
-                VersionStartExcluding: null,
-                VersionEndIncluding: e.ProductVersion,
-                VersionEndExcluding: null
-            ))
+            .Select(DefenderVulnerabilitySource.BuildExactVersionApplicability)
+            .Where(a => a is not null)
+            .Select(a => a!)
+            .DistinctBy(
+                DefenderVulnerabilitySource.ApplicabilityDeduplicationKey,
+                StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         return new VulnerabilityResolveInput(
@@ -255,9 +252,6 @@ public class DefenderVulnerabilityEnrichmentRunner(
             Applicabilities: applicabilities
         );
     }
-
-    private static string BuildCpeCriteria(DefenderMachineVulnerabilityEntry entry) =>
-        $"cpe:2.3:a:{(string.IsNullOrWhiteSpace(entry.ProductVendor) ? "*" : entry.ProductVendor.ToLowerInvariant())}:{(string.IsNullOrWhiteSpace(entry.ProductName) ? "*" : entry.ProductName.ToLowerInvariant())}:*:*:*:*:*:*:*:*";
 
     private static bool IsRecoverableTimeout(Exception ex, CancellationToken ct) =>
         ex switch

--- a/src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs
+++ b/src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs
@@ -316,9 +316,9 @@ public class ExposureDerivationService(
 
     /// <summary>
     /// Returns true when the installed version satisfies every present predicate on
-    /// the applicability. Unparseable versions (either side) fall back to a match
-    /// so we don't silently drop a known-vulnerable product because of a non-numeric
-    /// version string.
+    /// the applicability. Exact inclusive bounds fall back to string equality when
+    /// numeric parsing fails. Other unparseable versions keep the permissive behavior
+    /// so bounded NVD rules do not silently drop a known-vulnerable product.
     /// </summary>
     internal static bool VersionMatches(string? installedVersion, VulnerabilityApplicability app)
         => VersionMatches(
@@ -344,6 +344,26 @@ public class ExposureDerivationService(
         if (!hasPredicate)
         {
             return true;
+        }
+
+        var hasExactInclusiveBounds =
+            !string.IsNullOrWhiteSpace(versionStartIncluding)
+            && !string.IsNullOrWhiteSpace(versionEndIncluding)
+            && string.IsNullOrWhiteSpace(versionStartExcluding)
+            && string.IsNullOrWhiteSpace(versionEndExcluding)
+            && string.Equals(
+                versionStartIncluding!.Trim(),
+                versionEndIncluding!.Trim(),
+                StringComparison.OrdinalIgnoreCase);
+
+        if (hasExactInclusiveBounds
+            && (!Version.TryParse(installedVersion, out _)
+                || !Version.TryParse(versionStartIncluding, out _)))
+        {
+            return string.Equals(
+                installedVersion?.Trim(),
+                versionStartIncluding!.Trim(),
+                StringComparison.OrdinalIgnoreCase);
         }
 
         if (string.IsNullOrWhiteSpace(installedVersion)

--- a/src/PatchHound.Infrastructure/Services/IngestionService.cs
+++ b/src/PatchHound.Infrastructure/Services/IngestionService.cs
@@ -904,7 +904,9 @@ public class IngestionService
             .Where(item => item.IngestionRunId == ingestionRunId)
             .ToListAsync(ct);
 
-        var applicabilitiesByVulnExternalId = BuildApplicabilityInputsFromStagedExposures(stagedExposures);
+        var applicabilitiesByVulnExternalId = BuildApplicabilityInputsFromStagedExposures(
+            stagedExposures,
+            sourceKey);
 
         // ── Step 1: Load and upsert staged vulnerabilities into Vulnerability table ──
         var stagedVulns = await _dbContext
@@ -1458,17 +1460,26 @@ public class IngestionService
 
     /// <summary>
     /// Derives one <see cref="VulnerabilityApplicabilityInput"/> per unique
-    /// (vendor, product, version) triple present in the staged exposure payloads,
+    /// staged exposure payload shape. Defender payloads represent confirmed
+    /// product-version matches, so they are deduped by exact CPE/version bounds.
+    /// Other staged sources keep one applicability per unique
+    /// (vendor, product, version) triple,
     /// keyed by vulnerability external id. CPE is built with
     /// <see cref="SoftwareProductResolver.DeriveCpe"/> so it matches the CPE assigned
     /// to <see cref="SoftwareProduct"/> rows created from observed software, letting
     /// <see cref="ExposureDerivationService"/> join installs ↔ applicabilities.
     /// </summary>
     private static IReadOnlyDictionary<string, IReadOnlyList<VulnerabilityApplicabilityInput>>
-        BuildApplicabilityInputsFromStagedExposures(IReadOnlyList<StagedVulnerabilityExposure> stagedExposures)
+        BuildApplicabilityInputsFromStagedExposures(
+            IReadOnlyList<StagedVulnerabilityExposure> stagedExposures,
+            string sourceKey)
     {
         var byVuln = new Dictionary<string, Dictionary<(string Cpe, string? Version), VulnerabilityApplicabilityInput>>(
             StringComparer.OrdinalIgnoreCase);
+        var usesExactVersionApplicability = string.Equals(
+            sourceKey,
+            TenantSourceCatalog.DefenderSourceKey,
+            StringComparison.OrdinalIgnoreCase);
 
         foreach (var staged in stagedExposures)
         {
@@ -1493,7 +1504,14 @@ public class IngestionService
             }
 
             var cpe = SoftwareProductResolver.DeriveCpe(asset.ProductVendor ?? string.Empty, asset.ProductName);
-            var version = string.IsNullOrWhiteSpace(asset.ProductVersion) ? null : asset.ProductVersion;
+            var version = string.IsNullOrWhiteSpace(asset.ProductVersion)
+                ? null
+                : asset.ProductVersion.Trim();
+            if (usesExactVersionApplicability && version is null)
+            {
+                continue;
+            }
+
             var key = (cpe, version);
 
             if (!byVuln.TryGetValue(staged.VulnerabilityExternalId, out var perVuln))
@@ -1508,7 +1526,7 @@ public class IngestionService
                     SoftwareProductId: null,
                     CpeCriteria: cpe,
                     Vulnerable: true,
-                    VersionStartIncluding: null,
+                    VersionStartIncluding: usesExactVersionApplicability ? version : null,
                     VersionStartExcluding: null,
                     VersionEndIncluding: version,
                     VersionEndExcluding: null);

--- a/src/PatchHound.Infrastructure/VulnerabilitySources/DefenderVulnerabilitySource.cs
+++ b/src/PatchHound.Infrastructure/VulnerabilitySources/DefenderVulnerabilitySource.cs
@@ -148,15 +148,12 @@ public class DefenderVulnerabilitySource
             var severity = NormalizeSeverity(first.Severity);
             var apps = group
                 .Where(g => !string.IsNullOrWhiteSpace(g.ProductName))
-                .Select(g => new VulnerabilityApplicabilityInput(
-                    SoftwareProductId: null,
-                    CpeCriteria: BuildCpeCriteria(g),
-                    Vulnerable: true,
-                    VersionStartIncluding: null,
-                    VersionStartExcluding: null,
-                    VersionEndIncluding: g.ProductVersion,
-                    VersionEndExcluding: null
-                ))
+                .Select(BuildExactVersionApplicability)
+                .Where(a => a is not null)
+                .Select(a => a!)
+                .DistinctBy(
+                    ApplicabilityDeduplicationKey,
+                    StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             vulns.Add(
@@ -177,6 +174,34 @@ public class DefenderVulnerabilitySource
 
         return new CanonicalVulnerabilityBatch(vulns, assessments);
     }
+
+    internal static VulnerabilityApplicabilityInput? BuildExactVersionApplicability(
+        DefenderMachineVulnerabilityEntry entry
+    )
+    {
+        if (string.IsNullOrWhiteSpace(entry.ProductVersion))
+        {
+            return null;
+        }
+
+        var version = entry.ProductVersion.Trim();
+        return new VulnerabilityApplicabilityInput(
+            SoftwareProductId: null,
+            CpeCriteria: BuildCpeCriteria(entry),
+            Vulnerable: true,
+            VersionStartIncluding: version,
+            VersionStartExcluding: null,
+            VersionEndIncluding: version,
+            VersionEndExcluding: null
+        );
+    }
+
+    internal static string ApplicabilityDeduplicationKey(VulnerabilityApplicabilityInput applicability)
+        => string.Join(
+            '\u001f',
+            applicability.CpeCriteria,
+            applicability.VersionStartIncluding,
+            applicability.VersionEndIncluding);
 
     private static string BuildCpeCriteria(DefenderMachineVulnerabilityEntry entry) =>
         $"cpe:2.3:a:{(string.IsNullOrWhiteSpace(entry.ProductVendor) ? "*" : entry.ProductVendor.ToLowerInvariant())}:{(string.IsNullOrWhiteSpace(entry.ProductName) ? "*" : entry.ProductName.ToLowerInvariant())}:*:*:*:*:*:*:*:*";

--- a/tests/PatchHound.Tests/Infrastructure/Services/DefenderVulnerabilityEnrichmentRunnerTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/DefenderVulnerabilityEnrichmentRunnerTests.cs
@@ -55,7 +55,10 @@ public class DefenderVulnerabilityEnrichmentRunnerTests
         var apps = await db.VulnerabilityApplicabilities.ToListAsync();
         apps.Should().ContainSingle();
         apps[0].CpeCriteria.Should().Be("cpe:2.3:a:microsoft:windows_server:*:*:*:*:*:*:*:*");
+        apps[0].VersionStartIncluding.Should().Be("2022");
+        apps[0].VersionStartExcluding.Should().BeNull();
         apps[0].VersionEndIncluding.Should().Be("2022");
+        apps[0].VersionEndExcluding.Should().BeNull();
     }
 
     [Fact]

--- a/tests/PatchHound.Tests/Infrastructure/Services/ExposureDerivationServiceCteTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/ExposureDerivationServiceCteTests.cs
@@ -208,6 +208,46 @@ public class ExposureDerivationServiceCteTests
     }
 
     [Fact]
+    public async Task DeriveForTenantAsync_matches_exact_unparseable_version_by_string_equality()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateDbContext();
+
+        var product = SoftwareProduct.Create("Acme", "Server", "cpe:2.3:a:acme:server:*:*:*:*:*:*:*:*");
+        var vuln = Vulnerability.Create("microsoft-defender", "CVE-2026-CTE5", "t", "d", Severity.High, 7.5m, "v", DateTimeOffset.UtcNow);
+        db.SoftwareProducts.Add(product);
+        db.Vulnerabilities.Add(vuln);
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, product.Id, null, vulnerable: true,
+            versionStartIncluding: "Release",
+            versionStartExcluding: null,
+            versionEndIncluding: "RELEASE",
+            versionEndExcluding: null));
+
+        var source = SourceSystem.Create("test", "Test");
+        db.SourceSystems.Add(source);
+        var matchingDevice = Device.Create(TenantId, source.Id, "dev-1", "Device 1", Criticality.Medium);
+        var otherDevice = Device.Create(TenantId, source.Id, "dev-2", "Device 2", Criticality.Medium);
+        db.Devices.AddRange(matchingDevice, otherDevice);
+        var runId = Guid.NewGuid();
+        db.InstalledSoftware.Add(InstalledSoftware.Observe(
+            TenantId, matchingDevice.Id, product.Id, source.Id, "release", DateTimeOffset.UtcNow, runId));
+        db.InstalledSoftware.Add(InstalledSoftware.Observe(
+            TenantId, otherDevice.Id, product.Id, source.Id, "2023", DateTimeOffset.UtcNow, runId));
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureDerivationService(
+            db, NullLogger<ExposureDerivationService>.Instance, new PostgresBulkExposureWriter(db));
+
+        var result = await svc.DeriveForTenantAsync(TenantId, DateTimeOffset.UtcNow, runId, CancellationToken.None);
+
+        result.Inserted.Should().Be(1);
+        var exposure = await db.DeviceVulnerabilityExposures.AsNoTracking().IgnoreQueryFilters().SingleAsync();
+        exposure.DeviceId.Should().Be(matchingDevice.Id);
+        exposure.MatchedVersion.Should().Be("release");
+    }
+
+    [Fact]
     public async Task DeriveForTenantAsync_derives_across_installs_from_other_sources_prior_runs()
     {
         // Regression test: derivation must be source-agnostic. Each ingestion source

--- a/tests/PatchHound.Tests/Infrastructure/Services/ExposureDerivationServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/ExposureDerivationServiceTests.cs
@@ -14,6 +14,30 @@ namespace PatchHound.Tests.Infrastructure.Services;
 public class ExposureDerivationServiceTests
 {
     [Fact]
+    public void VersionMatches_requires_string_equality_for_unparseable_exact_inclusive_bounds()
+    {
+        ExposureDerivationService
+            .VersionMatches("2022", "2022", null, "2022", null)
+            .Should()
+            .BeTrue();
+
+        ExposureDerivationService
+            .VersionMatches("release", "Release", null, "RELEASE", null)
+            .Should()
+            .BeTrue();
+
+        ExposureDerivationService
+            .VersionMatches("2023", "2022", null, "2022", null)
+            .Should()
+            .BeFalse();
+
+        ExposureDerivationService
+            .VersionMatches(null, "2022", null, "2022", null)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
     public async Task Derives_exposure_for_product_keyed_applicability()
     {
         var tenantId = Guid.NewGuid();

--- a/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/IngestionServicePhase3Tests.cs
@@ -218,23 +218,18 @@ public class IngestionServicePhase3Tests
     }
 
     /// <summary>
-    /// Regression test for the Phase 3 refactor gap: when a source stages a vulnerability
-    /// with per-device <see cref="IngestionAffectedAsset"/> payload carrying ProductVendor
-    /// and ProductName, <see cref="IngestionService.ProcessStagedResultsAsync"/> must
-    /// populate a <see cref="VulnerabilityApplicability"/> row so that
-    /// <see cref="ExposureDerivationService"/> can match installed software against the
-    /// vulnerability. Without this, the applicabilities table stays empty and every
-    /// exposure produced by ProcessStagedResults gets immediately resolved by the
-    /// derivation pass.
+    /// Defender's machine vulnerability stream reports exact vulnerable product versions.
+    /// PatchHound should reuse that exact-version CPE rule for another machine with the
+    /// same installed version, without marking newer fixed versions vulnerable.
     /// </summary>
     [Fact]
-    public async Task ProcessStagedResultsAsync_creates_applicability_from_staged_payload_and_enables_exposure_derivation()
+    public async Task ProcessStagedResultsAsync_creates_exact_version_defender_applicability()
     {
         var tenantId = Guid.NewGuid();
         await using var db = await CreateTenantDbAsync(tenantId);
 
         var product = SoftwareProduct.Create(
-            "Microsoft", "Edge", "cpe:2.3:a:microsoft:edge:*:*:*:*:*:*:*:*");
+            "Microsoft", "Teams", "cpe:2.3:a:microsoft:teams:*:*:*:*:*:*:*:*");
         db.SoftwareProducts.Add(product);
 
         var sourceSystem = SourceSystem.Create("microsoft-defender", "Defender");
@@ -251,30 +246,42 @@ public class IngestionServicePhase3Tests
             SecurityRequirementLevel.High);
         db.SecurityProfiles.Add(profile);
 
-        var device = Device.Create(tenantId, sourceSystem.Id, "machine-1", "Machine 1", Criticality.High);
-        device.AssignSecurityProfile(profile.Id);
-        db.Devices.Add(device);
+        var vulnerableDevice = Device.Create(tenantId, sourceSystem.Id, "desktop-b33jt1r", "desktop-b33jt1r", Criticality.High);
+        vulnerableDevice.AssignSecurityProfile(profile.Id);
+        var sameVersionDevice = Device.Create(tenantId, sourceSystem.Id, "atreides", "atreides", Criticality.High);
+        sameVersionDevice.AssignSecurityProfile(profile.Id);
+        var fixedDevice = Device.Create(tenantId, sourceSystem.Id, "fenris", "fenris", Criticality.High);
+        fixedDevice.AssignSecurityProfile(profile.Id);
+        db.Devices.AddRange(vulnerableDevice, sameVersionDevice, fixedDevice);
 
         var run = IngestionRun.Start(tenantId, "microsoft-defender", DateTimeOffset.UtcNow);
         db.IngestionRuns.Add(run);
-        db.InstalledSoftware.Add(InstalledSoftware.Observe(
-            tenantId, device.Id, product.Id, sourceSystem.Id, "120.0", DateTimeOffset.UtcNow, run.Id));
+        db.InstalledSoftware.AddRange(
+            InstalledSoftware.Observe(
+                tenantId, vulnerableDevice.Id, product.Id, sourceSystem.Id,
+                "24277.3102.3183.2670", DateTimeOffset.UtcNow, run.Id),
+            InstalledSoftware.Observe(
+                tenantId, sameVersionDevice.Id, product.Id, sourceSystem.Id,
+                "24277.3102.3183.2670", DateTimeOffset.UtcNow, run.Id),
+            InstalledSoftware.Observe(
+                tenantId, fixedDevice.Id, product.Id, sourceSystem.Id,
+                "26032.208.4399.5", DateTimeOffset.UtcNow, run.Id));
 
         db.StagedVulnerabilities.Add(StagedVulnerability.Create(
             run.Id, tenantId, "microsoft-defender",
-            "CVE-2026-APPL", "Edge vuln", Severity.High, "{}", DateTimeOffset.UtcNow));
+            "CVE-2025-53783", "Teams vuln", Severity.High, "{}", DateTimeOffset.UtcNow));
 
         var affectedAsset = new IngestionAffectedAsset(
-            ExternalAssetId: "machine-1",
-            AssetName: "Machine 1",
+            ExternalAssetId: "desktop-b33jt1r",
+            AssetName: "desktop-b33jt1r",
             AssetType: AssetType.Device,
             ProductVendor: "Microsoft",
-            ProductName: "Edge",
-            ProductVersion: "120.0");
+            ProductName: "Teams",
+            ProductVersion: "24277.3102.3183.2670");
 
         db.StagedVulnerabilityExposures.Add(StagedVulnerabilityExposure.Create(
             run.Id, tenantId, "microsoft-defender",
-            "CVE-2026-APPL", "machine-1", "Machine 1",
+            "CVE-2025-53783", "desktop-b33jt1r", "desktop-b33jt1r",
             AssetType.Device,
             JsonSerializer.Serialize(affectedAsset, StagingSerializerOptions.Instance),
             DateTimeOffset.UtcNow));
@@ -287,20 +294,22 @@ public class IngestionServicePhase3Tests
             run.Id, tenantId, "microsoft-defender", snapshotId: null, "Defender", CancellationToken.None);
 
         var apps = await db.VulnerabilityApplicabilities.ToListAsync();
-        apps.Should().ContainSingle("staged payload's vendor/product should produce one applicability");
-        apps[0].CpeCriteria.Should().Be("cpe:2.3:a:microsoft:edge:*:*:*:*:*:*:*:*");
-        apps[0].Vulnerable.Should().BeTrue();
-        apps[0].VersionEndIncluding.Should().Be("120.0",
-            "applicability should carry the observed product version as the end-including predicate");
+        apps.Should().ContainSingle("Defender machine evidence should create one exact-version reusable CPE rule");
+        apps[0].CpeCriteria.Should().Be("cpe:2.3:a:microsoft:teams:*:*:*:*:*:*:*:*");
+        apps[0].VersionStartIncluding.Should().Be("24277.3102.3183.2670");
+        apps[0].VersionStartExcluding.Should().BeNull();
+        apps[0].VersionEndIncluding.Should().Be("24277.3102.3183.2670");
+        apps[0].VersionEndExcluding.Should().BeNull();
 
         await ingestion.RunExposureDerivationAsync(tenantId, run.Id, CancellationToken.None);
 
         var exposures = await db.DeviceVulnerabilityExposures
             .Where(e => e.Status != ExposureStatus.Resolved)
+            .Include(e => e.Device)
             .ToListAsync();
-        exposures.Should().ContainSingle(
-            "derivation must produce one live exposure from the installed software × new applicability match");
-        exposures[0].DeviceId.Should().Be(device.Id);
+        exposures.Select(e => e.Device.Name).Should().BeEquivalentTo(
+            ["desktop-b33jt1r", "atreides"],
+            "same product/version should be vulnerable, but newer fixed Teams should not");
     }
 
     [Fact]

--- a/tests/PatchHound.Tests/Infrastructure/Testing/FakeDefenderApiClient.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Testing/FakeDefenderApiClient.cs
@@ -13,6 +13,10 @@ public sealed class FakeDefenderApiClient : DefenderApiClient
         _machineVulnerabilities = machineVulnerabilities;
     }
 
+    public static FakeDefenderApiClient WithMachineVulnerabilities(
+        params DefenderMachineVulnerabilityEntry[] entries
+    ) => new(new DefenderMachineVulnerabilityResponse { Value = entries.ToList() });
+
     public static FakeDefenderApiClient WithSingleVulnerability(
         string cveId,
         Severity severity,

--- a/tests/PatchHound.Tests/Infrastructure/VulnerabilitySources/DefenderVulnerabilitySourceCanonicalTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/VulnerabilitySources/DefenderVulnerabilitySourceCanonicalTests.cs
@@ -17,4 +17,59 @@ public class DefenderVulnerabilitySourceCanonicalTests
         Assert.Equal("CVE-2026-0099", batch.Vulnerabilities[0].ExternalId);
         Assert.Equal("microsoft-defender", batch.Vulnerabilities[0].Source);
     }
+
+    [Fact]
+    public async Task FetchCanonicalVulnerabilitiesAsync_creates_exact_version_defender_applicabilities()
+    {
+        var apiClient = FakeDefenderApiClient.WithMachineVulnerabilities(
+            new DefenderMachineVulnerabilityEntry
+            {
+                Id = "entry-1",
+                CveId = "CVE-2026-0099",
+                MachineId = "machine-1",
+                MachineName = "Server01",
+                ProductName = "OpenSSL",
+                ProductVendor = "OpenSSL",
+                ProductVersion = "3.0.8.0",
+                Severity = "High",
+                CvssV3 = 8.5m,
+            },
+            new DefenderMachineVulnerabilityEntry
+            {
+                Id = "entry-2",
+                CveId = "CVE-2026-0099",
+                MachineId = "machine-2",
+                MachineName = "Server02",
+                ProductName = "OpenSSL",
+                ProductVendor = "OpenSSL",
+                ProductVersion = "3.0.13.0",
+                Severity = "High",
+                CvssV3 = 8.5m,
+            });
+        var source = new DefenderVulnerabilitySource(
+            apiClient,
+            FakeDefenderConfigProvider.Default(),
+            NullLogger<DefenderVulnerabilitySource>.Instance);
+
+        var batch = await source.FetchCanonicalVulnerabilitiesAsync(
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        var applicabilities = batch.Vulnerabilities[0].Applicabilities
+            .OrderBy(a => a.VersionStartIncluding, StringComparer.Ordinal)
+            .ToList();
+        Assert.Equal(2, applicabilities.Count);
+        Assert.All(
+            applicabilities,
+            applicability =>
+            {
+                Assert.Equal("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*", applicability.CpeCriteria);
+                Assert.Null(applicability.VersionStartExcluding);
+                Assert.Null(applicability.VersionEndExcluding);
+            });
+        Assert.Equal("3.0.13.0", applicabilities[0].VersionStartIncluding);
+        Assert.Equal("3.0.13.0", applicabilities[0].VersionEndIncluding);
+        Assert.Equal("3.0.8.0", applicabilities[1].VersionStartIncluding);
+        Assert.Equal("3.0.8.0", applicabilities[1].VersionEndIncluding);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #81.

- convert Defender per-machine ProductVersion evidence into exact-version applicability rules (`VersionStartIncluding == VersionEndIncluding == ProductVersion`)
- dedupe Defender applicabilities by CPE and exact version so repeated machine rows do not multiply identical rules
- reuse the same exact-version applicability shape in Defender enrichment
- add migrations that delete legacy Defender applicability rows with no lower bound and keep SQL exact-version matching consistent with the in-memory matcher

## Root Cause

Defender's machine vulnerability stream reports one row per vulnerable machine/software install. PatchHound was treating the installed version from that machine as a vulnerable upper bound, which turned each row into an overly broad rule like any install <= this version is vulnerable.

The desired behavior is not a direct machine-only evidence model. If Defender reports a product/version as vulnerable on one machine, the same product/version should be considered vulnerable on another machine even if Defender has not reported that second machine yet. Different versions must not inherit that exposure.

## Verification

- dotnet test --filter "FullyQualifiedName~IngestionServicePhase3Tests.ProcessStagedResultsAsync_creates_exact_version_defender_applicability|FullyQualifiedName~DefenderVulnerabilitySourceCanonicalTests|FullyQualifiedName~DefenderVulnerabilityEnrichmentRunnerTests|FullyQualifiedName~ExposureDerivationServiceTests.VersionMatches_requires_string_equality_for_unparseable_exact_inclusive_bounds|FullyQualifiedName~ExposureDerivationServiceCteTests.DeriveForTenantAsync_matches_exact_unparseable_version_by_string_equality"
- dotnet test PatchHound.slnx -v minimal
- npx gitnexus analyze
