### PR TITLE
feat(ai-profile): expose response format and Ollama num_ctx controls

### DIFF
--- a/frontend/src/api/ai-settings.schemas.ts
+++ b/frontend/src/api/ai-settings.schemas.ts
@@ -26,6 +26,8 @@ export const tenantAiProfileSchema = z.object({
   lastValidatedAt: nullableIsoDateTimeSchema,
   lastValidationStatus: z.string(),
   lastValidationError: z.string(),
+  numCtx: z.number().int().positive().nullable(),
+  responseFormat: z.enum(['None', 'Json']),
 })
 
 export const saveTenantAiProfileSchema = z.object({
@@ -50,6 +52,8 @@ export const saveTenantAiProfileSchema = z.object({
   maxResearchSources: z.number().int().positive(),
   allowedDomains: z.string(),
   apiKey: z.string(),
+  numCtx: z.number().int().positive().nullable().optional(),
+  responseFormat: z.enum(['None', 'Json']).optional(),
 })
 
 export const tenantAiProfileValidationSchema = z.object({

--- a/frontend/src/components/features/settings/TenantAiSettingsPage.tsx
+++ b/frontend/src/components/features/settings/TenantAiSettingsPage.tsx
@@ -121,6 +121,8 @@ function createEmptyProfile(): SaveTenantAiProfile {
     maxResearchSources: 5,
     allowedDomains: '',
     apiKey: '',
+    numCtx: null,
+    responseFormat: 'None',
   }
 }
 
@@ -147,6 +149,8 @@ function toDraft(profile: TenantAiProfile): SaveTenantAiProfile {
     maxResearchSources: profile.maxResearchSources,
     allowedDomains: profile.allowedDomains,
     apiKey: '',
+    numCtx: profile.numCtx,
+    responseFormat: profile.responseFormat,
   }
 }
 
@@ -724,12 +728,31 @@ function AiProfileEditorPage({
               ) : null}
 
               {draft.providerType === 'Ollama' ? (
-                <Field label="Keep alive" tooltip="Optional Ollama keep-alive value, for example 5m.">
-                  <Input
-                    value={draft.keepAlive}
-                    onChange={(event) => onDraftChange((current) => ({ ...current, keepAlive: event.target.value }))}
-                  />
-                </Field>
+                <>
+                  <Field label="Keep alive" tooltip="Optional Ollama keep-alive value, for example 5m.">
+                    <Input
+                      value={draft.keepAlive}
+                      onChange={(event) => onDraftChange((current) => ({ ...current, keepAlive: event.target.value }))}
+                    />
+                  </Field>
+                  <Field
+                    label="Context window (num_ctx)"
+                    tooltip="Optional Ollama context size in tokens. Leave blank to use the model default (often 2048, which silently truncates long prompts). 8192 is a safe choice for vuln assessment prompts."
+                  >
+                    <Input
+                      type="number"
+                      min="1"
+                      placeholder="Model default"
+                      value={draft.numCtx ?? ''}
+                      onChange={(event) =>
+                        onDraftChange((current) => ({
+                          ...current,
+                          numCtx: event.target.value === '' ? null : Number(event.target.value),
+                        }))
+                      }
+                    />
+                  </Field>
+                </>
               ) : null}
 
               {draft.providerType !== 'Ollama' ? (
@@ -811,6 +834,28 @@ function AiProfileEditorPage({
                     }))
                   }
                 />
+              </Field>
+              <Field
+                label="Response format"
+                tooltip="Force the provider to return strict JSON. Recommended for structured assessment jobs that parse the response."
+              >
+                <Select
+                  value={draft.responseFormat ?? 'None'}
+                  onValueChange={(value) =>
+                    onDraftChange((current) => ({
+                      ...current,
+                      responseFormat: value as SaveTenantAiProfile['responseFormat'],
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="None">Free text</SelectItem>
+                    <SelectItem value="Json">JSON</SelectItem>
+                  </SelectContent>
+                </Select>
               </Field>
             </div>
           </FormSection>

--- a/src/PatchHound.Api/Controllers/TenantAiProfilesController.cs
+++ b/src/PatchHound.Api/Controllers/TenantAiProfilesController.cs
@@ -471,8 +471,7 @@ public class TenantAiProfilesController : ControllerBase
             return new ProblemDetails { Title = "Num ctx must be greater than 0 when provided." };
         }
 
-        if (!string.IsNullOrWhiteSpace(request.ResponseFormat)
-            && !Enum.TryParse<TenantAiResponseFormat>(request.ResponseFormat, true, out _))
+        if (!TryParseResponseFormat(request.ResponseFormat, out _))
         {
             return new ProblemDetails { Title = "Response format must be 'None' or 'Json'." };
         }
@@ -572,16 +571,35 @@ public class TenantAiProfilesController : ControllerBase
             profile.ResponseFormat.ToString()
         );
 
-    private static TenantAiResponseFormat ResolveResponseFormat(string? value)
+    private static TenantAiResponseFormat ResolveResponseFormat(string? value) =>
+        TryParseResponseFormat(value, out var parsed) ? parsed : TenantAiResponseFormat.None;
+
+    private static bool TryParseResponseFormat(string? value, out TenantAiResponseFormat result)
     {
+        result = TenantAiResponseFormat.None;
         if (string.IsNullOrWhiteSpace(value))
         {
-            return TenantAiResponseFormat.None;
+            return true;
         }
 
-        return Enum.TryParse<TenantAiResponseFormat>(value, true, out var parsed)
-            ? parsed
-            : TenantAiResponseFormat.None;
+        // Reject numeric strings ("0", "1", "2") - the public API contract is the named enum values only.
+        if (int.TryParse(value, out _))
+        {
+            return false;
+        }
+
+        if (!Enum.TryParse<TenantAiResponseFormat>(value, ignoreCase: true, out var parsed))
+        {
+            return false;
+        }
+
+        if (!Enum.IsDefined(typeof(TenantAiResponseFormat), parsed))
+        {
+            return false;
+        }
+
+        result = parsed;
+        return true;
     }
 
     private static TenantAiWebResearchMode ResolveWebResearchMode(

--- a/src/PatchHound.Api/Controllers/TenantAiProfilesController.cs
+++ b/src/PatchHound.Api/Controllers/TenantAiProfilesController.cs
@@ -98,7 +98,9 @@ public class TenantAiProfilesController : ControllerBase
             webResearchMode: ResolveWebResearchMode(request),
             includeCitations: request.IncludeCitations,
             maxResearchSources: request.MaxResearchSources,
-            allowedDomains: request.AllowedDomains
+            allowedDomains: request.AllowedDomains,
+            numCtx: request.NumCtx,
+            responseFormat: ResolveResponseFormat(request.ResponseFormat)
         );
 
         var secretRef = BuildSecretRef(tenantId, profile.Id);
@@ -128,7 +130,9 @@ public class TenantAiProfilesController : ControllerBase
                 ResolveWebResearchMode(request),
                 request.IncludeCitations,
                 request.MaxResearchSources,
-                request.AllowedDomains
+                request.AllowedDomains,
+                request.NumCtx,
+                ResolveResponseFormat(request.ResponseFormat)
             );
         }
 
@@ -158,7 +162,9 @@ public class TenantAiProfilesController : ControllerBase
                 ResolveWebResearchMode(request),
                 request.IncludeCitations,
                 request.MaxResearchSources,
-                request.AllowedDomains
+                request.AllowedDomains,
+                request.NumCtx,
+                ResolveResponseFormat(request.ResponseFormat)
             );
         }
 
