### PR TITLE
fix(exposure): refresh linkage fields on upsert conflict (#83)

### DIFF
--- a/src/PatchHound.Core/Entities/DeviceVulnerabilityExposure.cs
+++ b/src/PatchHound.Core/Entities/DeviceVulnerabilityExposure.cs
@@ -85,6 +85,29 @@ public class DeviceVulnerabilityExposure
     }
 
     /// <summary>
+    /// Re-observes the exposure and re-points its linkage fields at the install that is
+    /// currently driving it. Mirrors the Postgres <c>ON CONFLICT DO UPDATE</c> path: the
+    /// caller supplies the canonical "current evidence" tuple (deduped, Product preferred
+    /// over Cpe), so a re-derivation that emerges from a different install no longer leaves
+    /// the row frozen at its original linkage. <see cref="FirstObservedAt"/> is untouched.
+    /// </summary>
+    public void Reobserve(
+        DateTimeOffset observedAt,
+        Guid runId,
+        Guid? installedSoftwareId,
+        Guid? softwareProductId,
+        string matchedVersion,
+        ExposureMatchSource matchSource)
+    {
+        Reobserve(observedAt, runId);
+
+        InstalledSoftwareId = installedSoftwareId;
+        SoftwareProductId = softwareProductId;
+        MatchedVersion = matchedVersion?.Trim() ?? string.Empty;
+        MatchSource = matchSource;
+    }
+
+    /// <summary>
     /// Marks the exposure resolved. <see cref="LastSeenRunId"/> is intentionally not updated —
     /// it continues to record the last run that observed the row as open.
     /// </summary>

--- a/src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs
+++ b/src/PatchHound.Infrastructure/Services/ExposureDerivationService.cs
@@ -171,7 +171,14 @@ public class ExposureDerivationService(
                     "ResolvedAt"     = NULL,
                     "LastSeenRunId"  = EXCLUDED."LastSeenRunId",
                     "LastMissedRunId" = NULL,
-                    "MissingSyncCount" = 0
+                    "MissingSyncCount" = 0,
+                    -- Re-point linkage at the current evidence (the deduped row prefers
+                    -- Product over Cpe), so the exposure keeps describing the install that
+                    -- is actually driving it instead of freezing at the original INSERT.
+                    "InstalledSoftwareId" = EXCLUDED."InstalledSoftwareId",
+                    "SoftwareProductId"   = EXCLUDED."SoftwareProductId",
+                    "MatchedVersion"      = EXCLUDED."MatchedVersion",
+                    "MatchSource"         = EXCLUDED."MatchSource"
                 RETURNING (xmax = 0) AS inserted
             )
             SELECT

--- a/tests/PatchHound.Tests/Infrastructure/Services/ExposureDerivationServiceCteTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/ExposureDerivationServiceCteTests.cs
@@ -298,4 +298,75 @@ public class ExposureDerivationServiceCteTests
         exposures.Select(e => e.DeviceId).Should().BeEquivalentTo(new[] { otherSourceDevice.Id, currentSourceDevice.Id });
         exposures.Should().OnlyContain(e => e.LastSeenRunId == currentRun);
     }
+
+    /// <summary>
+    /// Issue #83: on conflict the upsert must refresh the linkage columns, not freeze them
+    /// at the original INSERT. When an exposure is re-derived from a *different* install
+    /// (e.g. the originally-linked install was pruned and a sibling product now drives the
+    /// same (device, vuln)), the row must re-point at the new install, product, version and
+    /// match source — while keeping FirstObservedAt and bumping LastSeenRunId.
+    /// </summary>
+    [Fact]
+    public async Task DeriveForTenantAsync_repoints_linkage_when_exposure_rederived_from_different_install()
+    {
+        await _fx.ResetAsync();
+        await using var db = _fx.CreateDbContext();
+
+        var productA = SoftwareProduct.Create("Acme", "Widget", "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*");
+        var productB = SoftwareProduct.Create("Acme", "Gadget", "cpe:2.3:a:acme:gadget:*:*:*:*:*:*:*:*");
+        var vuln = Vulnerability.Create("nvd", "CVE-2026-CTE6", "t", "d", Severity.Critical, 9.5m, "v", DateTimeOffset.UtcNow);
+        db.SoftwareProducts.AddRange(productA, productB);
+        db.Vulnerabilities.Add(vuln);
+        // Both products are applicable to the same vulnerability, so an install of either
+        // produces an exposure on the same (device, vuln) conflict key.
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, productA.Id, null, true, null, null, null, null));
+        db.VulnerabilityApplicabilities.Add(VulnerabilityApplicability.Create(
+            vuln.Id, productB.Id, null, true, null, null, null, null));
+
+        var source = SourceSystem.Create("test", "Test");
+        db.SourceSystems.Add(source);
+        var device = Device.Create(TenantId, source.Id, "dev-1", "Device", Criticality.Medium);
+        db.Devices.Add(device);
+
+        var firstRun = Guid.NewGuid();
+        var installA = InstalledSoftware.Observe(TenantId, device.Id, productA.Id, source.Id, "1.0", DateTimeOffset.UtcNow, firstRun);
+        db.InstalledSoftware.Add(installA);
+        await db.SaveChangesAsync();
+
+        var svc = new ExposureDerivationService(
+            db, NullLogger<ExposureDerivationService>.Instance, new PostgresBulkExposureWriter(db));
+
+        var firstObservedAt = DateTimeOffset.UtcNow;
+        await svc.DeriveForTenantAsync(TenantId, firstObservedAt, firstRun, CancellationToken.None);
+
+        var initial = await db.DeviceVulnerabilityExposures.AsNoTracking().IgnoreQueryFilters().SingleAsync();
+        initial.InstalledSoftwareId.Should().Be(installA.Id);
+        initial.SoftwareProductId.Should().Be(productA.Id);
+        initial.MatchedVersion.Should().Be("1.0");
+
+        // The originally-linked install is pruned; a different product's install now drives
+        // the same (device, vuln) exposure.
+        db.InstalledSoftware.Remove(installA);
+        var secondRun = Guid.NewGuid();
+        var installB = InstalledSoftware.Observe(TenantId, device.Id, productB.Id, source.Id, "2.0", DateTimeOffset.UtcNow, secondRun);
+        db.InstalledSoftware.Add(installB);
+        await db.SaveChangesAsync();
+
+        var secondObservedAt = firstObservedAt.AddHours(1);
+        var result = await svc.DeriveForTenantAsync(TenantId, secondObservedAt, secondRun, CancellationToken.None);
+
+        result.Inserted.Should().Be(0);
+        result.Reobserved.Should().Be(1);
+        result.Resolved.Should().Be(0);
+
+        var refreshed = await db.DeviceVulnerabilityExposures.AsNoTracking().IgnoreQueryFilters().SingleAsync();
+        refreshed.Id.Should().Be(initial.Id, "the same conflict row is updated, not replaced");
+        refreshed.InstalledSoftwareId.Should().Be(installB.Id);
+        refreshed.SoftwareProductId.Should().Be(productB.Id);
+        refreshed.MatchedVersion.Should().Be("2.0");
+        refreshed.MatchSource.Should().Be(ExposureMatchSource.Product);
+        refreshed.FirstObservedAt.Should().BeCloseTo(firstObservedAt, TimeSpan.FromSeconds(1));
+        refreshed.LastSeenRunId.Should().Be(secondRun);
+    }
 }

