### PR TITLE
feat(risk-score): share-based tenant risk formula + dedicated bands

### DIFF
--- a/frontend/src/components/features/dashboard/MetricInfoTooltip.tsx
+++ b/frontend/src/components/features/dashboard/MetricInfoTooltip.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from 'react'
 import { CircleQuestionMark } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
-export function MetricInfoTooltip({ content }: { content: string }) {
+export function MetricInfoTooltip({ content }: { content: ReactNode }) {
   return (
     <Tooltip>
       <TooltipTrigger className="inline-flex items-center text-muted-foreground/80 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:text-foreground">

--- a/frontend/src/components/features/dashboard/RiskScoreCard.tsx
+++ b/frontend/src/components/features/dashboard/RiskScoreCard.tsx
@@ -8,7 +8,7 @@ import { Sparkline } from '@/components/features/dashboard/Sparkline'
 import { fetchRiskScoreSummary, recalculateRiskScores } from '@/api/risk-score.functions'
 import type { RiskScoreSummary } from '@/api/risk-score.schemas'
 import { useTenantScope } from '@/components/layout/tenant-scope'
-import { riskScoreBand } from '@/lib/risk-scoring'
+import { tenantRiskScoreBand, TENANT_RISK_SCORE_THRESHOLDS } from '@/lib/risk-scoring'
 import { MetricInfoTooltip } from './MetricInfoTooltip'
 import { RiskScoreDetailDialog } from './RiskScoreDetailDialog'
 
@@ -108,9 +108,12 @@ export function RiskScoreCard({ isLoading: parentLoading, filters }: RiskScoreCa
         <div className={`space-y-5 p-5 lg:p-6 ${posture.heroPanelBg}`}>
           <div className="flex items-start justify-between gap-4">
                 <div className="space-y-3">
-                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                    Current Risk Score
-                  </p>
+                  <div className="flex items-center gap-1.5">
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                      Current Risk Score
+                    </p>
+                    <InfoTooltip content={<RiskBandTooltipContent />} />
+                  </div>
                   <div className="flex flex-wrap items-end gap-3">
                     <p className="text-5xl font-semibold tracking-[-0.05em]">
                       {summary.overallScore.toFixed(0)}
@@ -335,6 +338,70 @@ function MetricTile({ label, tooltip, value, tone }: { label: string; tooltip: s
   )
 }
 
+function RiskBandTooltipContent() {
+  const rows: Array<{
+    band: string
+    range: string
+    tone: string
+    description: string
+  }> = [
+    {
+      band: 'Critical',
+      range: `≥ ${TENANT_RISK_SCORE_THRESHOLDS.critical}`,
+      tone: 'text-destructive',
+      description: 'Saturated High+ fleet, or significant penetration of critical-band assets.',
+    },
+    {
+      band: 'High',
+      range: `${TENANT_RISK_SCORE_THRESHOLDS.high}–${TENANT_RISK_SCORE_THRESHOLDS.critical - 1}`,
+      tone: 'text-tone-warning-foreground',
+      description: 'Meaningful critical share, or mixed-pressure fleet with widespread high-severity exposure.',
+    },
+    {
+      band: 'Medium',
+      range: `${TENANT_RISK_SCORE_THRESHOLDS.medium}–${TENANT_RISK_SCORE_THRESHOLDS.high - 1}`,
+      tone: 'text-chart-2',
+      description: 'A handful of critical findings in a mostly clean fleet, or some sustained High-band pressure.',
+    },
+    {
+      band: 'Low',
+      range: `1–${TENANT_RISK_SCORE_THRESHOLDS.medium - 1}`,
+      tone: 'text-chart-3',
+      description: 'Sparse exposure. Watch new drivers; maintain remediation velocity.',
+    },
+    {
+      band: 'None',
+      range: '0',
+      tone: 'text-muted-foreground',
+      description: 'No active exposure detected.',
+    },
+  ]
+
+  return (
+    <div className="space-y-2">
+      <p className="font-medium">Tenant risk bands</p>
+      <p className="text-xs text-muted-foreground">
+        Tenant score combines the worst single asset, the top-five asset average, and fleet-wide
+        severity shares. Higher fleet penetration of a severity band raises the score even when
+        the worst single asset is unchanged.
+      </p>
+      <div className="space-y-1.5 pt-1">
+        {rows.map((row) => (
+          <div key={row.band} className="flex gap-2">
+            <span className={`w-16 shrink-0 text-xs font-semibold uppercase tracking-wide ${row.tone}`}>
+              {row.band}
+            </span>
+            <span className="w-20 shrink-0 text-xs tabular-nums text-muted-foreground">
+              {row.range}
+            </span>
+            <span className="text-xs">{row.description}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function formatUtcTimestamp(value: string) {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) {
@@ -345,7 +412,7 @@ function formatUtcTimestamp(value: string) {
 }
 
 function riskPosture(score: number) {
-  const band = riskScoreBand(score)
+  const band = tenantRiskScoreBand(score)
 
   if (band === 'critical') {
     return {

--- a/frontend/src/lib/risk-scoring.ts
+++ b/frontend/src/lib/risk-scoring.ts
@@ -16,10 +16,30 @@ export const RISK_SCORE_RANGES = {
   critical: '850-1000',
 } as const
 
+export const TENANT_RISK_SCORE_THRESHOLDS = {
+  medium: 200,
+  high: 400,
+  critical: 600,
+} as const
+
+export const TENANT_RISK_SCORE_RANGES = {
+  low: '1-199',
+  medium: '200-399',
+  high: '400-599',
+  critical: '600-1000',
+} as const
+
 export function riskScoreBand(score: number): RiskScoreBand {
   if (score >= RISK_SCORE_THRESHOLDS.critical) return 'critical'
   if (score >= RISK_SCORE_THRESHOLDS.high) return 'high'
   if (score >= RISK_SCORE_THRESHOLDS.medium) return 'medium'
+  return 'low'
+}
+
+export function tenantRiskScoreBand(score: number): RiskScoreBand {
+  if (score >= TENANT_RISK_SCORE_THRESHOLDS.critical) return 'critical'
+  if (score >= TENANT_RISK_SCORE_THRESHOLDS.high) return 'high'
+  if (score >= TENANT_RISK_SCORE_THRESHOLDS.medium) return 'medium'
   return 'low'
 }
 

--- a/src/PatchHound.Api/Controllers/DashboardController.cs
+++ b/src/PatchHound.Api/Controllers/DashboardController.cs
@@ -1789,7 +1789,12 @@ public class DashboardController : ControllerBase
             ))
             .ToListAsync(ct);
 
-        var tenantRisk = RiskScoreService.CalculateTenantRisk(assetScores);
+        var totalDeviceCount = filteredAssetIds is not null
+            ? await filteredAssetIds.CountAsync(ct)
+            : await _dbContext.Devices.AsNoTracking()
+                .CountAsync(device => device.TenantId == tenantId, ct);
+
+        var tenantRisk = RiskScoreService.CalculateTenantRisk(assetScores, totalDeviceCount);
         var scoreDelta = hasFilters
             ? null
             : await CalculateTenantRiskDeltaAsync(tenantId, tenantRisk.OverallScore, ct);
@@ -1951,7 +1956,7 @@ public class DashboardController : ControllerBase
 
     private static string DescribeRiskLevel(decimal score)
     {
-        var riskBand = RiskBand.FromScore(score);
+        var riskBand = TenantRiskBand.FromScore(score);
 
         return riskBand switch
         {

--- a/src/PatchHound.Core/Services/RiskScoring/TenantRiskBand.cs
+++ b/src/PatchHound.Core/Services/RiskScoring/TenantRiskBand.cs
@@ -1,0 +1,17 @@
+namespace PatchHound.Core.Services.RiskScoring;
+
+public static class TenantRiskBand
+{
+    public const decimal MediumThreshold = 200m;
+    public const decimal HighThreshold = 400m;
+    public const decimal CriticalThreshold = 600m;
+
+    public static string FromScore(decimal score) => score switch
+    {
+        >= CriticalThreshold => "Critical",
+        >= HighThreshold => "High",
+        >= MediumThreshold => "Medium",
+        > 0m => "Low",
+        _ => "None",
+    };
+}

--- a/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
+++ b/src/PatchHound.Infrastructure/Services/RiskScoreService.cs
@@ -315,17 +315,22 @@ public class RiskScoreService(
             .OrderByDescending(item => item.OverallScore)
             .ToListAsync(ct);
 
-        return CalculateTenantRisk(deviceScores.Select(item => new AssetRiskResult(
-            item.DeviceId,
-            item.OverallScore,
-            item.MaxEpisodeRiskScore,
-            item.CriticalCount,
-            item.HighCount,
-            item.MediumCount,
-            item.LowCount,
-            item.OpenEpisodeCount,
-            item.FactorsJson
-        )).ToList());
+        var totalDeviceCount = await dbContext.Devices.AsNoTracking()
+            .CountAsync(item => item.TenantId == tenantId, ct);
+
+        return CalculateTenantRisk(
+            deviceScores.Select(item => new AssetRiskResult(
+                item.DeviceId,
+                item.OverallScore,
+                item.MaxEpisodeRiskScore,
+                item.CriticalCount,
+                item.HighCount,
+                item.MediumCount,
+                item.LowCount,
+                item.OpenEpisodeCount,
+                item.FactorsJson
+            )).ToList(),
+            totalDeviceCount);
     }
 
     public async Task<TenantRiskResult> GetFilteredTenantRiskAsync(
@@ -336,30 +341,33 @@ public class RiskScoreService(
         CancellationToken ct
     )
     {
-        var query = dbContext.DeviceRiskScores.AsNoTracking()
-            .Where(item => item.TenantId == tenantId)
-            .Join(
-                dbContext.Devices.AsNoTracking().Where(item => item.TenantId == tenantId),
-                score => score.DeviceId,
-                device => device.Id,
-                (score, device) => new { score, device }
-            );
+        var devicesQuery = dbContext.Devices.AsNoTracking()
+            .Where(item => item.TenantId == tenantId);
 
         if (minAgeDays.HasValue)
         {
             var cutoff = DateTimeOffset.UtcNow.AddDays(-minAgeDays.Value);
-            query = query.Where(item => item.device.LastSeenAt == null || item.device.LastSeenAt <= cutoff);
+            devicesQuery = devicesQuery.Where(item => item.LastSeenAt == null || item.LastSeenAt <= cutoff);
         }
 
         if (!string.IsNullOrWhiteSpace(platform))
         {
-            query = query.Where(item => item.device.OsPlatform != null && item.device.OsPlatform.Contains(platform));
+            devicesQuery = devicesQuery.Where(item => item.OsPlatform != null && item.OsPlatform.Contains(platform));
         }
 
         if (!string.IsNullOrWhiteSpace(deviceGroup))
         {
-            query = query.Where(item => item.device.GroupName != null && item.device.GroupName == deviceGroup);
+            devicesQuery = devicesQuery.Where(item => item.GroupName != null && item.GroupName == deviceGroup);
         }
+
+        var query = dbContext.DeviceRiskScores.AsNoTracking()
+            .Where(item => item.TenantId == tenantId)
+            .Join(
+                devicesQuery,
+                score => score.DeviceId,
+                device => device.Id,
+                (score, device) => new { score, device }
+            );
 
         var filtered = await query
             .OrderByDescending(item => item.score.OverallScore)
@@ -376,7 +384,9 @@ public class RiskScoreService(
             ))
             .ToListAsync(ct);
 
-        return CalculateTenantRisk(filtered);
+        var filteredDeviceCount = await devicesQuery.CountAsync(ct);
+
+        return CalculateTenantRisk(filtered, filteredDeviceCount);
     }
 
     public async Task<List<TenantRiskScoreSnapshot>> GetRiskHistoryAsync(Guid tenantId, CancellationToken ct)
@@ -388,7 +398,7 @@ public class RiskScoreService(
             .ToListAsync(ct);
     }
 
-    public static TenantRiskResult CalculateTenantRisk(IReadOnlyList<AssetRiskResult> assetScores)
+    public static TenantRiskResult CalculateTenantRisk(IReadOnlyList<AssetRiskResult> assetScores, int totalDeviceCount)
     {
         if (assetScores.Count == 0)
         {
@@ -405,14 +415,22 @@ public class RiskScoreService(
         var mediumAssetCount = ordered.Count(item => item.OverallScore >= RiskBand.MediumThreshold && item.OverallScore < RiskBand.HighThreshold);
         var lowAssetCount = ordered.Count(item => item.OverallScore > 0m && item.OverallScore < RiskBand.MediumThreshold);
 
+        // Denominator falls back to scored assets if total fleet count is missing or smaller than
+        // the scored set, so shares stay in [0, 1] under bad inputs.
+        var denominator = Math.Max(totalDeviceCount, ordered.Count);
+        var criticalShare = ShareOf(criticalAssetCount, denominator);
+        var highShare = ShareOf(highAssetCount, denominator);
+        var mediumShare = ShareOf(mediumAssetCount, denominator);
+        var lowShare = ShareOf(lowAssetCount, denominator);
+
         var score = Math.Clamp(
             Math.Round(
-                (0.55m * maxAsset)
-                + (0.30m * topFiveAverage)
-                + Math.Min(criticalAssetCount * 18m, 90m)
-                + Math.Min(highAssetCount * 8m, 40m)
-                + Math.Min(mediumAssetCount * 2m, 10m)
-                + Math.Min(lowAssetCount * 0.5m, 5m),
+                (0.20m * maxAsset)
+                + (0.10m * topFiveAverage)
+                + (ConcaveShare(criticalShare) * 400m)
+                + (ConcaveShare(highShare) * 200m)
+                + (ConcaveShare(mediumShare) * 70m)
+                + (ConcaveShare(lowShare) * 30m),
                 2),
             0m,
             1000m);
@@ -425,6 +443,12 @@ public class RiskScoreService(
             ordered
         );
     }
+
+    private static decimal ShareOf(int count, int denominator) =>
+        denominator <= 0 ? 0m : Math.Clamp((decimal)count / denominator, 0m, 1m);
+
+    private static decimal ConcaveShare(decimal share) =>
+        share <= 0m ? 0m : (decimal)Math.Sqrt((double)share);
 
     private async Task<List<AssetRiskResult>> CalculateAssetScoresAsync(Guid tenantId, CancellationToken ct)
     {
@@ -852,7 +876,9 @@ public class RiskScoreService(
         CancellationToken ct
     )
     {
-        var tenantRisk = CalculateTenantRisk(assetScores);
+        var totalDeviceCount = await dbContext.Devices.AsNoTracking()
+            .CountAsync(item => item.TenantId == tenantId, ct);
+        var tenantRisk = CalculateTenantRisk(assetScores, totalDeviceCount);
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         var existing = await dbContext.TenantRiskScoreSnapshots
             .FirstOrDefaultAsync(item => item.TenantId == tenantId && item.Date == today, ct);

--- a/tests/PatchHound.Tests/Api/DashboardControllerExecutiveSummaryTests.cs
+++ b/tests/PatchHound.Tests/Api/DashboardControllerExecutiveSummaryTests.cs
@@ -52,7 +52,7 @@ public class DashboardControllerExecutiveSummaryTests : IDisposable
         _dbContext.TenantRiskScoreSnapshots.Add(TenantRiskScoreSnapshot.Create(
             _tenantId,
             DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
-            700m,
+            500m,
             2,
             0,
             1));
@@ -63,7 +63,7 @@ public class DashboardControllerExecutiveSummaryTests : IDisposable
         dto.ExposureScore.Should().BeGreaterThan(0m);
         dto.ExecutiveExposure.Should().NotBeNull();
         dto.ExecutiveExposure!.Score.Should().Be(dto.ExposureScore);
-        dto.ExecutiveExposure.RiskLevel.Should().Be("High");
+        dto.ExecutiveExposure.RiskLevel.Should().Be("Critical");
         dto.ExecutiveExposure.ScoreDelta.Should().BeGreaterThan(0m);
         dto.ExecutiveExposure.Trend.Should().Be("Worsening");
         dto.ExecutiveExposure.Scope.Should().Be("Tenant");

--- a/tests/PatchHound.Tests/Infrastructure/RiskScoreServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/RiskScoreServiceTests.cs
@@ -92,13 +92,28 @@ public class RiskScoreServiceTests : IDisposable
                 new RiskScoreService.AssetRiskResult(Guid.NewGuid(), 810m, 800m, 0, 2, 0, 0, 2, "[]"),
                 new RiskScoreService.AssetRiskResult(Guid.NewGuid(), 120m, 120m, 0, 0, 0, 3, 3, "[]"),
                 new RiskScoreService.AssetRiskResult(Guid.NewGuid(), 85m, 85m, 0, 0, 0, 1, 1, "[]")
-            ]
+            ],
+            totalDeviceCount: 4
         );
 
         result.AssetCount.Should().Be(4);
         result.CriticalAssetCount.Should().Be(1);
         result.HighAssetCount.Should().Be(1);
-        result.OverallScore.Should().BeGreaterThan(700m);
+        result.OverallScore.Should().BeGreaterThan(400m);
+    }
+
+    [Fact]
+    public void CalculateTenantRisk_FleetSizeDilutesShare()
+    {
+        var assetScores = new[]
+        {
+            new RiskScoreService.AssetRiskResult(Guid.NewGuid(), 965m, 950m, 2, 0, 0, 0, 2, "[]"),
+        };
+
+        var smallFleet = RiskScoreService.CalculateTenantRisk(assetScores, totalDeviceCount: 4);
+        var largeFleet = RiskScoreService.CalculateTenantRisk(assetScores, totalDeviceCount: 2800);
+
+        smallFleet.OverallScore.Should().BeGreaterThan(largeFleet.OverallScore);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Tenant risk previously hit ~993 on any fleet with a handful of critical findings: the formula weighted the worst single asset at 55%, top-five average at 30%, and used count caps that saturated at 5 devices, so a 2,800-device fleet and a 28-device fleet scored essentially identically.
- This PR replaces count caps with concave fleet-penetration shares (`sqrt(share) * B`) and reduces the worst-asset dominance from 55/30 to 20/10. Shares use the full tenant fleet as denominator (filtered fleet for filtered views).
- Adds a dedicated `TenantRiskBand` (Medium=200, High=400, Critical=600) so tenant headline banding is calibrated independently of asset-level scoring (`RiskBand` unchanged). The Risk Score card gets a tooltip explaining each band.

### New formula

```
score = 0.20 * maxAsset
      + 0.10 * topFiveAverage
      + sqrt(criticalShare) * 400
      + sqrt(highShare)     * 200
      + sqrt(mediumShare)   *  70
      + sqrt(lowShare)      *  30
```

### Sanity check

For a 2837-asset fleet with 19 critical + 2818 high (the case that prompted this redesign), the headline drops from **993 → ~532** and lands in the new "High" band. A single critical asset in a clean 2800-device fleet now registers around 308 instead of pinning to ~993.

## Test plan

- [x] `dotnet test` — 843/843 passing
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Manually verify the Risk Score card on staging: tooltip renders, band label matches new thresholds, filtered view shares use the filtered fleet as denominator
- [ ] Note for release: existing `TenantRiskScoreSnapshot` rows were computed with the old formula — the 30-day sparkline will show a one-time step-down on deploy day
- [ ] Run `npx gitnexus analyze` post-merge to refresh the knowledge graph (index currently stale per local hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)