@@ -241,7 +247,9 @@ public class TenantAiProfilesController : ControllerBase
             ResolveWebResearchMode(request),
             request.IncludeCitations,
             request.MaxResearchSources,
-            request.AllowedDomains
+            request.AllowedDomains,
+            request.NumCtx,
+            ResolveResponseFormat(request.ResponseFormat)
         );
         profile.ResetValidation();
 
@@ -292,7 +300,9 @@ public class TenantAiProfilesController : ControllerBase
             profile.WebResearchMode,
             profile.IncludeCitations,
             profile.MaxResearchSources,
-            profile.AllowedDomains
+            profile.AllowedDomains,
+            profile.NumCtx,
+            profile.ResponseFormat
         );
 
         await _dbContext.SaveChangesAsync(ct);
@@ -402,7 +412,9 @@ public class TenantAiProfilesController : ControllerBase
                 profile.WebResearchMode,
                 profile.IncludeCitations,
                 profile.MaxResearchSources,
-                profile.AllowedDomains
+                profile.AllowedDomains,
+                profile.NumCtx,
+                profile.ResponseFormat
             );
         }
     }
@@ -452,6 +464,17 @@ public class TenantAiProfilesController : ControllerBase
         if (request.TimeoutSeconds <= 0)
         {
             return new ProblemDetails { Title = "Timeout seconds must be greater than 0." };
+        }
+
+        if (request.NumCtx is int ctx && ctx <= 0)
+        {
+            return new ProblemDetails { Title = "Num ctx must be greater than 0 when provided." };
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ResponseFormat)
+            && !Enum.TryParse<TenantAiResponseFormat>(request.ResponseFormat, true, out _))
+        {
+            return new ProblemDetails { Title = "Response format must be 'None' or 'Json'." };
         }
 
         if (request.IsDefault && !request.IsEnabled)
