### PR TITLE
[codex] Add local-first vulnerability research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (11164 symbols, 92808 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (11427 symbols, 97074 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (11427 symbols, 97074 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (11435 symbols, 97109 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (11164 symbols, 92808 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (11427 symbols, 97074 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Canonical entities must enforce EF max-length caps and FK `Guid` validity at the
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **PatchHound** (11427 symbols, 97074 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **PatchHound** (11435 symbols, 97109 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/frontend/src/api/ai-settings.schemas.ts
+++ b/frontend/src/api/ai-settings.schemas.ts
@@ -47,7 +47,7 @@ export const saveTenantAiProfileSchema = z.object({
   apiVersion: z.string(),
   keepAlive: z.string(),
   allowExternalResearch: z.boolean(),
-  webResearchMode: z.enum(['Disabled', 'ProviderNative', 'PatchHoundManaged']),
+  webResearchMode: z.enum(['Disabled', 'ProviderNative', 'PatchHoundManaged', 'LocalVulnerabilityIntel']),
   includeCitations: z.boolean(),
   maxResearchSources: z.number().int().positive(),
   allowedDomains: z.string(),

--- a/frontend/src/components/features/settings/TenantAiSettingsPage.tsx
+++ b/frontend/src/components/features/settings/TenantAiSettingsPage.tsx
@@ -893,7 +893,7 @@ function AiProfileEditorPage({
                   <div className="space-y-1">
                     <span className="text-sm font-medium text-foreground">Allow external web research</span>
                     <p className="text-sm text-muted-foreground">
-                      Use recent external context when supported by the provider or by PatchHound-managed research.
+                      Use recent external context when supported by the provider or by PatchHound-managed research. Vulnerability assessments always use local PatchHound intel first.
                     </p>
                   </div>
                 </label>
@@ -920,6 +920,11 @@ function AiProfileEditorPage({
                           <SelectItem value="PatchHoundManaged">PatchHound managed</SelectItem>
                         </SelectContent>
                       </Select>
+                      {draft.webResearchMode === 'PatchHoundManaged' ? (
+                        <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                          PatchHound-managed external research sends search queries and fetched public pages through the configured research service.
+                        </p>
+                      ) : null}
                     </Field>
 
                     <Field label="Max research sources" tooltip="Upper bound for external sources added to the research context.">

--- a/frontend/src/components/features/settings/TenantAiSettingsPage.tsx
+++ b/frontend/src/components/features/settings/TenantAiSettingsPage.tsx
@@ -917,12 +917,17 @@ function AiProfileEditorPage({
                           {draft.providerType === 'OpenAi' ? (
                             <SelectItem value="ProviderNative">Provider native</SelectItem>
                           ) : null}
+                          <SelectItem value="LocalVulnerabilityIntel">Local vulnerability intel</SelectItem>
                           <SelectItem value="PatchHoundManaged">PatchHound managed</SelectItem>
                         </SelectContent>
                       </Select>
                       {draft.webResearchMode === 'PatchHoundManaged' ? (
                         <p className="mt-2 text-xs leading-5 text-muted-foreground">
                           PatchHound-managed external research sends search queries and fetched public pages through the configured research service.
+                        </p>
+                      ) : draft.webResearchMode === 'LocalVulnerabilityIntel' ? (
+                        <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                          Local vulnerability intel uses PatchHound and NVD cache data only. It does not perform external HTTP research.
                         </p>
                       ) : null}
                     </Field>

--- a/src/PatchHound.Api/appsettings.Development.json
+++ b/src/PatchHound.Api/appsettings.Development.json
@@ -10,5 +10,8 @@
   },
   "ConnectionStrings": {
     "PatchHound": ""
+  },
+  "AiResearch": {
+    "JinaSearchProvider": "Google"
   }
 }

--- a/src/PatchHound.Api/appsettings.json
+++ b/src/PatchHound.Api/appsettings.json
@@ -27,6 +27,9 @@
   "Frontend": {
     "Origin": "http://localhost:5173"
   },
+  "AiResearch": {
+    "JinaSearchProvider": "Google"
+  },
   "FeatureManagement": {
     "Workflows": true,
     "AuthenticatedScans": true

--- a/src/PatchHound.Core/Enums/AiResearchProviderKind.cs
+++ b/src/PatchHound.Core/Enums/AiResearchProviderKind.cs
@@ -1,0 +1,7 @@
+namespace PatchHound.Core.Enums;
+
+public enum AiResearchProviderKind
+{
+    ExternalWebSearch = 0,
+    LocalVulnerabilityIntel = 1,
+}

--- a/src/PatchHound.Core/Enums/TenantAiWebResearchMode.cs
+++ b/src/PatchHound.Core/Enums/TenantAiWebResearchMode.cs
@@ -5,4 +5,5 @@ public enum TenantAiWebResearchMode
     Disabled = 0,
     ProviderNative = 1,
     PatchHoundManaged = 2,
+    LocalVulnerabilityIntel = 3,
 }

--- a/src/PatchHound.Core/Models/AiWebResearchRequest.cs
+++ b/src/PatchHound.Core/Models/AiWebResearchRequest.cs
@@ -1,8 +1,12 @@
+using PatchHound.Core.Enums;
+
 namespace PatchHound.Core.Models;
 
 public record AiWebResearchRequest(
     string Query,
     IReadOnlyList<string> AllowedDomains,
     int MaxSources,
-    bool IncludeCitations
+    bool IncludeCitations,
+    IReadOnlyList<Guid>? VulnerabilityIds = null,
+    IReadOnlyList<AiResearchProviderKind>? Providers = null
 );

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -128,8 +128,11 @@ public static class DependencyInjection
         services.AddScoped<ExecutiveDashboardBriefingService>();
         services.AddScoped<IRiskChangeBriefAiSummaryService, RiskChangeBriefAiSummaryService>();
         services.AddScoped<ITenantAiConfigurationResolver, TenantAiConfigurationResolver>();
+        services.Configure<AiResearchOptions>(configuration.GetSection(AiResearchOptions.SectionName));
+        services.AddScoped<LocalVulnerabilityIntelResearchProvider>();
+        services.AddScoped<ITenantAiResearchService, TenantAiResearchService>();
         services
-            .AddHttpClient<ITenantAiResearchService, TenantAiResearchService>()
+            .AddHttpClient<ExternalWebSearchResearchProvider>()
             .AddExternalHttpPolicies(maxConnectionsPerServer: 2);
         services.AddScoped<ISetupService, SetupService>();
         services.AddScoped<EnvironmentalSeverityCalculator>();

--- a/src/PatchHound.Infrastructure/Options/AiResearchOptions.cs
+++ b/src/PatchHound.Infrastructure/Options/AiResearchOptions.cs
@@ -1,0 +1,8 @@
+namespace PatchHound.Infrastructure.Options;
+
+public class AiResearchOptions
+{
+    public const string SectionName = "AiResearch";
+
+    public string JinaSearchProvider { get; set; } = "Google";
+}

--- a/src/PatchHound.Infrastructure/Services/ExternalWebSearchResearchProvider.cs
+++ b/src/PatchHound.Infrastructure/Services/ExternalWebSearchResearchProvider.cs
@@ -11,6 +11,9 @@ namespace PatchHound.Infrastructure.Services;
 
 public partial class ExternalWebSearchResearchProvider
 {
+    private const int MaxSnippetChars = 1800;
+    private const int MaxContextChars = 6000;
+
     private readonly HttpClient _httpClient;
     private readonly AiResearchOptions _options;
 
@@ -182,7 +185,7 @@ public partial class ExternalWebSearchResearchProvider
                     continue;
                 }
 
-                var proxiedUrl = $"https://r.jina.ai/http://{sourceUri.Host}{sourceUri.PathAndQuery}";
+                var proxiedUrl = $"https://r.jina.ai/http://{sourceUri.Authority}{sourceUri.PathAndQuery}";
                 using var response = await _httpClient.GetAsync(proxiedUrl, ct);
                 if (!response.IsSuccessStatusCode)
                 {
@@ -212,23 +215,59 @@ public partial class ExternalWebSearchResearchProvider
             return false;
         }
 
+        if (uri.IsLoopback || IsInternalHostName(uri.Host))
+        {
+            return false;
+        }
+
         if (uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
         {
             if (
                 IPAddress.TryParse(uri.Host, out var address)
-                && (
-                    IPAddress.IsLoopback(address)
-                    || address.IsIPv6LinkLocal
-                    || address.IsIPv6SiteLocal
-                    || IsPrivateIpv4(address)
-                )
+                && IsNonPublicAddress(address)
             )
             {
                 return false;
             }
         }
 
-        return !uri.IsLoopback;
+        return true;
+    }
+
+    private static bool IsInternalHostName(string host)
+    {
+        var normalized = host.TrimEnd('.').ToLowerInvariant();
+        return normalized is "localhost"
+            || normalized.EndsWith(".localhost", StringComparison.Ordinal)
+            || normalized.EndsWith(".local", StringComparison.Ordinal)
+            || normalized.EndsWith(".internal", StringComparison.Ordinal);
+    }
+
+    private static bool IsNonPublicAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        if (address.Equals(IPAddress.Any)
+            || address.Equals(IPAddress.IPv6Any)
+            || address.Equals(IPAddress.None)
+            || address.Equals(IPAddress.IPv6None))
+        {
+            return true;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            var bytes = address.GetAddressBytes();
+            return address.IsIPv6LinkLocal
+                || address.IsIPv6SiteLocal
+                || address.IsIPv6Multicast
+                || (bytes[0] & 0xfe) == 0xfc;
+        }
+
+        return IsPrivateIpv4(address);
     }
 
     private static bool IsPrivateIpv4(IPAddress address)
@@ -241,7 +280,10 @@ public partial class ExternalWebSearchResearchProvider
         var bytes = address.GetAddressBytes();
         return bytes[0] == 10
             || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
-            || (bytes[0] == 192 && bytes[1] == 168);
+            || (bytes[0] == 192 && bytes[1] == 168)
+            || (bytes[0] == 169 && bytes[1] == 254)
+            || bytes[0] == 0
+            || bytes[0] >= 224;
     }
 
     private static string ExtractSourceSnippet(string body)
@@ -254,7 +296,7 @@ public partial class ExternalWebSearchResearchProvider
             .Where(line => !line.StartsWith("Markdown Content:", StringComparison.OrdinalIgnoreCase))
             .Take(40);
 
-        return string.Join('\n', lines);
+        return Truncate(string.Join('\n', lines), MaxSnippetChars);
     }
 
     private static string BuildContext(
@@ -295,7 +337,17 @@ public partial class ExternalWebSearchResearchProvider
             }
         }
 
-        return builder.ToString().Trim();
+        return Truncate(builder.ToString().Trim(), MaxContextChars);
+    }
+
+    private static string Truncate(string value, int maxChars)
+    {
+        if (value.Length <= maxChars)
+        {
+            return value;
+        }
+
+        return value[..maxChars].TrimEnd() + "\n[truncated]";
     }
 
     [GeneratedRegex(@"\[(?<title>[^\]]+)\]\((?<url>https?://[^)]+)\)", RegexOptions.IgnoreCase)]

--- a/src/PatchHound.Infrastructure/Services/ExternalWebSearchResearchProvider.cs
+++ b/src/PatchHound.Infrastructure/Services/ExternalWebSearchResearchProvider.cs
@@ -1,0 +1,306 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using PatchHound.Core.Common;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Options;
+
+namespace PatchHound.Infrastructure.Services;
+
+public partial class ExternalWebSearchResearchProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly AiResearchOptions _options;
+
+    public ExternalWebSearchResearchProvider(
+        HttpClient httpClient,
+        IOptions<AiResearchOptions>? options = null
+    )
+    {
+        _httpClient = httpClient;
+        _options = options?.Value ?? new AiResearchOptions();
+    }
+
+    public async Task<Result<AiWebResearchBundle>> ResearchAsync(
+        AiWebResearchRequest request,
+        CancellationToken ct
+    )
+    {
+        try
+        {
+            var query = BuildQuery(request);
+            var url = BuildSearchUrl(query, _options.JinaSearchProvider);
+
+            using var response = await _httpClient.GetAsync(url, ct);
+            var body = await response.Content.ReadAsStringAsync(ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return Result<AiWebResearchBundle>.Failure(
+                    $"PatchHound-managed web research failed: {(int)response.StatusCode} {response.ReasonPhrase}"
+                );
+            }
+
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return Result<AiWebResearchBundle>.Failure(
+                    "PatchHound-managed web research returned an empty response."
+                );
+            }
+
+            var sources = ExtractSources(body, request.MaxSources);
+            var sourceContexts = await FetchSourceContextsAsync(sources, ct);
+            var context = BuildContext(
+                body,
+                sources,
+                sourceContexts,
+                request.MaxSources,
+                request.IncludeCitations
+            );
+
+            if (string.IsNullOrWhiteSpace(context))
+            {
+                return Result<AiWebResearchBundle>.Failure(
+                    "PatchHound-managed web research did not return usable context."
+                );
+            }
+
+            return Result<AiWebResearchBundle>.Success(
+                new AiWebResearchBundle(context, sources)
+            );
+        }
+        catch (Exception ex)
+        {
+            return Result<AiWebResearchBundle>.Failure(
+                $"PatchHound-managed web research failed: {ex.Message}"
+            );
+        }
+    }
+
+    private static string BuildQuery(AiWebResearchRequest request)
+    {
+        if (request.AllowedDomains.Count == 0)
+        {
+            return request.Query;
+        }
+
+        var domainTerms = request.AllowedDomains.Select(domain => $"site:{domain}");
+        return $"{request.Query} {string.Join(" OR ", domainTerms)}";
+    }
+
+    internal static string BuildSearchUrl(string query, string? provider)
+    {
+        var host = provider?.Trim().ToLowerInvariant() switch
+        {
+            "bing" => "www.bing.com",
+            _ => "www.google.com",
+        };
+
+        return $"https://r.jina.ai/http://{host}/search?q={Uri.EscapeDataString(query)}";
+    }
+
+    private static IReadOnlyList<AiWebResearchSource> ExtractSources(string body, int maxSources)
+    {
+        var results = new List<AiWebResearchSource>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match match in MarkdownLinkRegex().Matches(body))
+        {
+            var title = WebUtility.HtmlDecode(match.Groups["title"].Value.Trim());
+            var url = match.Groups["url"].Value.Trim();
+            if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(url))
+            {
+                continue;
+            }
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || !IsAllowedUrl(uri))
+            {
+                continue;
+            }
+
+            var normalizedUrl = uri.ToString();
+            if (!seen.Add(normalizedUrl))
+            {
+                continue;
+            }
+
+            results.Add(new AiWebResearchSource(title, normalizedUrl, null));
+            if (results.Count >= maxSources)
+            {
+                break;
+            }
+        }
+
+        if (results.Count >= maxSources)
+        {
+            return results;
+        }
+
+        foreach (Match match in BareUrlRegex().Matches(body))
+        {
+            var url = match.Value.TrimEnd('.', ',', ')', ']');
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || !IsAllowedUrl(uri))
+            {
+                continue;
+            }
+
+            var normalizedUrl = uri.ToString();
+            if (!seen.Add(normalizedUrl))
+            {
+                continue;
+            }
+
+            results.Add(new AiWebResearchSource(uri.Host, normalizedUrl, null));
+            if (results.Count >= maxSources)
+            {
+                break;
+            }
+        }
+
+        return results;
+    }
+
+    private async Task<IReadOnlyDictionary<string, string>> FetchSourceContextsAsync(
+        IReadOnlyList<AiWebResearchSource> sources,
+        CancellationToken ct
+    )
+    {
+        if (sources.Count == 0)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        var contexts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var source in sources)
+        {
+            try
+            {
+                if (!Uri.TryCreate(source.Url, UriKind.Absolute, out var sourceUri))
+                {
+                    continue;
+                }
+
+                var proxiedUrl = $"https://r.jina.ai/http://{sourceUri.Host}{sourceUri.PathAndQuery}";
+                using var response = await _httpClient.GetAsync(proxiedUrl, ct);
+                if (!response.IsSuccessStatusCode)
+                {
+                    continue;
+                }
+
+                var body = await response.Content.ReadAsStringAsync(ct);
+                var snippet = ExtractSourceSnippet(body);
+                if (!string.IsNullOrWhiteSpace(snippet))
+                {
+                    contexts[source.Url] = snippet;
+                }
+            }
+            catch
+            {
+                // Source fetches are best effort; the managed search response still carries context.
+            }
+        }
+
+        return contexts;
+    }
+
+    private static bool IsAllowedUrl(Uri uri)
+    {
+        if (uri.Scheme is not ("http" or "https"))
+        {
+            return false;
+        }
+
+        if (uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
+        {
+            if (
+                IPAddress.TryParse(uri.Host, out var address)
+                && (
+                    IPAddress.IsLoopback(address)
+                    || address.IsIPv6LinkLocal
+                    || address.IsIPv6SiteLocal
+                    || IsPrivateIpv4(address)
+                )
+            )
+            {
+                return false;
+            }
+        }
+
+        return !uri.IsLoopback;
+    }
+
+    private static bool IsPrivateIpv4(IPAddress address)
+    {
+        if (address.AddressFamily != AddressFamily.InterNetwork)
+        {
+            return false;
+        }
+
+        var bytes = address.GetAddressBytes();
+        return bytes[0] == 10
+            || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+            || (bytes[0] == 192 && bytes[1] == 168);
+    }
+
+    private static string ExtractSourceSnippet(string body)
+    {
+        var text = body.Replace("\r", "\n");
+        var lines = text
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(line => !line.StartsWith("Title:", StringComparison.OrdinalIgnoreCase))
+            .Where(line => !line.StartsWith("URL Source:", StringComparison.OrdinalIgnoreCase))
+            .Where(line => !line.StartsWith("Markdown Content:", StringComparison.OrdinalIgnoreCase))
+            .Take(40);
+
+        return string.Join('\n', lines);
+    }
+
+    private static string BuildContext(
+        string searchBody,
+        IReadOnlyList<AiWebResearchSource> sources,
+        IReadOnlyDictionary<string, string> sourceContexts,
+        int maxSources,
+        bool includeCitations
+    )
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("External research context:");
+        builder.AppendLine(ExtractSourceSnippet(searchBody));
+
+        if (sourceContexts.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Fetched source context:");
+            foreach (var source in sources.Take(maxSources))
+            {
+                if (!sourceContexts.TryGetValue(source.Url, out var snippet))
+                {
+                    continue;
+                }
+
+                builder.AppendLine($"- {source.Title} ({source.Url})");
+                builder.AppendLine(snippet);
+            }
+        }
+
+        if (includeCitations && sources.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Sources:");
+            foreach (var source in sources.Take(maxSources))
+            {
+                builder.AppendLine($"- {source.Title}: {source.Url}");
+            }
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    [GeneratedRegex(@"\[(?<title>[^\]]+)\]\((?<url>https?://[^)]+)\)", RegexOptions.IgnoreCase)]
+    private static partial Regex MarkdownLinkRegex();
+
+    [GeneratedRegex(@"https?://[^\s\])>]+", RegexOptions.IgnoreCase)]
+    private static partial Regex BareUrlRegex();
+}

--- a/src/PatchHound.Infrastructure/Services/ExternalWebSearchResearchProvider.cs
+++ b/src/PatchHound.Infrastructure/Services/ExternalWebSearchResearchProvider.cs
@@ -347,7 +347,34 @@ public partial class ExternalWebSearchResearchProvider
             return value;
         }
 
-        return value[..maxChars].TrimEnd() + "\n[truncated]";
+        return value[..FindTruncationBoundary(value, maxChars)].TrimEnd() + "\n[truncated]";
+    }
+
+    private static int FindTruncationBoundary(string value, int maxChars)
+    {
+        var newline = value.LastIndexOf('\n', maxChars - 1, maxChars);
+        if (newline > maxChars / 2)
+        {
+            return newline;
+        }
+
+        for (var index = maxChars - 1; index >= maxChars / 2; index--)
+        {
+            if (value[index] is '.' or '!' or '?')
+            {
+                return index + 1;
+            }
+        }
+
+        for (var index = maxChars - 1; index >= maxChars / 2; index--)
+        {
+            if (char.IsWhiteSpace(value[index]))
+            {
+                return index;
+            }
+        }
+
+        return maxChars;
     }
 
     [GeneratedRegex(@"\[(?<title>[^\]]+)\]\((?<url>https?://[^)]+)\)", RegexOptions.IgnoreCase)]

--- a/src/PatchHound.Infrastructure/Services/LocalVulnerabilityIntelResearchProvider.cs
+++ b/src/PatchHound.Infrastructure/Services/LocalVulnerabilityIntelResearchProvider.cs
@@ -175,6 +175,33 @@ public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
             return value;
         }
 
-        return value[..maxChars].TrimEnd() + "\n[truncated]";
+        return value[..FindTruncationBoundary(value, maxChars)].TrimEnd() + "\n[truncated]";
+    }
+
+    private static int FindTruncationBoundary(string value, int maxChars)
+    {
+        var newline = value.LastIndexOf('\n', maxChars - 1, maxChars);
+        if (newline > maxChars / 2)
+        {
+            return newline;
+        }
+
+        for (var index = maxChars - 1; index >= maxChars / 2; index--)
+        {
+            if (value[index] is '.' or '!' or '?')
+            {
+                return index + 1;
+            }
+        }
+
+        for (var index = maxChars - 1; index >= maxChars / 2; index--)
+        {
+            if (char.IsWhiteSpace(value[index]))
+            {
+                return index;
+            }
+        }
+
+        return maxChars;
     }
 }

