### PR TITLE
fix(ai): restore long timeouts and make TimeoutSeconds live

### DIFF
--- a/src/PatchHound.Api/Controllers/TenantAiProfilesController.cs
+++ b/src/PatchHound.Api/Controllers/TenantAiProfilesController.cs
@@ -461,9 +461,9 @@ public class TenantAiProfilesController : ControllerBase
             return new ProblemDetails { Title = "Max output tokens must be greater than 0." };
         }
 
-        if (request.TimeoutSeconds <= 0)
+        if (request.TimeoutSeconds <= 0 || request.TimeoutSeconds > 3600)
         {
-            return new ProblemDetails { Title = "Timeout seconds must be greater than 0." };
+            return new ProblemDetails { Title = "Timeout seconds must be between 1 and 3600." };
         }
 
         if (request.NumCtx is int ctx && ctx <= 0)

--- a/src/PatchHound.Core/Services/TenantAiTextGenerationService.cs
+++ b/src/PatchHound.Core/Services/TenantAiTextGenerationService.cs
@@ -53,10 +53,23 @@ public class TenantAiTextGenerationService
             );
         }
 
+        var timeoutSeconds = resolvedProfile.Profile.TimeoutSeconds;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        if (timeoutSeconds > 0)
+        {
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+        }
+
         string content;
         try
         {
-            content = await provider.GenerateTextAsync(request, resolvedProfile, ct);
+            content = await provider.GenerateTextAsync(request, resolvedProfile, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            return Result<AiTextGenerationResult>.Failure(
+                $"AI generation timed out after {timeoutSeconds}s (per-profile TimeoutSeconds)."
+            );
         }
         catch (Exception ex)
         {

--- a/src/PatchHound.Core/Services/TenantAiTextGenerationService.cs
+++ b/src/PatchHound.Core/Services/TenantAiTextGenerationService.cs
@@ -53,7 +53,14 @@ public class TenantAiTextGenerationService
             );
         }
 
-        var timeoutSeconds = resolvedProfile.Profile.TimeoutSeconds;
+        // Clamp at one hour: well above the AI HttpClient ceiling (5 min) so it's
+        // effectively dead code, but it guarantees CancelAfter cannot throw on a
+        // pathological value from legacy data.
+        const int maxTimeoutSeconds = 3600;
+        var rawTimeoutSeconds = resolvedProfile.Profile.TimeoutSeconds;
+        var timeoutSeconds = rawTimeoutSeconds > 0
+            ? Math.Min(rawTimeoutSeconds, maxTimeoutSeconds)
+            : 0;
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         if (timeoutSeconds > 0)
         {

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -166,18 +166,20 @@ public static class DependencyInjection
         services.Configure<SmtpOptions>(configuration.GetSection("Smtp"));
 
         // AI Report Providers
+        //
+        // HttpClient timeout here is a safety ceiling that protects against the request hanging
+        // indefinitely (network/socket-level issues). The user-facing per-request timeout is
+        // applied in TenantAiTextGenerationService from TenantAiProfile.TimeoutSeconds.
+        var aiSafetyCeiling = TimeSpan.FromMinutes(5);
         services
             .AddHttpClient<OllamaAiProvider>()
-            .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromMinutes(3))
-            .AddExternalHttpPolicies(maxConnectionsPerServer: 4);
+            .AddExternalHttpPolicies(maxConnectionsPerServer: 4, requestTimeout: aiSafetyCeiling);
         services
             .AddHttpClient<AzureOpenAiProvider>()
-            .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromMinutes(3))
-            .AddExternalHttpPolicies(maxConnectionsPerServer: 4);
+            .AddExternalHttpPolicies(maxConnectionsPerServer: 4, requestTimeout: aiSafetyCeiling);
         services
             .AddHttpClient<OpenAiProvider>()
-            .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromMinutes(3))
-            .AddExternalHttpPolicies(maxConnectionsPerServer: 4);
+            .AddExternalHttpPolicies(maxConnectionsPerServer: 4, requestTimeout: aiSafetyCeiling);
         services.AddScoped<IAiReportProvider>(sp => sp.GetRequiredService<OllamaAiProvider>());
         services.AddScoped<IAiReportProvider>(sp => sp.GetRequiredService<AzureOpenAiProvider>());
         services.AddScoped<IAiReportProvider>(sp => sp.GetRequiredService<OpenAiProvider>());

--- a/src/PatchHound.Infrastructure/ExternalHttp/ExternalHttpResiliencePolicies.cs
+++ b/src/PatchHound.Infrastructure/ExternalHttp/ExternalHttpResiliencePolicies.cs
@@ -35,9 +35,11 @@ internal static class ExternalHttpResiliencePolicies
 
     public static IHttpClientBuilder AddExternalHttpPolicies(
         this IHttpClientBuilder builder,
-        int maxConnectionsPerServer
+        int maxConnectionsPerServer,
+        TimeSpan? requestTimeout = null
     )
     {
+        var effectiveTimeout = requestTimeout ?? DefaultRequestTimeout;
         return builder
             .ConfigurePrimaryHttpMessageHandler(() =>
                 new SocketsHttpHandler
@@ -49,7 +51,7 @@ internal static class ExternalHttpResiliencePolicies
                     ConnectTimeout = ConnectTimeout,
                 }
             )