@@ -544,8 +567,22 @@ public class TenantAiProfilesController : ControllerBase
             !string.IsNullOrWhiteSpace(profile.SecretRef),
             profile.LastValidatedAt,
             profile.LastValidationStatus.ToString(),
-            profile.LastValidationError
+            profile.LastValidationError,
+            profile.NumCtx,
+            profile.ResponseFormat.ToString()
         );
+
+    private static TenantAiResponseFormat ResolveResponseFormat(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return TenantAiResponseFormat.None;
+        }
+
+        return Enum.TryParse<TenantAiResponseFormat>(value, true, out var parsed)
+            ? parsed
+            : TenantAiResponseFormat.None;
+    }
 
     private static TenantAiWebResearchMode ResolveWebResearchMode(
         SaveTenantAiProfileRequest request

--- a/src/PatchHound.Api/Models/Settings/TenantAiProfileDto.cs
+++ b/src/PatchHound.Api/Models/Settings/TenantAiProfileDto.cs
@@ -24,7 +24,9 @@ public record TenantAiProfileDto(
     bool HasSecret,
     DateTimeOffset? LastValidatedAt,
     string LastValidationStatus,
-    string LastValidationError
+    string LastValidationError,
+    int? NumCtx,
+    string ResponseFormat
 );
 
 public record SaveTenantAiProfileRequest(
@@ -47,7 +49,9 @@ public record SaveTenantAiProfileRequest(
     bool IncludeCitations,
     int MaxResearchSources,
     string AllowedDomains,
-    string ApiKey
+    string ApiKey,
+    int? NumCtx,
+    string? ResponseFormat
 );
 
 public record TenantAiProfileValidationResultDto(

--- a/src/PatchHound.Core/Entities/TenantAiProfile.cs
+++ b/src/PatchHound.Core/Entities/TenantAiProfile.cs
@@ -16,6 +16,8 @@ public class TenantAiProfile
     public decimal? TopP { get; private set; }
     public int MaxOutputTokens { get; private set; }
     public int TimeoutSeconds { get; private set; }
+    public int? NumCtx { get; private set; }
+    public TenantAiResponseFormat ResponseFormat { get; private set; }
     public string BaseUrl { get; private set; } = string.Empty;
     public string DeploymentName { get; private set; } = string.Empty;
     public string ApiVersion { get; private set; } = string.Empty;
@@ -55,7 +57,9 @@ public class TenantAiProfile
         TenantAiWebResearchMode webResearchMode = TenantAiWebResearchMode.Disabled,
         bool includeCitations = true,
         int maxResearchSources = 5,
-        string allowedDomains = ""
+        string allowedDomains = "",
+        int? numCtx = null,
+        TenantAiResponseFormat responseFormat = TenantAiResponseFormat.None
     )
     {
         var now = DateTimeOffset.UtcNow;
@@ -73,6 +77,8 @@ public class TenantAiProfile
             TopP = topP,
             MaxOutputTokens = maxOutputTokens,
             TimeoutSeconds = timeoutSeconds,
+            NumCtx = ValidateNumCtx(numCtx),
+            ResponseFormat = responseFormat,
             BaseUrl = baseUrl.Trim(),
             DeploymentName = deploymentName.Trim(),
             ApiVersion = apiVersion.Trim(),
@@ -108,7 +114,9 @@ public class TenantAiProfile
         TenantAiWebResearchMode webResearchMode,
         bool includeCitations,
         int maxResearchSources,
-        string allowedDomains
+        string allowedDomains,
+        int? numCtx,
+        TenantAiResponseFormat responseFormat
     )
     {
         Name = name.Trim();
@@ -120,6 +128,8 @@ public class TenantAiProfile
         TopP = topP;
         MaxOutputTokens = maxOutputTokens;
         TimeoutSeconds = timeoutSeconds;
+        NumCtx = ValidateNumCtx(numCtx);
+        ResponseFormat = responseFormat;
         BaseUrl = baseUrl.Trim();
         DeploymentName = deploymentName.Trim();
         ApiVersion = apiVersion.Trim();
@@ -150,5 +160,20 @@ public class TenantAiProfile
         LastValidationStatus = TenantAiProfileValidationStatus.Unknown;
         LastValidationError = string.Empty;
         UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private static int? ValidateNumCtx(int? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+        if (value < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                "NumCtx must be a positive integer when provided.");
+        }
+        return value;
     }
 }

--- a/src/PatchHound.Core/Enums/TenantAiResponseFormat.cs
+++ b/src/PatchHound.Core/Enums/TenantAiResponseFormat.cs
@@ -1,0 +1,7 @@
+namespace PatchHound.Core.Enums;
+
+public enum TenantAiResponseFormat
+{
+    None = 0,
+    Json = 1,
+}

--- a/src/PatchHound.Infrastructure/AiProviders/AzureOpenAiProvider.cs
+++ b/src/PatchHound.Infrastructure/AiProviders/AzureOpenAiProvider.cs
@@ -114,19 +114,23 @@ public class AzureOpenAiProvider : IAiReportProvider
 
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
         request.Headers.Add("api-key", profile.ApiKey);
-        request.Content = JsonContent.Create(
-            new
+        var payload = new Dictionary<string, object?>
+        {
+            ["messages"] = new[]
             {
-                messages = new[]
-                {
-                    new { role = "system", content = systemPrompt },
-                    new { role = "user", content = userPrompt },
-                },
-                temperature = decimal.ToDouble(profile.Profile.Temperature),
-                top_p = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
-                max_tokens = maxTokens,
-            }
-        );
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = userPrompt },
+            },
+            ["temperature"] = decimal.ToDouble(profile.Profile.Temperature),
+            ["top_p"] = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
+            ["max_tokens"] = maxTokens,
+        };
+        if (profile.Profile.ResponseFormat == TenantAiResponseFormat.Json)
+        {
+            payload["response_format"] = new { type = "json_object" };
+        }
+
+        request.Content = JsonContent.Create(payload);
 
         using var response = await _httpClient.SendAsync(request, ct);
         var body = await response.Content.ReadAsStringAsync(ct);