--- a/src/PatchHound.Infrastructure/Services/LocalVulnerabilityIntelResearchProvider.cs
+++ b/src/PatchHound.Infrastructure/Services/LocalVulnerabilityIntelResearchProvider.cs
@@ -10,6 +10,9 @@ namespace PatchHound.Infrastructure.Services;
 
 public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
 {
+    private const int MaxRenderedVulnerabilities = 5;
+    private const int MaxContextChars = 6000;
+
     public async Task<Result<AiWebResearchBundle>> ResearchAsync(
         AiWebResearchRequest request,
         CancellationToken ct
@@ -40,7 +43,6 @@ public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
         var applicabilities = await db.VulnerabilityApplicabilities.AsNoTracking()
             .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
             .OrderBy(item => item.CpeCriteria)
-            .Take(20)
             .ToListAsync(ct);
         var assessments = await db.ThreatAssessments.AsNoTracking()
             .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
@@ -75,7 +77,7 @@ public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
         var builder = new StringBuilder();
         builder.AppendLine("Local vulnerability intel:");
 
-        foreach (var vulnerability in vulnerabilities)
+        foreach (var vulnerability in vulnerabilities.Take(MaxRenderedVulnerabilities))
         {
             builder.AppendLine($"- Vulnerability: {vulnerability.ExternalId}");
             if (!string.IsNullOrWhiteSpace(vulnerability.Title))
@@ -151,7 +153,7 @@ public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
             }
         }
 
-        return builder.ToString().Trim();
+        return Truncate(builder.ToString().Trim(), MaxContextChars);
     }
 
     private static IReadOnlyList<NvdCachedReference> ParseNvdReferences(string referencesJson)