-            .ConfigureHttpClient(client => client.Timeout = DefaultRequestTimeout)
+            .ConfigureHttpClient(client => client.Timeout = effectiveTimeout)
             .AddPolicyHandler(
                 (serviceProvider, _) =>
                 {

--- a/tests/PatchHound.Tests/Api/TenantAiProfilesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/TenantAiProfilesControllerTests.cs
@@ -206,6 +206,45 @@ public class TenantAiProfilesControllerTests : IDisposable
     }
 
     [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(3601)]
+    [InlineData(int.MaxValue)]
+    public async Task Create_TimeoutSecondsOutOfRange_ReturnsBadRequest(int timeoutSeconds)
+    {
+        var action = await _controller.Create(
+            new SaveTenantAiProfileRequest(
+                "Default",
+                "OpenAi",
+                true,
+                true,
+                "gpt-4.1-mini",
+                "Prompt",
+                0.2m,
+                1.0m,
+                1200,
+                timeoutSeconds,
+                "https://api.openai.com/v1",
+                "",
+                "",
+                "",
+                false,
+                "Disabled",
+                true,
+                5,
+                "",
+                "secret-value",
+                null,
+                null
+            ),
+            CancellationToken.None
+        );
+
+        action.Result.Should().BeOfType<BadRequestObjectResult>();
+        (await _dbContext.TenantAiProfiles.CountAsync()).Should().Be(0);
+    }
+
+    [Theory]
     [InlineData("2")]
     [InlineData("0")]
     [InlineData("Bogus")]

--- a/tests/PatchHound.Tests/Core/TenantAiTextGenerationServiceTests.cs
+++ b/tests/PatchHound.Tests/Core/TenantAiTextGenerationServiceTests.cs
@@ -48,6 +48,38 @@ public class TenantAiTextGenerationServiceTests
     }
 
     [Fact]