--- a/src/PatchHound.Infrastructure/AiProviders/OllamaAiProvider.cs
+++ b/src/PatchHound.Infrastructure/AiProviders/OllamaAiProvider.cs
@@ -165,24 +165,34 @@ public class OllamaAiProvider : IAiReportProvider
             HttpMethod.Post,
             $"{NormalizeBaseUrl(profile.Profile.BaseUrl)}/generate"
         );
-        request.Content = JsonContent.Create(
-            new
-            {
-                model = profile.Profile.Model,
-                stream = false,
-                keep_alive = string.IsNullOrWhiteSpace(profile.Profile.KeepAlive)
-                    ? null
-                    : profile.Profile.KeepAlive,
-                system = systemPrompt,
-                prompt,
-                options = new
-                {
-                    temperature = decimal.ToDouble(profile.Profile.Temperature),
-                    top_p = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
-                    num_predict = maxTokens,
-                },
-            }
-        );
+        var options = new Dictionary<string, object?>
+        {
+            ["temperature"] = decimal.ToDouble(profile.Profile.Temperature),
+            ["top_p"] = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
+            ["num_predict"] = maxTokens,
+        };
+        if (profile.Profile.NumCtx is int numCtx)
+        {
+            options["num_ctx"] = numCtx;
+        }
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = profile.Profile.Model,
+            ["stream"] = false,
+            ["keep_alive"] = string.IsNullOrWhiteSpace(profile.Profile.KeepAlive)
+                ? null
+                : profile.Profile.KeepAlive,
+            ["system"] = systemPrompt,
+            ["prompt"] = prompt,
+            ["options"] = options,
+        };
+        if (profile.Profile.ResponseFormat == TenantAiResponseFormat.Json)
+        {
+            payload["format"] = "json";
+        }
+
+        request.Content = JsonContent.Create(payload);
 
         using var response = await _httpClient.SendAsync(request, ct);
         var body = await response.Content.ReadAsStringAsync(ct);