@@ -164,5 +166,15 @@ public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
         {
             return [];
         }
+    }
+
+    private static string Truncate(string value, int maxChars)
+    {
+        if (value.Length <= maxChars)
+        {
+            return value;
+        }
+
+        return value[..maxChars].TrimEnd() + "\n[truncated]";
     }
 }

--- a/src/PatchHound.Infrastructure/Services/LocalVulnerabilityIntelResearchProvider.cs
+++ b/src/PatchHound.Infrastructure/Services/LocalVulnerabilityIntelResearchProvider.cs
@@ -1,0 +1,168 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Common;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Infrastructure.Services;
+
+public class LocalVulnerabilityIntelResearchProvider(PatchHoundDbContext db)
+{
+    public async Task<Result<AiWebResearchBundle>> ResearchAsync(
+        AiWebResearchRequest request,
+        CancellationToken ct
+    )
+    {
+        if (request.VulnerabilityIds is not { Count: > 0 })
+        {
+            return Result<AiWebResearchBundle>.Success(new AiWebResearchBundle(string.Empty, []));
+        }
+
+        var vulnerabilities = await db.Vulnerabilities.AsNoTracking()
+            .Where(item => request.VulnerabilityIds.Contains(item.Id))
+            .OrderBy(item => item.ExternalId)
+            .ToListAsync(ct);
+
+        if (vulnerabilities.Count == 0)
+        {
+            return Result<AiWebResearchBundle>.Success(new AiWebResearchBundle(string.Empty, []));
+        }
+
+        var vulnerabilityIds = vulnerabilities.Select(item => item.Id).ToArray();
+        var externalIds = vulnerabilities.Select(item => item.ExternalId).ToArray();
+        var references = await db.VulnerabilityReferences.AsNoTracking()
+            .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
+            .OrderBy(item => item.Source)
+            .ThenBy(item => item.Url)
+            .ToListAsync(ct);
+        var applicabilities = await db.VulnerabilityApplicabilities.AsNoTracking()
+            .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
+            .OrderBy(item => item.CpeCriteria)
+            .Take(20)
+            .ToListAsync(ct);
+        var assessments = await db.ThreatAssessments.AsNoTracking()
+            .Where(item => vulnerabilityIds.Contains(item.VulnerabilityId))
+            .ToListAsync(ct);
+        var nvdCache = await db.NvdCveCache.AsNoTracking()
+            .Where(item => externalIds.Contains(item.CveId))
+            .ToListAsync(ct);
+
+        var context = BuildContext(vulnerabilities, references, applicabilities, assessments, nvdCache);
+        var sources = references
+            .Select(item => new AiWebResearchSource(item.Source, item.Url, null))
+            .Concat(
+                nvdCache.SelectMany(item => ParseNvdReferences(item.ReferencesJson))
+                    .Select(item => new AiWebResearchSource(item.Source, item.Url, null))
+            )
+            .GroupBy(item => item.Url, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .Take(request.MaxSources)
+            .ToList();
+
+        return Result<AiWebResearchBundle>.Success(new AiWebResearchBundle(context, sources));
+    }
+
+    private static string BuildContext(
+        IReadOnlyList<Vulnerability> vulnerabilities,
+        IReadOnlyList<VulnerabilityReference> references,
+        IReadOnlyList<VulnerabilityApplicability> applicabilities,
+        IReadOnlyList<ThreatAssessment> assessments,
+        IReadOnlyList<NvdCveCache> nvdCache
+    )
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Local vulnerability intel:");
+
+        foreach (var vulnerability in vulnerabilities)
+        {
+            builder.AppendLine($"- Vulnerability: {vulnerability.ExternalId}");
+            if (!string.IsNullOrWhiteSpace(vulnerability.Title))
+            {
+                builder.AppendLine($"  Title: {vulnerability.Title}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(vulnerability.Description))
+            {
+                builder.AppendLine($"  Canonical description: {vulnerability.Description}");
+            }
+
+            builder.AppendLine($"  Severity: {vulnerability.VendorSeverity}");
+            if (vulnerability.CvssScore is not null)
+            {
+                builder.AppendLine($"  CVSS score: {vulnerability.CvssScore}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(vulnerability.CvssVector))
+            {
+                builder.AppendLine($"  CVSS vector: {vulnerability.CvssVector}");
+            }
+
+            var cached = nvdCache.FirstOrDefault(item =>
+                string.Equals(item.CveId, vulnerability.ExternalId, StringComparison.OrdinalIgnoreCase)
+            );
+            if (cached is not null)
+            {
+                builder.AppendLine($"  NVD description: {cached.Description}");
+                if (cached.PublishedDate is not null)
+                {
+                    builder.AppendLine($"  NVD published: {cached.PublishedDate:O}");
+                }
+            }
+
+            var threat = assessments.FirstOrDefault(item => item.VulnerabilityId == vulnerability.Id);
+            if (threat is not null)
+            {
+                builder.AppendLine($"  Threat score: {threat.ThreatScore}");
+                builder.AppendLine($"  Exploit likelihood score: {threat.ExploitLikelihoodScore}");
+                if (threat.EpssScore is not null)
+                {
+                    builder.AppendLine($"  EPSS score: {threat.EpssScore}");
+                }
+
+                builder.AppendLine($"  Known exploited: {threat.KnownExploited.ToString().ToLowerInvariant()}");
+                builder.AppendLine($"  Public exploit: {threat.PublicExploit.ToString().ToLowerInvariant()}");
+                builder.AppendLine($"  Active alert: {threat.ActiveAlert.ToString().ToLowerInvariant()}");
+                builder.AppendLine($"  Ransomware association: {threat.HasRansomwareAssociation.ToString().ToLowerInvariant()}");
+                builder.AppendLine($"  Malware association: {threat.HasMalwareAssociation.ToString().ToLowerInvariant()}");
+            }
+
+            var vulnReferences = references.Where(item => item.VulnerabilityId == vulnerability.Id).Take(10).ToList();
+            if (vulnReferences.Count > 0)
+            {
+                builder.AppendLine("  References:");
+                foreach (var reference in vulnReferences)
+                {
+                    builder.AppendLine($"  - {reference.Source}: {reference.Url}");
+                }
+            }
+
+            var vulnApplicabilities = applicabilities.Where(item => item.VulnerabilityId == vulnerability.Id).Take(10).ToList();
+            if (vulnApplicabilities.Count > 0)
+            {
+                builder.AppendLine("  Applicability:");
+                foreach (var applicability in vulnApplicabilities)
+                {
+                    builder.AppendLine(
+                        $"  - CPE: {applicability.CpeCriteria ?? "mapped software product"}; vulnerable: {applicability.Vulnerable.ToString().ToLowerInvariant()}; version start including: {applicability.VersionStartIncluding ?? "n/a"}; version end including: {applicability.VersionEndIncluding ?? "n/a"}"
+                    );
+                }
+            }
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static IReadOnlyList<NvdCachedReference> ParseNvdReferences(string referencesJson)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<List<NvdCachedReference>>(referencesJson) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/TenantAiResearchService.cs
+++ b/src/PatchHound.Infrastructure/Services/TenantAiResearchService.cs
@@ -10,6 +10,8 @@ public class TenantAiResearchService(
     ExternalWebSearchResearchProvider externalWebSearchProvider
 ) : ITenantAiResearchService
 {
+    private const int MaxCombinedContextChars = 12000;
+
     public async Task<Result<AiWebResearchBundle>> ResearchAsync(
         TenantAiProfileResolved profile,
         AiWebResearchRequest request,
@@ -60,12 +62,22 @@ public class TenantAiResearchService(
 
         return Result<AiWebResearchBundle>.Success(
             new AiWebResearchBundle(
-                string.Join("\n\n", contexts),
+                Truncate(string.Join("\n\n", contexts), MaxCombinedContextChars),
                 sources.GroupBy(item => item.Url, StringComparer.OrdinalIgnoreCase)
                     .Select(group => group.First())
                     .Take(request.MaxSources)
                     .ToList()
             )
         );
+    }
+
+    private static string Truncate(string value, int maxChars)
+    {
+        if (value.Length <= maxChars)
+        {
+            return value;
+        }
+
+        return value[..maxChars].TrimEnd() + "\n[truncated]";
     }
 }

--- a/src/PatchHound.Infrastructure/Services/TenantAiResearchService.cs
+++ b/src/PatchHound.Infrastructure/Services/TenantAiResearchService.cs
@@ -1,323 +1,71 @@
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Text.RegularExpressions;
 using PatchHound.Core.Common;
+using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Core.Models;
 
 namespace PatchHound.Infrastructure.Services;
 
-public partial class TenantAiResearchService : ITenantAiResearchService
+public class TenantAiResearchService(
+    LocalVulnerabilityIntelResearchProvider localVulnerabilityIntelProvider,
+    ExternalWebSearchResearchProvider externalWebSearchProvider
+) : ITenantAiResearchService
 {
-    private readonly HttpClient _httpClient;
-
-    public TenantAiResearchService(HttpClient httpClient)
-    {
-        _httpClient = httpClient;
-    }
-
-    public Task<Result<AiWebResearchBundle>> ResearchAsync(
+    public async Task<Result<AiWebResearchBundle>> ResearchAsync(
         TenantAiProfileResolved profile,
         AiWebResearchRequest request,
         CancellationToken ct
     )
     {
-        return ResearchInternalAsync(profile, request, ct);
-    }
+        var providers = request.Providers is { Count: > 0 }
+            ? request.Providers
+            : [AiResearchProviderKind.ExternalWebSearch];
 
-    private async Task<Result<AiWebResearchBundle>> ResearchInternalAsync(
-        TenantAiProfileResolved profile,
-        AiWebResearchRequest request,
-        CancellationToken ct
-    )
-    {
-        try
-        {
-            var query = BuildQuery(request);
-            var url =
-                $"https://r.jina.ai/http://www.bing.com/search?q={Uri.EscapeDataString(query)}";
-
-            using var response = await _httpClient.GetAsync(url, ct);
-            var body = await response.Content.ReadAsStringAsync(ct);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return Result<AiWebResearchBundle>.Failure(
-                    $"PatchHound-managed web research failed: {(int)response.StatusCode} {response.ReasonPhrase}"
-                );
-            }
-
-            if (string.IsNullOrWhiteSpace(body))
-            {
-                return Result<AiWebResearchBundle>.Failure(
-                    "PatchHound-managed web research returned an empty response."
-                );
-            }
-
-            var sources = ExtractSources(body, request.MaxSources);
-            var sourceContexts = await FetchSourceContextsAsync(sources, ct);
-            var context = BuildContext(
-                body,
-                sources,
-                sourceContexts,
-                request.MaxSources,
-                request.IncludeCitations
-            );
-
-            if (string.IsNullOrWhiteSpace(context))
-            {
-                return Result<AiWebResearchBundle>.Failure(
-                    "PatchHound-managed web research did not return usable context."
-                );
-            }
-
-            return Result<AiWebResearchBundle>.Success(
-                new AiWebResearchBundle(context, sources)
-            );
-        }
-        catch (Exception ex)
-        {
-            return Result<AiWebResearchBundle>.Failure(
-                $"PatchHound-managed web research failed: {ex.Message}"
-            );
-        }
-    }
-
-    private static string BuildQuery(AiWebResearchRequest request)
-    {
-        if (request.AllowedDomains.Count == 0)
-        {
-            return request.Query;
-        }
-
-        var domainTerms = request.AllowedDomains.Select(domain => $"site:{domain}");
-        return $"{request.Query} {string.Join(" OR ", domainTerms)}";
-    }
-
-    private static IReadOnlyList<AiWebResearchSource> ExtractSources(string body, int maxSources)
-    {
-        var results = new List<AiWebResearchSource>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (Match match in MarkdownLinkRegex().Matches(body))
-        {
-            var title = WebUtility.HtmlDecode(match.Groups["title"].Value.Trim());
-            var url = match.Groups["url"].Value.Trim();
-            if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(url))
-            {
-                continue;
-            }
-
-            if (!seen.Add(url))
-            {
-                continue;
-            }
-
-            results.Add(new AiWebResearchSource(title, url, null));
-            if (results.Count >= maxSources)
-            {
-                break;
-            }
-        }
-
-        foreach (Match match in BareUrlRegex().Matches(body))
-        {
-            var url = match.Value.Trim();
-            if (!seen.Add(url))
-            {
-                continue;
-            }
-
-            results.Add(new AiWebResearchSource(url, url, null));
-            if (results.Count >= maxSources)
-            {
-                break;
-            }
-        }
-
-        return results;
-    }
-
-    private async Task<IReadOnlyList<string>> FetchSourceContextsAsync(
-        IReadOnlyList<AiWebResearchSource> sources,
-        CancellationToken ct
-    )
-    {
         var contexts = new List<string>();
+        var sources = new List<AiWebResearchSource>();
+        var errors = new List<string>();
 
-        foreach (var source in sources)
+        foreach (var provider in providers.Distinct())
         {
-            if (!IsAllowedUrl(source.Url))
+            var result = provider switch
             {
+                AiResearchProviderKind.LocalVulnerabilityIntel =>
+                    await localVulnerabilityIntelProvider.ResearchAsync(request, ct),
+                AiResearchProviderKind.ExternalWebSearch =>
+                    await externalWebSearchProvider.ResearchAsync(request, ct),
+                _ => Result<AiWebResearchBundle>.Success(new AiWebResearchBundle(string.Empty, [])),
+            };
+
+            if (!result.IsSuccess)
+            {
+                if (!string.IsNullOrWhiteSpace(result.Error))
+                {
+                    errors.Add(result.Error);
+                }
+
                 continue;
             }
 
-            try
+            if (!string.IsNullOrWhiteSpace(result.Value.Context))
             {
-                var normalizedUrl = source.Url
-                    .Replace("https://", string.Empty, StringComparison.OrdinalIgnoreCase)
-                    .Replace("http://", string.Empty, StringComparison.OrdinalIgnoreCase);
-                using var response = await _httpClient.GetAsync(
-                    $"https://r.jina.ai/http://{normalizedUrl}", ct);
-                if (!response.IsSuccessStatusCode)
-                {
-                    continue;
-                }
-
-                var body = await response.Content.ReadAsStringAsync(ct);
-                if (string.IsNullOrWhiteSpace(body))
-                {
-                    continue;
-                }
-
-                var snippet = ExtractSourceSnippet(body);
-                if (!string.IsNullOrWhiteSpace(snippet))
-                {
-                    contexts.Add($"Source: {source.Title}\n{snippet}");
-                }
+                contexts.Add(result.Value.Context);
             }
-            catch
-            {
-                // Best-effort enrichment only; continue with available source context.
-            }
+
+            sources.AddRange(result.Value.Sources);
         }
 
-        return contexts;
-    }
-
-    private static bool IsAllowedUrl(string url)
-    {
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        if (contexts.Count == 0 && sources.Count == 0 && errors.Count > 0)
         {
-            return false;
+            return Result<AiWebResearchBundle>.Failure(errors[0]);
         }
 
-        if (uri.Scheme is not ("http" or "https"))
-        {
-            return false;
-        }
-
-        var host = uri.Host;
-
-        // Block private/internal/link-local addresses
-        if (IPAddress.TryParse(host, out var ip))
-        {
-            if (ip.AddressFamily == AddressFamily.InterNetworkV6 && ip.IsIPv6LinkLocal)
-                return false;
-            var bytes = ip.GetAddressBytes();
-            if (bytes.Length == 4)
-            {
-                // 10.x.x.x, 172.16-31.x.x, 192.168.x.x, 127.x.x.x, 169.254.x.x
-                if (bytes[0] == 10) return false;
-                if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) return false;
-                if (bytes[0] == 192 && bytes[1] == 168) return false;
-                if (bytes[0] == 127) return false;
-                if (bytes[0] == 169 && bytes[1] == 254) return false;
-                if (bytes[0] == 0) return false;
-            }
-        }
-        else
-        {
-            // Block common internal hostnames
-            if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
-                return false;
-            if (host.EndsWith(".local", StringComparison.OrdinalIgnoreCase))
-                return false;
-            if (host.EndsWith(".internal", StringComparison.OrdinalIgnoreCase))
-                return false;
-        }
-
-        return true;
-    }
-
-    private static string? ExtractSourceSnippet(string body)
-    {
-        var normalizedBody = body
-            .Replace("\r\n", "\n", StringComparison.Ordinal)
-            .Replace('\r', '\n');
-
-        var lines = normalizedBody
-            .Split('\n', StringSplitOptions.TrimEntries)
-            .Where(line =>
-                !string.IsNullOrWhiteSpace(line)
-                && !line.StartsWith("Title:", StringComparison.OrdinalIgnoreCase)
-                && !line.StartsWith("URL Source:", StringComparison.OrdinalIgnoreCase)
-                && !line.StartsWith("Markdown Content:", StringComparison.OrdinalIgnoreCase)
+        return Result<AiWebResearchBundle>.Success(
+            new AiWebResearchBundle(
+                string.Join("\n\n", contexts),
+                sources.GroupBy(item => item.Url, StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.First())
+                    .Take(request.MaxSources)
+                    .ToList()
             )
-            .Take(18)
-            .ToList();
-
-        if (lines.Count == 0)
-        {
-            return null;
-        }
-
-        var snippet = string.Join('\n', lines);
-        return snippet.Length > 1800 ? snippet[..1800] : snippet;
+        );
     }
-
-    private static string BuildContext(
-        string body,
-        IReadOnlyList<AiWebResearchSource> sources,
-        IReadOnlyList<string> sourceContexts,
-        int maxSources,
-        bool includeCitations
-    )
-    {
-        var normalizedBody = body
-            .Replace("\r\n", "\n", StringComparison.Ordinal)
-            .Replace('\r', '\n');
-
-        var lines = normalizedBody
-            .Split('\n', StringSplitOptions.TrimEntries)
-            .Where(line =>
-                !string.IsNullOrWhiteSpace(line)
-                && !line.StartsWith("Title:", StringComparison.OrdinalIgnoreCase)
-                && !line.StartsWith("URL Source:", StringComparison.OrdinalIgnoreCase)
-                && !line.StartsWith("Markdown Content:", StringComparison.OrdinalIgnoreCase)
-            )
-            .Take(40)
-            .ToList();
-
-        var builder = new StringBuilder();
-        builder.AppendLine("External research context:");
-        foreach (var line in lines)
-        {
-            builder.AppendLine(line);
-        }
-
-        if (sourceContexts.Count > 0)
-        {
-            builder.AppendLine();
-            builder.AppendLine("Fetched source context:");
-            foreach (var sourceContext in sourceContexts.Take(maxSources))
-            {
-                builder.AppendLine(sourceContext);
-                builder.AppendLine();
-            }
-        }
-
-        if (includeCitations && sources.Count > 0)
-        {
-            builder.AppendLine();
-            builder.AppendLine("Sources:");
-            foreach (var source in sources.Take(maxSources))
-            {
-                builder.Append("- ");
-                builder.Append(source.Title);
-                builder.Append(" — ");
-                builder.AppendLine(source.Url);
-            }
-        }
-
-        var context = builder.ToString().Trim();
-        return context.Length > 6000 ? context[..6000] : context;
-    }
-
-    [GeneratedRegex(@"\[(?<title>[^\]]+)\]\((?<url>https?://[^)\s]+)\)", RegexOptions.IgnoreCase)]
-    private static partial Regex MarkdownLinkRegex();
-
-    [GeneratedRegex(@"https?://[^\s)>\]]+", RegexOptions.IgnoreCase)]
-    private static partial Regex BareUrlRegex();
 }

--- a/src/PatchHound.Infrastructure/Services/TenantAiResearchService.cs
+++ b/src/PatchHound.Infrastructure/Services/TenantAiResearchService.cs
@@ -78,6 +78,33 @@ public class TenantAiResearchService(
             return value;
         }
 
-        return value[..maxChars].TrimEnd() + "\n[truncated]";
+        return value[..FindTruncationBoundary(value, maxChars)].TrimEnd() + "\n[truncated]";
+    }
+
+    private static int FindTruncationBoundary(string value, int maxChars)
+    {
+        var newline = value.LastIndexOf('\n', maxChars - 1, maxChars);
+        if (newline > maxChars / 2)
+        {
+            return newline;
+        }
+
+        for (var index = maxChars - 1; index >= maxChars / 2; index--)
+        {
+            if (value[index] is '.' or '!' or '?')
+            {
+                return index + 1;
+            }
+        }
+
+        for (var index = maxChars - 1; index >= maxChars / 2; index--)
+        {
+            if (char.IsWhiteSpace(value[index]))
+            {
+                return index;
+            }
+        }
+
+        return maxChars;
     }
 }

--- a/src/PatchHound.Worker/VulnerabilityAssessmentWorker.cs
+++ b/src/PatchHound.Worker/VulnerabilityAssessmentWorker.cs
@@ -128,6 +128,7 @@ public class VulnerabilityAssessmentWorker(
             var resolvedProfile = resolvedProfileResult.Value;
             request = await BuildAssessmentRequestForProfileAsync(
                 resolvedProfile,
+                vulnerability.Id,
                 vulnerability.ExternalId,
                 request,
                 scope.ServiceProvider,
@@ -403,13 +404,17 @@ public class VulnerabilityAssessmentWorker(
             && profile.ProviderType == TenantAiProviderType.OpenAi
         )
         {
-            return request with
+            var providerNativeRequest = request with
             {
                 UseProviderNativeWebResearch = true,
                 AllowedDomains = ParseAllowedDomains(profile.AllowedDomains),
                 MaxResearchSources = profile.MaxResearchSources,
                 IncludeCitations = profile.IncludeCitations,
             };
+
+            return string.IsNullOrWhiteSpace(externalContext)
+                ? providerNativeRequest
+                : providerNativeRequest with { ExternalContext = externalContext };
         }
 
         return string.IsNullOrWhiteSpace(externalContext)
@@ -419,6 +424,7 @@ public class VulnerabilityAssessmentWorker(
 
     private async Task<AiTextGenerationRequest> BuildAssessmentRequestForProfileAsync(
         TenantAiProfileResolved resolvedProfile,
+        Guid vulnerabilityId,
         string externalId,
         AiTextGenerationRequest request,
         IServiceProvider serviceProvider,
@@ -426,9 +432,42 @@ public class VulnerabilityAssessmentWorker(
     )
     {
         var profile = resolvedProfile.Profile;
-        if (!profile.AllowExternalResearch || profile.WebResearchMode == TenantAiWebResearchMode.Disabled)
+        var researchService = serviceProvider.GetRequiredService<ITenantAiResearchService>();
+        var providers = profile.AllowExternalResearch && profile.WebResearchMode == TenantAiWebResearchMode.PatchHoundManaged
+            ? new[]
+            {
+                AiResearchProviderKind.LocalVulnerabilityIntel,
+                AiResearchProviderKind.ExternalWebSearch,
+            }
+            : new[]
+            {
+                AiResearchProviderKind.LocalVulnerabilityIntel,
+            };
+
+        var researchResult = await researchService.ResearchAsync(
+            resolvedProfile,
+            new AiWebResearchRequest(
+                BuildResearchQuery(externalId),
+                ParseAllowedDomains(profile.AllowedDomains),
+                profile.MaxResearchSources,
+                profile.IncludeCitations,
+                [vulnerabilityId],
+                providers
+            ),
+            ct
+        );
+
+        var externalContext = researchResult.IsSuccess
+            ? researchResult.Value.Context
+            : null;
+
+        if (!researchResult.IsSuccess)
         {
-            return request;
+            logger.LogWarning(
+                "VulnerabilityAssessmentWorker: managed research failed for {ExternalId}: {Error}",
+                externalId,
+                researchResult.Error ?? "empty context"
+            );
         }
 
         if (
@@ -436,37 +475,20 @@ public class VulnerabilityAssessmentWorker(
             && profile.ProviderType == TenantAiProviderType.OpenAi
         )
         {
-            return BuildAssessmentRequest(externalId, profile, externalContext: null);
+            return BuildAssessmentRequest(externalId, profile, externalContext);
         }
 
-        if (profile.WebResearchMode != TenantAiWebResearchMode.PatchHoundManaged)
+        if (profile.AllowExternalResearch && profile.WebResearchMode == TenantAiWebResearchMode.PatchHoundManaged)
         {
-            return request;
+            return BuildAssessmentRequest(externalId, profile, externalContext);
         }
 
-        var researchService = serviceProvider.GetRequiredService<ITenantAiResearchService>();
-        var researchResult = await researchService.ResearchAsync(
-            resolvedProfile,
-            new AiWebResearchRequest(
-                BuildResearchQuery(externalId),
-                ParseAllowedDomains(profile.AllowedDomains),
-                profile.MaxResearchSources,
-                profile.IncludeCitations
-            ),
-            ct
-        );
-
-        if (!researchResult.IsSuccess || string.IsNullOrWhiteSpace(researchResult.Value.Context))
+        if (!string.IsNullOrWhiteSpace(externalContext))
         {
-            logger.LogWarning(
-                "VulnerabilityAssessmentWorker: managed web research failed or returned no context for {ExternalId}: {Error}",
-                externalId,
-                researchResult.Error ?? "empty context"
-            );
-            return request;
+            return request with { ExternalContext = externalContext };
         }
 
-        return BuildAssessmentRequest(externalId, profile, researchResult.Value.Context);
+        return request;
     }
 
     private static string BuildResearchQuery(string externalId) =>

--- a/src/PatchHound.Worker/appsettings.Development.json
+++ b/src/PatchHound.Worker/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
+  },
+  "AiResearch": {
+    "JinaSearchProvider": "Google"
   }
 }

--- a/src/PatchHound.Worker/appsettings.json
+++ b/src/PatchHound.Worker/appsettings.json
@@ -6,6 +6,9 @@
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   },
+  "AiResearch": {
+    "JinaSearchProvider": "Google"
+  },
   "FeatureManagement": {
     "Workflows": true,
     "AuthenticatedScans": true

--- a/tests/PatchHound.Tests/Infrastructure/TenantAiResearchServiceTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/TenantAiResearchServiceTests.cs
@@ -1,8 +1,15 @@
 using System.Net;
+using System.Text.Json;
 using System.Text;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
 using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Options;
 using PatchHound.Infrastructure.Services;
 using PatchHound.Tests.TestData;
 
@@ -29,7 +36,8 @@ public class TenantAiResearchServiceTests
                 ),
             }
         );
-        var service = new TenantAiResearchService(new HttpClient(handler));
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var service = CreateService(db, handler);
         var profile = TenantAiProfileFactory.Create(
             Guid.NewGuid(),
             providerType: TenantAiProviderType.Ollama,
@@ -54,10 +62,275 @@ public class TenantAiResearchServiceTests
         result.Value.Sources.Should().HaveCount(2);
         result.Value.Sources[0].Url.Should().Be("https://spring.io/security");
         handler.Requests.Should().HaveCount(3);
+        handler.Requests[0].RequestUri!.ToString().Should().StartWith("https://r.jina.ai/http://www.google.com/search?");
         handler.Requests[0].RequestUri!.ToString().Should().Contain("site%3Anvd.nist.gov");
         handler.Requests[0].RequestUri!.ToString().Should().Contain("site%3Aspring.io");
         handler.Requests[1].RequestUri!.ToString().Should().Be("https://r.jina.ai/http://spring.io/security");
         handler.Requests[2].RequestUri!.ToString().Should().Be("https://r.jina.ai/http://nvd.nist.gov/vuln/detail/CVE-2026-0001");
+    }
+
+    [Fact]
+    public async Task ResearchAsync_UsesConfiguredBingSearchProvider()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    Title: Bing
+                    Markdown Content:
+                    [NVD CVE Entry](https://nvd.nist.gov/vuln/detail/CVE-2026-0001)
+                    """,
+                    Encoding.UTF8,
+                    "text/plain"
+                ),
+            }
+        );
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var service = CreateService(
+            db,
+            handler,
+            new AiResearchOptions { JinaSearchProvider = "Bing" }
+        );
+        var profile = TenantAiProfileFactory.Create(
+            Guid.NewGuid(),
+            providerType: TenantAiProviderType.Ollama,
+            allowExternalResearch: true,
+            webResearchMode: TenantAiWebResearchMode.PatchHoundManaged
+        );
+
+        await service.ResearchAsync(
+            new TenantAiProfileResolved(profile, string.Empty),
+            new AiWebResearchRequest("CVE-2026-0001", [], 1, true),
+            CancellationToken.None
+        );
+
+        handler.Requests[0].RequestUri!.ToString().Should().StartWith("https://r.jina.ai/http://www.bing.com/search?");
+    }
+
+    [Fact]
+    public void AddHttpClient_CanResolveTenantAiResearchService_WithConfiguredOptions()
+    {
+        var services = new ServiceCollection();
+        services.Configure<AiResearchOptions>(options => options.JinaSearchProvider = "Bing");
+        services.AddSingleton(TestDbContextFactory.CreateSystemContext());
+        services.AddScoped<LocalVulnerabilityIntelResearchProvider>();
+        services.AddHttpClient<ExternalWebSearchResearchProvider>();
+        services.AddScoped<ITenantAiResearchService, TenantAiResearchService>();
+
+        using var provider = services.BuildServiceProvider();
+
+        var service = provider.GetRequiredService<ITenantAiResearchService>();
+
+        service.Should().BeOfType<TenantAiResearchService>();
+    }
+
+    [Fact]
+    public async Task ResearchAsync_ReturnsLocalVulnerabilityIntel_WithoutExternalHttp()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var vulnerability = SeedLocalIntel(db);
+        var handler = new RecordingHttpMessageHandler(_ =>
+            throw new InvalidOperationException("External HTTP should not be used for local intel only.")
+        );
+        var service = CreateService(db, handler);
+        var profile = TenantAiProfileFactory.Create(
+            Guid.NewGuid(),
+            providerType: TenantAiProviderType.Ollama,
+            allowExternalResearch: false,
+            webResearchMode: TenantAiWebResearchMode.Disabled
+        );
+
+        var result = await service.ResearchAsync(
+            new TenantAiProfileResolved(profile, string.Empty),
+            new AiWebResearchRequest(
+                "CVE-2026-1234",
+                [],
+                5,
+                true,
+                [vulnerability.Id],
+                [AiResearchProviderKind.LocalVulnerabilityIntel]
+            ),
+            CancellationToken.None
+        );
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Context.Should().Contain("Local vulnerability intel:");
+        result.Value.Context.Should().Contain("NVD cached description");
+        result.Value.Context.Should().Contain("Known exploited: true");
+        result.Value.Context.Should().Contain("https://vendor.example/advisory");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResearchAsync_CombinesLocalIntelAndExternalWebSearch_WhenBothRequested()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var vulnerability = SeedLocalIntel(db);
+        var handler = new RecordingHttpMessageHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    Title: Search
+                    Markdown Content:
+                    [Vendor update](https://vendor.example/update)
+                    Exploitation is being discussed publicly.
+                    """,
+                    Encoding.UTF8,
+                    "text/plain"
+                ),
+            }
+        );
+        var service = CreateService(db, handler);
+        var profile = TenantAiProfileFactory.Create(
+            Guid.NewGuid(),
+            providerType: TenantAiProviderType.Ollama,
+            allowExternalResearch: true,
+            webResearchMode: TenantAiWebResearchMode.PatchHoundManaged
+        );
+
+        var result = await service.ResearchAsync(
+            new TenantAiProfileResolved(profile, string.Empty),
+            new AiWebResearchRequest(
+                "CVE-2026-1234",
+                [],
+                5,
+                true,
+                [vulnerability.Id],
+                [AiResearchProviderKind.LocalVulnerabilityIntel, AiResearchProviderKind.ExternalWebSearch]
+            ),
+            CancellationToken.None
+        );
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Context.Should().Contain("Local vulnerability intel:");
+        result.Value.Context.Should().Contain("NVD cached description");
+        result.Value.Context.Should().Contain("External research context:");
+        result.Value.Context.Should().Contain("Exploitation is being discussed publicly.");
+        handler.Requests.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ResearchAsync_LocalIntelCacheMiss_ReturnsEmptyBundleWithoutExternalHttp()
+    {
+        await using var db = TestDbContextFactory.CreateSystemContext();
+        var handler = new RecordingHttpMessageHandler(_ =>
+            throw new InvalidOperationException("External HTTP should not be used for local intel only.")
+        );
+        var service = CreateService(db, handler);
+        var profile = TenantAiProfileFactory.Create(
+            Guid.NewGuid(),
+            providerType: TenantAiProviderType.Ollama,
+            allowExternalResearch: false,
+            webResearchMode: TenantAiWebResearchMode.Disabled
+        );
+
+        var result = await service.ResearchAsync(
+            new TenantAiProfileResolved(profile, string.Empty),
+            new AiWebResearchRequest(
+                "CVE-2026-9999",
+                [],
+                5,
+                true,
+                [Guid.NewGuid()],
+                [AiResearchProviderKind.LocalVulnerabilityIntel]
+            ),
+            CancellationToken.None
+        );
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Context.Should().BeEmpty();
+        result.Value.Sources.Should().BeEmpty();
+        handler.Requests.Should().BeEmpty();
+    }
+
+    private static TenantAiResearchService CreateService(
+        PatchHoundDbContext db,
+        RecordingHttpMessageHandler handler,
+        AiResearchOptions? options = null
+    )
+    {
+        var externalProvider = new ExternalWebSearchResearchProvider(
+            new HttpClient(handler),
+            Options.Create(options ?? new AiResearchOptions())
+        );
+        return new TenantAiResearchService(
+            new LocalVulnerabilityIntelResearchProvider(db),
+            externalProvider
+        );
+    }
+
+    private static Vulnerability SeedLocalIntel(PatchHoundDbContext db)
+    {
+        var vulnerability = Vulnerability.Create(
+            "nvd",
+            "CVE-2026-1234",
+            "CVE-2026-1234",
+            "Canonical description",
+            Severity.Critical,
+            9.8m,
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            new DateTimeOffset(2026, 1, 2, 0, 0, 0, TimeSpan.Zero)
+        );
+        db.Vulnerabilities.Add(vulnerability);
+        db.VulnerabilityReferences.Add(
+            VulnerabilityReference.Create(
+                vulnerability.Id,
+                "https://vendor.example/advisory",
+                "Vendor",
+                ["advisory"]
+            )
+        );
+        db.VulnerabilityApplicabilities.Add(
+            VulnerabilityApplicability.Create(
+                vulnerability.Id,
+                null,
+                "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                true,
+                "1.0",
+                null,
+                "2.0",
+                null,
+                "nvd"
+            )
+        );
+        db.ThreatAssessments.Add(
+            ThreatAssessment.Create(
+                vulnerability.Id,
+                95m,
+                90m,
+                88m,
+                70m,
+                0.91m,
+                knownExploited: true,
+                publicExploit: true,
+                activeAlert: false,
+                hasRansomwareAssociation: true,
+                hasMalwareAssociation: false,
+                "[]",
+                "test"
+            )
+        );
+        db.NvdCveCache.Add(
+            NvdCveCache.Create(
+                "CVE-2026-1234",
+                "NVD cached description",
+                9.8m,
+                "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                new DateTimeOffset(2026, 1, 2, 0, 0, 0, TimeSpan.Zero),
+                DateTimeOffset.UtcNow,
+                JsonSerializer.Serialize(
+                    new[] { new NvdCachedReference("https://nvd.nist.gov/vuln/detail/CVE-2026-1234", "NVD", new List<string> { "nvd" }) }
+                ),
+                JsonSerializer.Serialize(
+                    new[] { new NvdCachedCpeMatch(true, "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", "1.0", null, "2.0", null) }
+                )
+            )
+        );
+        db.SaveChanges();
+
+        return vulnerability;
     }
 
     private sealed class RecordingHttpMessageHandler(


### PR DESCRIPTION
## Summary

- add local vulnerability intel as the baseline research source for CVE assessment jobs
- split r.jina-backed external research into a dedicated provider and make the existing research service orchestrate local plus external providers
- add configurable r.jina search provider defaults and UI warning copy for PatchHound-managed external research

## Behavior

- vulnerability assessments now include local PatchHound/NVD/threat context first
- external r.jina research is only added for PatchHound-managed profiles when external research is enabled
- provider-native OpenAI research keeps provider-native web search while also carrying local context

## Validation

- `dotnet test --filter "FullyQualifiedName~PatchHound.Tests.Infrastructure.TenantAiResearchServiceTests|FullyQualifiedName~PatchHound.Tests.Worker.IngestionWorkerTests"`
- `dotnet test PatchHound.slnx -v minimal`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- GitNexus `detect_changes(scope: staged)` reported low risk and no affected execution flows