--- a/tests/PatchHound.Tests/TestData/InMemoryBulkExposureWriter.cs
+++ b/tests/PatchHound.Tests/TestData/InMemoryBulkExposureWriter.cs
@@ -39,11 +39,12 @@ internal sealed class InMemoryBulkExposureWriter(PatchHoundDbContext db) : IBulk
                       && e.VulnerabilityId == row.VulnerabilityId,
                     ct);
 
+            var match = row.MatchSource == nameof(ExposureMatchSource.Cpe)
+                ? ExposureMatchSource.Cpe
+                : ExposureMatchSource.Product;
+
             if (existing is null)
             {
-                var match = row.MatchSource == nameof(ExposureMatchSource.Cpe)
-                    ? ExposureMatchSource.Cpe
-                    : ExposureMatchSource.Product;
                 var fresh = DeviceVulnerabilityExposure.Observe(
                     row.TenantId,
                     row.DeviceId,
@@ -59,7 +60,14 @@ internal sealed class InMemoryBulkExposureWriter(PatchHoundDbContext db) : IBulk
             }
             else
             {
-                existing.Reobserve(row.ObservedAt, row.RunId);
+                // Mirror the Postgres ON CONFLICT path: re-point linkage at the current evidence.
+                existing.Reobserve(
+                    row.ObservedAt,
+                    row.RunId,
+                    installedSoftwareId: row.InstalledSoftwareId,
+                    softwareProductId: row.SoftwareProductId,
+                    matchedVersion: row.MatchedVersion ?? string.Empty,
+                    matchSource: match);
                 reobserved++;
             }
         }


### PR DESCRIPTION
Closes #83.

## Problem

`ExposureDerivationService.DeriveAndUpsertPostgresAsync` only refreshed `LastObservedAt`, `Status`, `ResolvedAt`, `LastSeenRunId` (+ miss tracking) on the `ON CONFLICT DO UPDATE` branch. The linkage fields (`InstalledSoftwareId`, `SoftwareProductId`, `MatchedVersion`, `MatchSource`) stayed frozen at the original `INSERT`, so over time the row stopped describing the install actually driving the exposure — pruned installs left `InstalledSoftwareId = NULL`, and `MatchedVersion` drifted from the linked install's current version.

## Changes

- **Postgres upsert**: `ON CONFLICT DO UPDATE` now re-points the four linkage columns to `EXCLUDED.*` (the deduped current-evidence tuple, Product preferred over Cpe). Existing status/observation/miss-tracking updates are unchanged.
- **Entity**: added a richer `DeviceVulnerabilityExposure.Reobserve(observedAt, runId, installedSoftwareId, softwareProductId, matchedVersion, matchSource)` overload (factory-boundary discipline), delegating to the original for shared logic.
- **InMemory writer**: now calls the new overload so the test path mirrors production.
- **New CTE test**: re-derives an exposure from a *different* install (original pruned) and asserts the row re-points to the new install/product/version, with `FirstObservedAt` preserved and `LastSeenRunId` bumped.

`FirstObservedAt` is intentionally untouched on conflict.

## Verification

- New test confirmed red→green: it **fails** against the unfixed code (`InstalledSoftwareId` stays NULL) and **passes** with the fix.
- Full suite: **926/926 passing**, including all 8 `ExposureDerivationServiceCteTests` and the episode-closure tests (`LastSeenRunId` bump preserved, so `ResolveStaleAsync` still leaves true stale exposures behind).

## Acceptance criteria

- [x] Postgres upsert refreshes the four linkage columns on conflict.
- [x] InMemory writer matches.
- [x] New CTE test asserts re-derivation from a different install re-points linkage.
- [x] No regression in `ExposureDerivationServiceCteTests`.
- [x] No regression in episode-closure flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)