@@ -225,21 +235,25 @@ public class OllamaAiProvider : IAiReportProvider
             HttpMethod.Post,
             $"{NormalizeOpenAiBaseUrl(profile.Profile.BaseUrl)}/chat/completions"
         );
-        request.Content = JsonContent.Create(
-            new
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = profile.Profile.Model,
+            ["messages"] = new object[]
             {
-                model = profile.Profile.Model,
-                messages = new object[]
-                {
-                    new { role = "system", content = systemPrompt },
-                    new { role = "user", content = prompt },
-                },
-                stream = false,
-                temperature = decimal.ToDouble(profile.Profile.Temperature),
-                top_p = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
-                max_tokens = maxTokens,
-            }
-        );
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = prompt },
+            },
+            ["stream"] = false,
+            ["temperature"] = decimal.ToDouble(profile.Profile.Temperature),
+            ["top_p"] = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
+            ["max_tokens"] = maxTokens,
+        };
+        if (profile.Profile.ResponseFormat == TenantAiResponseFormat.Json)
+        {
+            payload["response_format"] = new { type = "json_object" };
+        }
+
+        request.Content = JsonContent.Create(payload);
 
         using var response = await _httpClient.SendAsync(request, ct);
         var body = await response.Content.ReadAsStringAsync(ct);

--- a/src/PatchHound.Infrastructure/AiProviders/OpenAiProvider.cs
+++ b/src/PatchHound.Infrastructure/AiProviders/OpenAiProvider.cs
@@ -170,20 +170,24 @@ public class OpenAiProvider : IAiReportProvider
             $"{profile.Profile.BaseUrl.TrimEnd('/')}/chat/completions"
         );
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", profile.ApiKey);
-        request.Content = JsonContent.Create(
-            new
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = profile.Profile.Model,
+            ["messages"] = new[]
             {
-                model = profile.Profile.Model,
-                messages = new[]
-                {
-                    new { role = "system", content = systemPrompt },
-                    new { role = "user", content = userPrompt },
-                },
-                temperature = decimal.ToDouble(profile.Profile.Temperature),
-                top_p = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
-                max_completion_tokens = maxTokens,
-            }
-        );
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = userPrompt },
+            },
+            ["temperature"] = decimal.ToDouble(profile.Profile.Temperature),
+            ["top_p"] = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
+            ["max_completion_tokens"] = maxTokens,
+        };
+        if (profile.Profile.ResponseFormat == TenantAiResponseFormat.Json)
+        {
+            payload["response_format"] = new { type = "json_object" };
+        }
+
+        request.Content = JsonContent.Create(payload);
 
         using var response = await _httpClient.SendAsync(request, ct);
         var body = await response.Content.ReadAsStringAsync(ct);
@@ -236,27 +240,31 @@ public class OpenAiProvider : IAiReportProvider
             $"{profile.Profile.BaseUrl.TrimEnd('/')}/responses"
         );
         httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", profile.ApiKey);