+    public async Task GenerateResolvedAsync_ClampsAbsurdProfileTimeoutToOneHour()
+    {
+        // A TimeoutSeconds value that overflows CancelAfter's TimeSpan limit must not
+        // bubble out as ArgumentOutOfRangeException. The service clamps internally.
+        var tenantId = Guid.NewGuid();
+        var profile = TenantAiProfileFactory.Create(tenantId, timeoutSeconds: int.MaxValue);
+        var resolved = new TenantAiProfileResolved(profile, "secret");
+
+        var provider = Substitute.For<IAiReportProvider>();
+        provider.ProviderType.Returns(TenantAiProviderType.OpenAi);
+        provider
+            .GenerateTextAsync(Arg.Any<AiTextGenerationRequest>(), Arg.Any<TenantAiProfileResolved>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("ok"));
+
+        var service = new TenantAiTextGenerationService([provider], Substitute.For<ITenantAiConfigurationResolver>());
+
+        var act = async () => await service.GenerateResolvedAsync(
+            resolved,
+            new AiTextGenerationRequest(
+                SystemPrompt: string.Empty,
+                UserPrompt: "test",
+                ExternalContext: null,
+                UseProviderNativeWebResearch: false,
+                MaxResearchSources: 0,
+                IncludeCitations: false,
+                MaxOutputTokens: 100),
+            CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task GenerateResolvedAsync_OuterCancellationPropagatesAsGenericFailure()
     {
         var tenantId = Guid.NewGuid();

--- a/tests/PatchHound.Tests/Core/TenantAiTextGenerationServiceTests.cs
+++ b/tests/PatchHound.Tests/Core/TenantAiTextGenerationServiceTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using NSubstitute;
+using PatchHound.Core.Common;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Core.Services;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Core;
+
+public class TenantAiTextGenerationServiceTests
+{
+    [Fact]
+    public async Task GenerateResolvedAsync_AppliesProfileTimeoutSecondsToProviderCall()
+    {
+        var tenantId = Guid.NewGuid();
+        var profile = TenantAiProfileFactory.Create(tenantId, timeoutSeconds: 1);
+        var resolved = new TenantAiProfileResolved(profile, "secret");
+
+        var provider = Substitute.For<IAiReportProvider>();
+        provider.ProviderType.Returns(TenantAiProviderType.OpenAi);
+        provider
+            .GenerateTextAsync(Arg.Any<AiTextGenerationRequest>(), Arg.Any<TenantAiProfileResolved>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var providerCt = call.Arg<CancellationToken>();
+                await Task.Delay(TimeSpan.FromSeconds(5), providerCt);
+                return "should not reach";
+            });
+
+        var service = new TenantAiTextGenerationService([provider], Substitute.For<ITenantAiConfigurationResolver>());
+
+        var result = await service.GenerateResolvedAsync(
+            resolved,
+            new AiTextGenerationRequest(
+                SystemPrompt: string.Empty,
+                UserPrompt: "test",
+                ExternalContext: null,
+                UseProviderNativeWebResearch: false,
+                MaxResearchSources: 0,
+                IncludeCitations: false,
+                MaxOutputTokens: 100),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("timed out after 1s");
+    }
+
+    [Fact]
+    public async Task GenerateResolvedAsync_OuterCancellationPropagatesAsGenericFailure()
+    {
+        var tenantId = Guid.NewGuid();
+        var profile = TenantAiProfileFactory.Create(tenantId, timeoutSeconds: 60);
+        var resolved = new TenantAiProfileResolved(profile, "secret");
+
+        var provider = Substitute.For<IAiReportProvider>();
+        provider.ProviderType.Returns(TenantAiProviderType.OpenAi);
+        provider
+            .GenerateTextAsync(Arg.Any<AiTextGenerationRequest>(), Arg.Any<TenantAiProfileResolved>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var providerCt = call.Arg<CancellationToken>();
+                await Task.Delay(TimeSpan.FromSeconds(5), providerCt);
+                return "should not reach";
+            });
+
+        var service = new TenantAiTextGenerationService([provider], Substitute.For<ITenantAiConfigurationResolver>());
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        var result = await service.GenerateResolvedAsync(
+            resolved,
+            new AiTextGenerationRequest(
+                SystemPrompt: string.Empty,
+                UserPrompt: "test",
+                ExternalContext: null,
+                UseProviderNativeWebResearch: false,
+                MaxResearchSources: 0,
+                IncludeCitations: false,
+                MaxOutputTokens: 100),
+            cts.Token);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().NotContain("timed out after");
+    }
+}


### PR DESCRIPTION
## Summary

While diagnosing failing Ollama vulnerability assessment jobs, found that **every** AI provider HttpClient was running with a 20-second timeout instead of the intended 3 minutes. Ollama logs showed exactly 20-second 500s; the DB confirmed 157 jobs failed with `HttpClient.Timeout of 20 seconds elapsing` / `The operation was canceled`.

### Root cause

`ExternalHttpResiliencePolicies.AddExternalHttpPolicies` set `client.Timeout = 20s` unconditionally. The AI provider DI registrations looked correct at a glance:

```csharp
.AddHttpClient<OllamaAiProvider>()
.ConfigureHttpClient(client => client.Timeout = TimeSpan.FromMinutes(3))   // intended
.AddExternalHttpPolicies(maxConnectionsPerServer: 4);                       // overrides → 20s
```

But `ConfigureHttpClient` appends a configurator; configurators run in registration order, and the 20-second one inside the policy helper was last. Local 32B models on Apple Silicon routinely take 30–90s per assessment — every Ollama call was being canceled mid-stream.

Separately, `TenantAiProfile.TimeoutSeconds` was a configurable field that the entity / DTO / controller / migration all carried, but **no code ever applied it** to any operation. Dead config.

### Fix

- `AddExternalHttpPolicies` now accepts an optional `TimeSpan? requestTimeout`. Default remains 20s — that's a sensible aggressive ceiling for general external HTTP (NVD, EndOfLife, supply chain feeds, etc.). AI providers pass a **5-minute safety ceiling** instead, leaving the user-facing knob to be the per-profile value.
- `TenantAiTextGenerationService.GenerateResolvedAsync` wraps the provider call in a `CancellationTokenSource.CreateLinkedTokenSource(ct)` and `CancelAfter(profile.TimeoutSeconds)`. Cancellation caused by the per-profile CTS is mapped to a distinct error (`"AI generation timed out after Ns (per-profile TimeoutSeconds)"`) so it doesn't get confused with outer cancellation.
- New `TenantAiTextGenerationServiceTests` covers both paths.

### After deploy

Once the container is rebuilt, requeue the 175 affected rows:

```sql
UPDATE "VulnerabilityAssessmentJobs"
SET "Status" = 'Pending', "Error" = '', "StartedAt" = NULL, "CompletedAt" = NULL, "UpdatedAt" = NOW()
WHERE "Status" = 'Failed' AND "Error" LIKE 'AI generation%';
```

Not included in this PR: the 145 jobs failing with `No enabled default AI profile is configured for this tenant`. That's a separate design question (cross-tenant AI profile fallback vs. not enqueueing the job in the first place) — flagged in the diagnostic discussion, not addressed here.

## Test plan

- [x] `dotnet test` — 861/861 passing
- [ ] Rebuild + restart `worker` container, requeue rows with the SQL above
- [ ] Confirm Ollama logs no longer show 20-second 500s
- [ ] Confirm `profile.TimeoutSeconds` actually bounds the request — set it to 5s temporarily, watch a job fail with the new "timed out after 5s" message
- [ ] Verify NVD / EndOfLife / Defender / Mailgun HTTP behavior is unchanged (their 20s default is preserved)
- [ ] Run `npx gitnexus analyze` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)