-        httpRequest.Content = JsonContent.Create(
-            new
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = profile.Profile.Model,
+            ["input"] = new object[]
             {
-                model = profile.Profile.Model,
-                input = new object[]
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = userPrompt },
+            },
+            ["tools"] = new object[]
+            {
+                new
                 {
-                    new { role = "system", content = systemPrompt },
-                    new { role = "user", content = userPrompt },
+                    type = "web_search_preview",
                 },
-                tools = new object[]
-                {
-                    new
-                    {
-                        type = "web_search_preview",
-                    },
-                },
-                temperature = decimal.ToDouble(profile.Profile.Temperature),
-                top_p = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
-                max_output_tokens = maxTokens,
-            }
-        );
+            },
+            ["temperature"] = decimal.ToDouble(profile.Profile.Temperature),
+            ["top_p"] = profile.Profile.TopP is decimal topP ? decimal.ToDouble(topP) : (double?)null,
+            ["max_output_tokens"] = maxTokens,
+        };
+        if (profile.Profile.ResponseFormat == TenantAiResponseFormat.Json)
+        {
+            payload["text"] = new { format = new { type = "json_object" } };
+        }
+
+        httpRequest.Content = JsonContent.Create(payload);
 
         using var response = await _httpClient.SendAsync(httpRequest, ct);
         var body = await response.Content.ReadAsStringAsync(ct);

--- a/src/PatchHound.Infrastructure/Data/Configurations/TenantAiProfileConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/TenantAiProfileConfiguration.cs
@@ -34,5 +34,9 @@ public class TenantAiProfileConfiguration : IEntityTypeConfiguration<TenantAiPro
         builder.Property(item => item.LastValidationError).HasMaxLength(1024).IsRequired();
         builder.Property(item => item.Temperature).HasPrecision(4, 2);
         builder.Property(item => item.TopP).HasPrecision(4, 2);
+        builder
+            .Property(item => item.ResponseFormat)
+            .HasConversion<string>()
+            .HasMaxLength(16);
     }
 }

--- a/src/PatchHound.Infrastructure/Migrations/20260521051248_AddAiProfileFormatAndContext.Designer.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260521051248_AddAiProfileFormatAndContext.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521051248_AddAiProfileFormatAndContext")]
+    partial class AddAiProfileFormatAndContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1600,87 +1603,6 @@ namespace PatchHound.Infrastructure.Migrations
                         .IsUnique();
 
                     b.ToTable("DeviceVulnerabilityExposures");
-                });
-
-            modelBuilder.Entity("PatchHound.Core.Entities.EnrichmentChangeLog", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("ChangeReason")
-                        .HasMaxLength(1024)
-                        .HasColumnType("character varying(1024)");
-
-                    b.Property<DateTimeOffset>("ChangedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<decimal?>("Confidence")
-                        .HasPrecision(6, 4)
-                        .HasColumnType("numeric(6,4)");
-
-                    b.Property<string>("DisplayName")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.Property<Guid?>("EnrichmentJobId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("EnrichmentRunId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("EntityId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("EntityType")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<string>("FieldPath")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.Property<string>("NewValueJson")
-                        .HasColumnType("text");
-
-                    b.Property<string>("OldValueJson")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Scope")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.Property<string>("SourceKey")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<Guid?>("TenantId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("ValueKind")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("EnrichmentJobId");
-
-                    b.HasIndex("EnrichmentRunId");
-
-                    b.HasIndex("Scope", "TenantId", "SourceKey", "ChangedAt");
-
-                    b.HasIndex("Scope", "TenantId", "EntityType", "EntityId", "ChangedAt");
-
-                    b.ToTable("EnrichmentChangeLog", null, t =>
-                        {
-                            t.HasCheckConstraint("CK_EnrichmentChangeLog_Scope_TenantId", "(\"Scope\" = 'Global' AND \"TenantId\" IS NULL) OR (\"Scope\" = 'Tenant' AND \"TenantId\" IS NOT NULL)");
-                        });
                 });
 
             modelBuilder.Entity("PatchHound.Core.Entities.EnrichmentJob", b =>

--- a/src/PatchHound.Infrastructure/Migrations/20260521051248_AddAiProfileFormatAndContext.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260521051248_AddAiProfileFormatAndContext.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAiProfileFormatAndContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "NumCtx",
+                table: "TenantAiProfiles",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ResponseFormat",
+                table: "TenantAiProfiles",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                defaultValue: "None");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NumCtx",
+                table: "TenantAiProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ResponseFormat",
+                table: "TenantAiProfiles");
+        }
+    }
+}

--- a/tests/PatchHound.Tests/Api/TenantAiProfilesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/TenantAiProfilesControllerTests.cs
@@ -79,7 +79,9 @@ public class TenantAiProfilesControllerTests : IDisposable
                 true,
                 5,
                 "",
-                "secret-value"
+                "secret-value",
+                null,
+                null
             ),
             CancellationToken.None
         );
@@ -192,7 +194,9 @@ public class TenantAiProfilesControllerTests : IDisposable
                 true,
                 5,
                 "",
-                "secret-value"
+                "secret-value",
+                null,
+                null
             ),
             CancellationToken.None
         );
@@ -237,7 +241,9 @@ public class TenantAiProfilesControllerTests : IDisposable
                 true,
                 5,
                 "",
-                ""
+                "",
+                null,
+                null
             ),
             CancellationToken.None
         );

--- a/tests/PatchHound.Tests/Api/TenantAiProfilesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/TenantAiProfilesControllerTests.cs
@@ -205,6 +205,44 @@ public class TenantAiProfilesControllerTests : IDisposable
         (await _dbContext.TenantAiProfiles.CountAsync()).Should().Be(0);
     }
 
+    [Theory]
+    [InlineData("2")]
+    [InlineData("0")]
+    [InlineData("Bogus")]
+    public async Task Create_InvalidResponseFormat_ReturnsBadRequest(string responseFormat)
+    {
+        var action = await _controller.Create(
+            new SaveTenantAiProfileRequest(
+                "Default",
+                "OpenAi",
+                true,
+                true,
+                "gpt-4.1-mini",
+                "Prompt",
+                0.2m,
+                1.0m,
+                1200,
+                60,
+                "https://api.openai.com/v1",
+                "",
+                "",
+                "",
+                false,
+                "Disabled",
+                true,
+                5,
+                "",
+                "secret-value",
+                null,
+                responseFormat
+            ),
+            CancellationToken.None
+        );
+
+        action.Result.Should().BeOfType<BadRequestObjectResult>();
+        (await _dbContext.TenantAiProfiles.CountAsync()).Should().Be(0);
+    }
+
     [Fact]
     public async Task Update_ProfileConfiguration_ResetsValidationStatus()
     {


### PR DESCRIPTION
## Summary

- Adds **ResponseFormat** (None | Json) and **NumCtx** (nullable int) to `TenantAiProfile` so vuln assessment jobs can opt into strict JSON output and override Ollama's default 2k context window that silently truncates long prompts.
- ResponseFormat is plumbed across all providers (Ollama generate `format: "json"`, Ollama/OpenAI/Azure chat `response_format: { type: "json_object" }`, OpenAI Responses API `text.format`). NumCtx is Ollama-only — other providers manage context server-side, and the UI hides the field for them.
- New migration `AddAiProfileFormatAndContext`; existing rows default to `ResponseFormat = "None"`.

## Frontend

A **Response format** select sits in the Runtime controls section of the AI Settings form (universal). A **Context window (num_ctx)** field appears next to Keep alive when the provider is Ollama.

## Test plan

- [x] `dotnet test` — 856/856 passing
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Manually verify: create an Ollama profile, set NumCtx=8192 and ResponseFormat=Json, run a vuln assessment, confirm the request body in Ollama logs contains both fields
- [ ] Verify Azure/OpenAI profiles still send `response_format: { type: "json_object" }` when Json selected
- [ ] Run `npx gitnexus analyze` post-merge to refresh the knowledge graph (index currently stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)