### PR TITLE
feat: add OpenBao setup scripts (PowerShell + Bash)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@ POSTGRES_DB=patchhound
 POSTGRES_USER=patchhound
 POSTGRES_PASSWORD=change-me
 
-OPENBAO_ADDR=http://localhost:8200
 OPENBAO_INTERNAL_ADDR=http://openbao:8200
 OPENBAO_TOKEN=
 OPENBAO_KV_MOUNT=patchhound
@@ -24,6 +23,5 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 
 SESSION_SECRET=change-me-to-at-least-32-characters
-SESSION_DATABASE_URL=
 ENTRA_CLIENT_SECRET=
 ENTRA_SCOPES=openid profile email

--- a/setup.ps1
+++ b/setup.ps1
@@ -29,11 +29,10 @@ $status = $null
 do {
     Start-Sleep -Seconds 2
     $elapsed += 2
-    # bao status exits 0 (active) or 2 (sealed) when ready; capture JSON from stdout regardless.
+    # Ignore exit code — bao status exits 1 for both "not yet up" and "uninitialized".
+    # Valid JSON in stdout is the only reliable signal the server is accepting requests.
     $statusJson = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null
-    if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 2) {
-        $status = $statusJson | ConvertFrom-Json -ErrorAction SilentlyContinue
-    }
+    $status = $statusJson | ConvertFrom-Json -ErrorAction SilentlyContinue
 } while (-not $status -and $elapsed -lt $maxWait)
 
 if (-not $status) {

--- a/setup.ps1
+++ b/setup.ps1
@@ -152,28 +152,11 @@ Set-EnvValue -File '.env' -Key 'OPENBAO_TOKEN' -Value $appToken
 
 # ── 12. Prompt for Azure AD values ────────────────────────────────────────────
 Write-Host "==> Azure AD configuration" -ForegroundColor Cyan
-Write-Host "    Press Enter to keep the current value (shown in brackets)."
 Write-Host ""
 
-function Read-EnvValue {
-    param([string]$File, [string]$Key)
-    $line = Get-Content $File | Where-Object { $_ -match "^$Key=" } | Select-Object -First 1
-    if ($line) { return $line.Substring($Key.Length + 1) }
-    return ''
-}
-
-$currentClientId  = Read-EnvValue -File '.env' -Key 'AZURE_AD_CLIENT_ID'
-$currentTenantId  = Read-EnvValue -File '.env' -Key 'AZURE_AD_TENANT_ID'
-$currentAudience  = Read-EnvValue -File '.env' -Key 'AZURE_AD_AUDIENCE'
-
-$clientId = Read-Host "  AZURE_AD_CLIENT_ID  [$currentClientId]"
-if ([string]::IsNullOrWhiteSpace($clientId)) { $clientId = $currentClientId }
-
-$tenantId = Read-Host "  AZURE_AD_TENANT_ID  [$currentTenantId]"
-if ([string]::IsNullOrWhiteSpace($tenantId)) { $tenantId = $currentTenantId }
-
-$audience = Read-Host "  AZURE_AD_AUDIENCE    [$currentAudience]"
-if ([string]::IsNullOrWhiteSpace($audience)) { $audience = $currentAudience }
+$clientId = Read-Host "  AZURE_AD_CLIENT_ID"
+$tenantId = Read-Host "  AZURE_AD_TENANT_ID"
+$audience = Read-Host "  AZURE_AD_AUDIENCE"
 
 Set-EnvValue -File '.env' -Key 'AZURE_AD_CLIENT_ID' -Value $clientId
 Set-EnvValue -File '.env' -Key 'AZURE_AD_TENANT_ID' -Value $tenantId

--- a/setup.ps1
+++ b/setup.ps1
@@ -23,9 +23,8 @@ Write-Host "`n==> Starting OpenBao container..." -ForegroundColor Cyan
 docker compose up -d openbao
 
 # Wait until the HTTP listener is accepting connections.
-# Use the sys/health endpoint — it responds with a non-connection-error HTTP
-# status regardless of init/seal state. We do NOT use `bao status` here:
-# it exits 1 when uninitialized, which is indistinguishable from "not yet started".
+# curl.exe exits 0 for any HTTP response regardless of status code (without -f),
+# and non-zero only when it cannot connect at all. This works on all init/seal states.
 Write-Host "    Waiting for OpenBao HTTP listener..."
 $maxWait = 60
 $elapsed = 0
@@ -33,15 +32,8 @@ $ready = $false
 do {
     Start-Sleep -Seconds 2
     $elapsed += 2
-    try {
-        $null = Invoke-WebRequest -Uri "$BAO_ADDR/v1/sys/health" -TimeoutSec 2 -ErrorAction Stop
-        $ready = $true
-    } catch [System.Net.WebException] {
-        # A WebException with a response means the server is up (e.g. 429, 501, 503).
-        if ($_.Exception.Response) { $ready = $true }
-    } catch {
-        # Connection refused / timeout — not ready yet.
-    }
+    curl.exe -s --max-time 2 "$BAO_ADDR/v1/sys/health" -o NUL 2>$null
+    if ($LASTEXITCODE -eq 0) { $ready = $true }
 } while (-not $ready -and $elapsed -lt $maxWait)
 
 if (-not $ready) {

--- a/setup.ps1
+++ b/setup.ps1
@@ -25,10 +25,15 @@ docker compose up -d openbao
 Write-Host "    Waiting for OpenBao to be ready..."
 $maxWait = 60
 $elapsed = 0
+$status = $null
 do {
     Start-Sleep -Seconds 2
     $elapsed += 2
-    $status = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+    # bao status exits 0 (active) or 2 (sealed) when ready; capture JSON from stdout regardless.
+    $statusJson = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null
+    if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 2) {
+        $status = $statusJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+    }
 } while (-not $status -and $elapsed -lt $maxWait)
 
 if (-not $status) {
@@ -56,7 +61,6 @@ $rootToken = $init.root_token
 $unsealKeys = $init.unseal_keys_b64
 
 # ── 4. Unseal ────────────────────────────────────────────────────────────────
-$status = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
 if ($status -and -not $status.sealed) {
     Write-Host "    OpenBao already unsealed." -ForegroundColor Yellow
 } else {

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,171 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$BAO_ADDR = 'http://127.0.0.1:8200'
+$KV_MOUNT = 'patchhound'
+$INIT_DIR = '.openbao-init'
+$INIT_FILE = "$INIT_DIR/init.json"
+
+function Invoke-Bao {
+    param([string[]]$Args)
+    docker compose exec -e "BAO_ADDR=$BAO_ADDR" openbao bao @Args
+}
+
+# ── 1. Build containers ──────────────────────────────────────────────────────
+Write-Host "`n==> Building containers..." -ForegroundColor Cyan
+docker compose build
+
+# ── 2. Start OpenBao only ────────────────────────────────────────────────────
+Write-Host "`n==> Starting OpenBao container..." -ForegroundColor Cyan
+docker compose up -d openbao
+
+Write-Host "    Waiting for OpenBao to be ready..."
+$maxWait = 60
+$elapsed = 0
+do {
+    Start-Sleep -Seconds 2
+    $elapsed += 2
+    $status = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+} while (-not $status -and $elapsed -lt $maxWait)
+
+if (-not $status) {
+    Write-Error "OpenBao did not become ready within ${maxWait}s."
+}
+
+# ── 3. Initialize ────────────────────────────────────────────────────────────
+New-Item -ItemType Directory -Force -Path $INIT_DIR | Out-Null
+
+if ($status.initialized) {
+    Write-Host "    OpenBao already initialized." -ForegroundColor Yellow
+    if (-not (Test-Path $INIT_FILE)) {
+        Write-Error "OpenBao is initialized but $INIT_FILE is missing. Recreate the openbao_data volume to start fresh."
+    }
+    $init = Get-Content $INIT_FILE | ConvertFrom-Json
+} else {
+    Write-Host "`n==> Initializing OpenBao..." -ForegroundColor Cyan
+    $initJson = Invoke-Bao 'operator', 'init', '-format=json'
+    $initJson | Set-Content -Path $INIT_FILE
+    $init = $initJson | ConvertFrom-Json
+    Write-Host "    Init output saved to $INIT_FILE"
+}
+
+$rootToken = $init.root_token
+$unsealKeys = $init.unseal_keys_b64
+
+# ── 4. Unseal ────────────────────────────────────────────────────────────────
+$status = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($status -and -not $status.sealed) {
+    Write-Host "    OpenBao already unsealed." -ForegroundColor Yellow
+} else {
+    Write-Host "`n==> Unsealing OpenBao..." -ForegroundColor Cyan
+    foreach ($key in $unsealKeys[0..2]) {
+        Invoke-Bao 'operator', 'unseal', $key | Out-Null
+    }
+    Write-Host "    Unsealed."
+}
+
+# ── 5. Login with root token ─────────────────────────────────────────────────
+Write-Host "`n==> Logging in with root token..." -ForegroundColor Cyan
+Invoke-Bao 'login', '-no-print', $rootToken
+
+# ── 6. Enable KV v2 ──────────────────────────────────────────────────────────
+$secretsList = Invoke-Bao 'secrets', 'list', '-format=json' | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($secretsList -and $secretsList."$KV_MOUNT/") {
+    Write-Host "    KV mount '$KV_MOUNT' already enabled." -ForegroundColor Yellow
+} else {
+    Write-Host "`n==> Enabling KV v2 at $KV_MOUNT/..." -ForegroundColor Cyan
+    Invoke-Bao 'secrets', 'enable', "-path=$KV_MOUNT", 'kv-v2'
+}
+
+# ── 7. Write policy ───────────────────────────────────────────────────────────
+Write-Host "`n==> Writing PatchHound policy..." -ForegroundColor Cyan
+$policyHcl = @"
+path "$KV_MOUNT/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+"@
+$policyFile = "$INIT_DIR/patchhound-policy.hcl"
+$policyHcl | Set-Content -Path $policyFile
+
+docker compose cp $policyFile openbao:/tmp/patchhound-policy.hcl
+Invoke-Bao 'policy', 'write', 'patchhound', '/tmp/patchhound-policy.hcl'
+
+# ── 8. Create application token ───────────────────────────────────────────────
+Write-Host "`n==> Creating PatchHound application token..." -ForegroundColor Cyan
+$tokenJson = Invoke-Bao 'token', 'create', '-policy=patchhound', '-format=json' | ConvertFrom-Json
+$appToken = $tokenJson.auth.client_token
+$appToken | Set-Content -Path "$INIT_DIR/app-token.txt"
+Write-Host "    Application token saved to $INIT_DIR/app-token.txt"
+
+# ── 9. Stop OpenBao ───────────────────────────────────────────────────────────
+Write-Host "`n==> Stopping OpenBao container..." -ForegroundColor Cyan
+docker compose stop openbao
+
+# ── 10. Print tokens ──────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "============================================" -ForegroundColor Green
+Write-Host "  OpenBao setup complete" -ForegroundColor Green
+Write-Host "============================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "Root token:        $rootToken" -ForegroundColor Yellow
+Write-Host "PatchHound token:  $appToken" -ForegroundColor Yellow
+Write-Host ""
+
+# ── 11. Create / update .env ──────────────────────────────────────────────────
+if (-not (Test-Path '.env')) {
+    Write-Host "==> Copying .env.example -> .env..." -ForegroundColor Cyan
+    Copy-Item '.env.example' '.env'
+}
+
+function Set-EnvValue {
+    param([string]$File, [string]$Key, [string]$Value)
+    $content = Get-Content $File
+    $pattern = "^$Key=.*$"
+    if ($content -match $pattern) {
+        $content = $content -replace $pattern, "$Key=$Value"
+    } else {
+        $content += "$Key=$Value"
+    }
+    $content | Set-Content -Path $File -NoNewline:$false
+}
+
+Set-EnvValue -File '.env' -Key 'OPENBAO_TOKEN' -Value $appToken
+
+# ── 12. Prompt for Azure AD values ────────────────────────────────────────────
+Write-Host "==> Azure AD configuration" -ForegroundColor Cyan
+Write-Host "    Press Enter to keep the current value (shown in brackets)."
+Write-Host ""
+
+function Read-EnvValue {
+    param([string]$File, [string]$Key)
+    $line = Get-Content $File | Where-Object { $_ -match "^$Key=" } | Select-Object -First 1
+    if ($line) { return $line.Substring($Key.Length + 1) }
+    return ''
+}
+
+$currentClientId  = Read-EnvValue -File '.env' -Key 'AZURE_AD_CLIENT_ID'
+$currentTenantId  = Read-EnvValue -File '.env' -Key 'AZURE_AD_TENANT_ID'
+$currentAudience  = Read-EnvValue -File '.env' -Key 'AZURE_AD_AUDIENCE'
+
+$clientId = Read-Host "  AZURE_AD_CLIENT_ID  [$currentClientId]"
+if ([string]::IsNullOrWhiteSpace($clientId)) { $clientId = $currentClientId }
+
+$tenantId = Read-Host "  AZURE_AD_TENANT_ID  [$currentTenantId]"
+if ([string]::IsNullOrWhiteSpace($tenantId)) { $tenantId = $currentTenantId }
+
+$audience = Read-Host "  AZURE_AD_AUDIENCE    [$currentAudience]"
+if ([string]::IsNullOrWhiteSpace($audience)) { $audience = $currentAudience }
+
+Set-EnvValue -File '.env' -Key 'AZURE_AD_CLIENT_ID' -Value $clientId
+Set-EnvValue -File '.env' -Key 'AZURE_AD_TENANT_ID' -Value $tenantId
+Set-EnvValue -File '.env' -Key 'AZURE_AD_AUDIENCE'  -Value $audience
+
+Write-Host ""
+Write-Host "==> .env updated." -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Cyan
+Write-Host "  docker compose up -d --build"
+Write-Host ""

--- a/setup.ps1
+++ b/setup.ps1
@@ -10,8 +10,8 @@ $INIT_DIR = '.openbao-init'
 $INIT_FILE = "$INIT_DIR/init.json"
 
 function Invoke-Bao {
-    param([string[]]$Args)
-    docker compose exec -e "BAO_ADDR=$BAO_ADDR" openbao bao @Args
+    param([string[]]$BaoArgs)
+    docker compose exec -e "BAO_ADDR=$BAO_ADDR" openbao bao @BaoArgs
 }
 
 # ── 1. Build containers ──────────────────────────────────────────────────────

--- a/setup.ps1
+++ b/setup.ps1
@@ -22,7 +22,6 @@ POSTGRES_DB=patchhound
 POSTGRES_USER=patchhound
 POSTGRES_PASSWORD=change-me
 
-OPENBAO_ADDR=http://localhost:8200
 OPENBAO_INTERNAL_ADDR=http://openbao:8200
 OPENBAO_TOKEN=
 OPENBAO_KV_MOUNT=patchhound
@@ -44,7 +43,6 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 
 SESSION_SECRET=change-me-to-at-least-32-characters
-SESSION_DATABASE_URL=
 ENTRA_CLIENT_SECRET=
 ENTRA_SCOPES=openid profile email
 '@ | Set-Content -Path '.env'

--- a/setup.ps1
+++ b/setup.ps1
@@ -14,6 +14,42 @@ function Invoke-Bao {
     docker compose exec -e "BAO_ADDR=$BAO_ADDR" openbao bao @BaoArgs
 }
 
+# ── 0. Ensure a minimal .env exists before any docker compose command ────────
+if (-not (Test-Path '.env')) {
+    Write-Host "`n==> Creating minimal .env..." -ForegroundColor Cyan
+    @'
+POSTGRES_DB=patchhound
+POSTGRES_USER=patchhound
+POSTGRES_PASSWORD=change-me
+
+OPENBAO_ADDR=http://localhost:8200
+OPENBAO_INTERNAL_ADDR=http://openbao:8200
+OPENBAO_TOKEN=
+OPENBAO_KV_MOUNT=patchhound
+
+API_ENVIRONMENT=Development
+WORKER_ENVIRONMENT=Development
+FRONTEND_NODE_ENV=production
+
+AZURE_AD_CLIENT_ID=
+AZURE_AD_TENANT_ID=common
+AZURE_AD_AUDIENCE=
+AZURE_AD_ENABLE_PII_LOGGING=true
+
+FRONTEND_ORIGIN=http://localhost:3000
+
+SMTP_HOST=localhost
+SMTP_PORT=25
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+SESSION_SECRET=change-me-to-at-least-32-characters
+SESSION_DATABASE_URL=
+ENTRA_CLIENT_SECRET=
+ENTRA_SCOPES=openid profile email
+'@ | Set-Content -Path '.env'
+}
+
 # ── 1. Build containers ──────────────────────────────────────────────────────
 Write-Host "`n==> Building containers..." -ForegroundColor Cyan
 docker compose build
@@ -130,12 +166,7 @@ Write-Host "Root token:        $rootToken" -ForegroundColor Yellow
 Write-Host "PatchHound token:  $appToken" -ForegroundColor Yellow
 Write-Host ""
 
-# ── 11. Create / update .env ──────────────────────────────────────────────────
-if (-not (Test-Path '.env')) {
-    Write-Host "==> Copying .env.example -> .env..." -ForegroundColor Cyan
-    Copy-Item '.env.example' '.env'
-}
-
+# ── 11. Update .env with generated token ─────────────────────────────────────
 function Set-EnvValue {
     param([string]$File, [string]$Key, [string]$Value)
     $content = Get-Content $File

--- a/setup.ps1
+++ b/setup.ps1
@@ -22,27 +22,40 @@ docker compose build
 Write-Host "`n==> Starting OpenBao container..." -ForegroundColor Cyan
 docker compose up -d openbao
 
-Write-Host "    Waiting for OpenBao to be ready..."
+# Wait until the HTTP listener is accepting connections.
+# Use the sys/health endpoint — it responds with a non-connection-error HTTP
+# status regardless of init/seal state. We do NOT use `bao status` here:
+# it exits 1 when uninitialized, which is indistinguishable from "not yet started".
+Write-Host "    Waiting for OpenBao HTTP listener..."
 $maxWait = 60
 $elapsed = 0
-$status = $null
+$ready = $false
 do {
     Start-Sleep -Seconds 2
     $elapsed += 2
-    # Ignore exit code — bao status exits 1 for both "not yet up" and "uninitialized".
-    # Valid JSON in stdout is the only reliable signal the server is accepting requests.
-    $statusJson = docker compose exec openbao bao status -address=$BAO_ADDR -format=json 2>$null
-    $status = $statusJson | ConvertFrom-Json -ErrorAction SilentlyContinue
-} while (-not $status -and $elapsed -lt $maxWait)
+    try {
+        $null = Invoke-WebRequest -Uri "$BAO_ADDR/v1/sys/health" -TimeoutSec 2 -ErrorAction Stop
+        $ready = $true
+    } catch [System.Net.WebException] {
+        # A WebException with a response means the server is up (e.g. 429, 501, 503).
+        if ($_.Exception.Response) { $ready = $true }
+    } catch {
+        # Connection refused / timeout — not ready yet.
+    }
+} while (-not $ready -and $elapsed -lt $maxWait)
 
-if (-not $status) {
-    Write-Error "OpenBao did not become ready within ${maxWait}s."
+if (-not $ready) {
+    Write-Error "OpenBao did not start within ${maxWait}s."
 }
+Write-Host "    OpenBao is up."
 
 # ── 3. Initialize ────────────────────────────────────────────────────────────
 New-Item -ItemType Directory -Force -Path $INIT_DIR | Out-Null
 
-if ($status.initialized) {
+# Check init state via the API (not bao status).
+$initState = Invoke-RestMethod -Uri "$BAO_ADDR/v1/sys/init" -ErrorAction SilentlyContinue
+
+if ($initState.initialized) {
     Write-Host "    OpenBao already initialized." -ForegroundColor Yellow
     if (-not (Test-Path $INIT_FILE)) {
         Write-Error "OpenBao is initialized but $INIT_FILE is missing. Recreate the openbao_data volume to start fresh."
@@ -60,10 +73,12 @@ $rootToken = $init.root_token
 $unsealKeys = $init.unseal_keys_b64
 
 # ── 4. Unseal ────────────────────────────────────────────────────────────────
-if ($status -and -not $status.sealed) {
+$sealState = Invoke-RestMethod -Uri "$BAO_ADDR/v1/sys/seal-status" -ErrorAction SilentlyContinue
+
+if ($sealState -and -not $sealState.sealed) {
     Write-Host "    OpenBao already unsealed." -ForegroundColor Yellow
 } else {
-    Write-Host "`n==> Unsealing OpenBao..." -ForegroundColor Cyan
+    Write-Host "`n==> Unsealing OpenBao (3 of 5 keys)..." -ForegroundColor Cyan
     foreach ($key in $unsealKeys[0..2]) {
         Invoke-Bao 'operator', 'unseal', $key | Out-Null
     }
@@ -107,11 +122,16 @@ Write-Host "    Application token saved to $INIT_DIR/app-token.txt"
 Write-Host "`n==> Stopping OpenBao container..." -ForegroundColor Cyan
 docker compose stop openbao
 
-# ── 10. Print tokens ──────────────────────────────────────────────────────────
+# ── 10. Print summary ─────────────────────────────────────────────────────────
 Write-Host ""
 Write-Host "============================================" -ForegroundColor Green
 Write-Host "  OpenBao setup complete" -ForegroundColor Green
 Write-Host "============================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "Unseal keys (keep these safe):" -ForegroundColor Yellow
+for ($i = 0; $i -lt $unsealKeys.Count; $i++) {
+    Write-Host "  Key $($i + 1): $($unsealKeys[$i])" -ForegroundColor Yellow
+}
 Write-Host ""
 Write-Host "Root token:        $rootToken" -ForegroundColor Yellow
 Write-Host "PatchHound token:  $appToken" -ForegroundColor Yellow

--- a/setup.ps1
+++ b/setup.ps1
@@ -83,7 +83,8 @@ Invoke-Bao 'login', '-no-print', $rootToken
 
 # ── 6. Enable KV v2 ──────────────────────────────────────────────────────────
 $secretsList = Invoke-Bao 'secrets', 'list', '-format=json' | ConvertFrom-Json -ErrorAction SilentlyContinue
-if ($secretsList -and $secretsList."$KV_MOUNT/") {
+$kvMountKey = "$KV_MOUNT/"
+if ($secretsList -and $secretsList.PSObject.Properties[$kvMountKey]) {
     Write-Host "    KV mount '$KV_MOUNT' already enabled." -ForegroundColor Yellow
 } else {
     Write-Host "`n==> Enabling KV v2 at $KV_MOUNT/..." -ForegroundColor Cyan

--- a/setup.sh
+++ b/setup.sh
@@ -160,20 +160,11 @@ set_env_value .env OPENBAO_TOKEN "$app_token"
 
 # ── 12. Prompt for Azure AD values ────────────────────────────────────────────
 cyan "==> Azure AD configuration"
-echo "    Press Enter to keep the current value (shown in brackets)."
 echo
 
-current_client_id=$(read_env_value .env AZURE_AD_CLIENT_ID)
-current_tenant_id=$(read_env_value .env AZURE_AD_TENANT_ID)
-current_audience=$(read_env_value  .env AZURE_AD_AUDIENCE)
-
-read -r -p "  AZURE_AD_CLIENT_ID  [${current_client_id}]: " client_id
-read -r -p "  AZURE_AD_TENANT_ID  [${current_tenant_id}]: " tenant_id
-read -r -p "  AZURE_AD_AUDIENCE    [${current_audience}]: " audience
-
-[ -z "$client_id" ] && client_id="$current_client_id"
-[ -z "$tenant_id" ] && tenant_id="$current_tenant_id"
-[ -z "$audience"  ] && audience="$current_audience"
+read -r -p "  AZURE_AD_CLIENT_ID: " client_id
+read -r -p "  AZURE_AD_TENANT_ID: " tenant_id
+read -r -p "  AZURE_AD_AUDIENCE:  " audience
 
 set_env_value .env AZURE_AD_CLIENT_ID "$client_id"
 set_env_value .env AZURE_AD_TENANT_ID "$tenant_id"

--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,42 @@ json_field() {
     python3 -c "import sys,json; print(json.load(sys.stdin)$1)"
 }
 
+# ── 0. Ensure a minimal .env exists before any docker compose command ────────
+if [ ! -f .env ]; then
+    cyan "==> Creating minimal .env..."
+    cat > .env <<'EOF'
+POSTGRES_DB=patchhound
+POSTGRES_USER=patchhound
+POSTGRES_PASSWORD=change-me
+
+OPENBAO_ADDR=http://localhost:8200
+OPENBAO_INTERNAL_ADDR=http://openbao:8200
+OPENBAO_TOKEN=
+OPENBAO_KV_MOUNT=patchhound
+
+API_ENVIRONMENT=Development
+WORKER_ENVIRONMENT=Development
+FRONTEND_NODE_ENV=production
+
+AZURE_AD_CLIENT_ID=
+AZURE_AD_TENANT_ID=common
+AZURE_AD_AUDIENCE=
+AZURE_AD_ENABLE_PII_LOGGING=true
+
+FRONTEND_ORIGIN=http://localhost:3000
+
+SMTP_HOST=localhost
+SMTP_PORT=25
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+SESSION_SECRET=change-me-to-at-least-32-characters
+SESSION_DATABASE_URL=
+ENTRA_CLIENT_SECRET=
+ENTRA_SCOPES=openid profile email
+EOF
+fi
+
 # ── 1. Build containers ──────────────────────────────────────────────────────
 echo; cyan "==> Building containers..."
 docker compose build
@@ -150,12 +186,7 @@ yellow "Root token:        $root_token"
 yellow "PatchHound token:  $app_token"
 echo
 
-# ── 11. Create / update .env ──────────────────────────────────────────────────
-if [ ! -f .env ]; then
-    cyan "==> Copying .env.example -> .env..."
-    cp .env.example .env
-fi
-
+# ── 11. Update .env with generated token ─────────────────────────────────────
 set_env_value .env OPENBAO_TOKEN "$app_token"
 
 # ── 12. Prompt for Azure AD values ────────────────────────────────────────────

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BAO_ADDR='http://127.0.0.1:8200'
+KV_MOUNT='patchhound'
+INIT_DIR='.openbao-init'
+INIT_FILE="$INIT_DIR/init.json"
+
+bao() { docker compose exec -e "BAO_ADDR=$BAO_ADDR" openbao bao "$@"; }
+
+cyan()   { printf '\033[36m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+
+set_env_value() {
+    local file="$1" key="$2" value="$3"
+    if grep -qE "^${key}=" "$file"; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+    else
+        echo "${key}=${value}" >> "$file"
+    fi
+}
+
+read_env_value() {
+    local file="$1" key="$2"
+    grep -E "^${key}=" "$file" | head -1 | cut -d= -f2- || true
+}
+
+# ── 1. Build containers ──────────────────────────────────────────────────────
+echo; cyan "==> Building containers..."
+docker compose build
+
+# ── 2. Start OpenBao only ────────────────────────────────────────────────────
+echo; cyan "==> Starting OpenBao container..."
+docker compose up -d openbao
+
+echo "    Waiting for OpenBao to be ready..."
+max_wait=60
+elapsed=0
+while ! docker compose exec openbao bao status -address="$BAO_ADDR" -format=json >/dev/null 2>&1; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+    if [ "$elapsed" -ge "$max_wait" ]; then
+        echo "ERROR: OpenBao did not become ready within ${max_wait}s." >&2
+        exit 1
+    fi
+done
+
+# ── 3. Initialize ────────────────────────────────────────────────────────────
+mkdir -p "$INIT_DIR"
+chmod 700 "$INIT_DIR"
+
+initialized=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('initialized','false'))" 2>/dev/null || echo false)
+
+if [ "$initialized" = "True" ] || [ "$initialized" = "true" ]; then
+    yellow "    OpenBao already initialized."
+    if [ ! -f "$INIT_FILE" ]; then
+        echo "ERROR: OpenBao is initialized but $INIT_FILE is missing. Recreate the openbao_data volume to start fresh." >&2
+        exit 1
+    fi
+else
+    echo; cyan "==> Initializing OpenBao..."
+    bao operator init -format=json > "$INIT_FILE"
+    chmod 600 "$INIT_FILE"
+    echo "    Init output saved to $INIT_FILE"
+fi
+
+root_token=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['root_token'])")
+unseal_key0=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][0])")
+unseal_key1=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][1])")
+unseal_key2=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][2])")
+
+# ── 4. Unseal ────────────────────────────────────────────────────────────────
+sealed=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('sealed','true'))" 2>/dev/null || echo true)
+
+if [ "$sealed" = "False" ] || [ "$sealed" = "false" ]; then
+    yellow "    OpenBao already unsealed."
+else
+    echo; cyan "==> Unsealing OpenBao..."
+    bao operator unseal "$unseal_key0" >/dev/null
+    bao operator unseal "$unseal_key1" >/dev/null
+    bao operator unseal "$unseal_key2" >/dev/null
+    echo "    Unsealed."
+fi
+
+# ── 5. Login with root token ─────────────────────────────────────────────────
+echo; cyan "==> Logging in with root token..."
+bao login -no-print "$root_token"
+
+# ── 6. Enable KV v2 ──────────────────────────────────────────────────────────
+if bao secrets list -format=json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if '${KV_MOUNT}/' in d else 1)" 2>/dev/null; then
+    yellow "    KV mount '$KV_MOUNT' already enabled."
+else
+    echo; cyan "==> Enabling KV v2 at $KV_MOUNT/..."
+    bao secrets enable -path="$KV_MOUNT" kv-v2
+fi
+
+# ── 7. Write policy ───────────────────────────────────────────────────────────
+echo; cyan "==> Writing PatchHound policy..."
+policy_file="$INIT_DIR/patchhound-policy.hcl"
+cat > "$policy_file" <<EOF
+path "${KV_MOUNT}/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+EOF
+
+docker compose cp "$policy_file" openbao:/tmp/patchhound-policy.hcl
+bao policy write patchhound /tmp/patchhound-policy.hcl
+
+# ── 8. Create application token ───────────────────────────────────────────────
+echo; cyan "==> Creating PatchHound application token..."
+app_token=$(bao token create -policy=patchhound -format=json | python3 -c "import sys,json; print(json.load(sys.stdin)['auth']['client_token'])")
+echo "$app_token" > "$INIT_DIR/app-token.txt"
+chmod 600 "$INIT_DIR/app-token.txt"
+echo "    Application token saved to $INIT_DIR/app-token.txt"
+
+# ── 9. Stop OpenBao ───────────────────────────────────────────────────────────
+echo; cyan "==> Stopping OpenBao container..."
+docker compose stop openbao
+
+# ── 10. Print tokens ──────────────────────────────────────────────────────────
+echo
+green "============================================"
+green "  OpenBao setup complete"
+green "============================================"
+echo
+yellow "Root token:        $root_token"
+yellow "PatchHound token:  $app_token"
+echo
+
+# ── 11. Create / update .env ──────────────────────────────────────────────────
+if [ ! -f .env ]; then
+    cyan "==> Copying .env.example -> .env..."
+    cp .env.example .env
+fi
+
+set_env_value .env OPENBAO_TOKEN "$app_token"
+
+# ── 12. Prompt for Azure AD values ────────────────────────────────────────────
+cyan "==> Azure AD configuration"
+echo "    Press Enter to keep the current value (shown in brackets)."
+echo
+
+current_client_id=$(read_env_value .env AZURE_AD_CLIENT_ID)
+current_tenant_id=$(read_env_value .env AZURE_AD_TENANT_ID)
+current_audience=$(read_env_value  .env AZURE_AD_AUDIENCE)
+
+read -r -p "  AZURE_AD_CLIENT_ID  [${current_client_id}]: " client_id
+read -r -p "  AZURE_AD_TENANT_ID  [${current_tenant_id}]: " tenant_id
+read -r -p "  AZURE_AD_AUDIENCE    [${current_audience}]: " audience
+
+[ -z "$client_id" ] && client_id="$current_client_id"
+[ -z "$tenant_id" ] && tenant_id="$current_tenant_id"
+[ -z "$audience"  ] && audience="$current_audience"
+
+set_env_value .env AZURE_AD_CLIENT_ID "$client_id"
+set_env_value .env AZURE_AD_TENANT_ID "$tenant_id"
+set_env_value .env AZURE_AD_AUDIENCE  "$audience"
+
+echo
+green "==> .env updated."
+echo
+cyan "Next steps:"
+echo "  docker compose up -d --build"
+echo

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,6 @@ POSTGRES_DB=patchhound
 POSTGRES_USER=patchhound
 POSTGRES_PASSWORD=change-me
 
-OPENBAO_ADDR=http://localhost:8200
 OPENBAO_INTERNAL_ADDR=http://openbao:8200
 OPENBAO_TOKEN=
 OPENBAO_KV_MOUNT=patchhound
@@ -60,7 +59,6 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 
 SESSION_SECRET=change-me-to-at-least-32-characters
-SESSION_DATABASE_URL=
 ENTRA_CLIENT_SECRET=
 ENTRA_SCOPES=openid profile email
 EOF

--- a/setup.sh
+++ b/setup.sh
@@ -37,13 +37,13 @@ docker compose up -d openbao
 echo "    Waiting for OpenBao to be ready..."
 max_wait=60
 elapsed=0
-# bao status exits 0 (active) or 2 (sealed) when the server is up; exit 1 means not yet ready.
-bao_status_json() {
-    docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null
-    local rc=$?
-    [ $rc -eq 0 ] || [ $rc -eq 2 ]
-}
-while ! bao_status_json; do
+# Ignore exit code — bao status exits 1 for both "not yet up" and "uninitialized".
+# Valid JSON in stdout is the only reliable signal that the server is accepting requests.
+while true; do
+    status_json=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null || true)
+    if python3 -c "import sys,json; json.loads(sys.stdin.read())" <<< "$status_json" 2>/dev/null; then
+        break
+    fi
     sleep 2
     elapsed=$((elapsed + 2))
     if [ "$elapsed" -ge "$max_wait" ]; then
@@ -56,8 +56,6 @@ done
 mkdir -p "$INIT_DIR"
 chmod 700 "$INIT_DIR"
 
-# Reuse the JSON already fetched by the readiness loop.
-status_json=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null || true)
 initialized=$(printf '%s' "$status_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('initialized') else 'no')" 2>/dev/null || echo no)
 
 if [ "$initialized" = "yes" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,10 @@ read_env_value() {
     grep -E "^${key}=" "$file" | head -1 | cut -d= -f2- || true
 }
 
+json_field() {
+    python3 -c "import sys,json; print(json.load(sys.stdin)$1)"
+}
+
 # ── 1. Build containers ──────────────────────────────────────────────────────
 echo; cyan "==> Building containers..."
 docker compose build
@@ -34,31 +38,33 @@ docker compose build
 echo; cyan "==> Starting OpenBao container..."
 docker compose up -d openbao
 
-echo "    Waiting for OpenBao to be ready..."
+# Wait until the HTTP listener is accepting connections.
+# Use the sys/health endpoint — it responds with a non-connection-error HTTP
+# status regardless of init/seal state, so curl exits 0 as soon as the server
+# is up. We do NOT use `bao status` here: it exits 1 when uninitialized, which
+# is indistinguishable from "server not yet started".
+echo "    Waiting for OpenBao HTTP listener..."
 max_wait=60
 elapsed=0
-# Ignore exit code — bao status exits 1 for both "not yet up" and "uninitialized".
-# Valid JSON in stdout is the only reliable signal that the server is accepting requests.
-while true; do
-    status_json=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null || true)
-    if python3 -c "import sys,json; json.loads(sys.stdin.read())" <<< "$status_json" 2>/dev/null; then
-        break
-    fi
+until curl -sf --max-time 2 "$BAO_ADDR/v1/sys/health" -o /dev/null 2>/dev/null \
+      || curl -s  --max-time 2 "$BAO_ADDR/v1/sys/health" -o /dev/null 2>/dev/null; do
     sleep 2
     elapsed=$((elapsed + 2))
     if [ "$elapsed" -ge "$max_wait" ]; then
-        echo "ERROR: OpenBao did not become ready within ${max_wait}s." >&2
+        echo "ERROR: OpenBao did not start within ${max_wait}s." >&2
         exit 1
     fi
 done
+echo "    OpenBao is up."
 
 # ── 3. Initialize ────────────────────────────────────────────────────────────
 mkdir -p "$INIT_DIR"
 chmod 700 "$INIT_DIR"
 
-initialized=$(printf '%s' "$status_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('initialized') else 'no')" 2>/dev/null || echo no)
+# Check init state via the API (not bao status).
+init_state=$(curl -s "$BAO_ADDR/v1/sys/init" | python3 -c "import sys,json; print('yes' if json.load(sys.stdin).get('initialized') else 'no')" 2>/dev/null || echo no)
 
-if [ "$initialized" = "yes" ]; then
+if [ "$init_state" = "yes" ]; then
     yellow "    OpenBao already initialized."
     if [ ! -f "$INIT_FILE" ]; then
         echo "ERROR: OpenBao is initialized but $INIT_FILE is missing. Recreate the openbao_data volume to start fresh." >&2
@@ -71,18 +77,18 @@ else
     echo "    Init output saved to $INIT_FILE"
 fi
 
-root_token=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['root_token'])")
-unseal_key0=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][0])")
-unseal_key1=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][1])")
-unseal_key2=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][2])")
+root_token=$(json_field "['root_token']"          < "$INIT_FILE")
+unseal_key0=$(json_field "['unseal_keys_b64'][0]" < "$INIT_FILE")
+unseal_key1=$(json_field "['unseal_keys_b64'][1]" < "$INIT_FILE")
+unseal_key2=$(json_field "['unseal_keys_b64'][2]" < "$INIT_FILE")
 
 # ── 4. Unseal ────────────────────────────────────────────────────────────────
-sealed=$(printf '%s' "$status_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('sealed') else 'no')" 2>/dev/null || echo yes)
+seal_state=$(curl -s "$BAO_ADDR/v1/sys/seal-status" | python3 -c "import sys,json; print('yes' if json.load(sys.stdin).get('sealed') else 'no')" 2>/dev/null || echo yes)
 
-if [ "$sealed" = "no" ]; then
+if [ "$seal_state" = "no" ]; then
     yellow "    OpenBao already unsealed."
 else
-    echo; cyan "==> Unsealing OpenBao..."
+    echo; cyan "==> Unsealing OpenBao (3 of 5 keys)..."
     bao operator unseal "$unseal_key0" >/dev/null
     bao operator unseal "$unseal_key1" >/dev/null
     bao operator unseal "$unseal_key2" >/dev/null
@@ -124,11 +130,21 @@ echo "    Application token saved to $INIT_DIR/app-token.txt"
 echo; cyan "==> Stopping OpenBao container..."
 docker compose stop openbao
 
-# ── 10. Print tokens ──────────────────────────────────────────────────────────
+# ── 10. Print summary ─────────────────────────────────────────────────────────
+all_keys=$(python3 -c "
+import json
+d = json.load(open('$INIT_FILE'))
+for i, k in enumerate(d['unseal_keys_b64'], 1):
+    print(f'  Key {i}: {k}')
+")
+
 echo
 green "============================================"
 green "  OpenBao setup complete"
 green "============================================"
+echo
+yellow "Unseal keys (keep these safe):"
+yellow "$all_keys"
 echo
 yellow "Root token:        $root_token"
 yellow "PatchHound token:  $app_token"

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,13 @@ docker compose up -d openbao
 echo "    Waiting for OpenBao to be ready..."
 max_wait=60
 elapsed=0
-while ! docker compose exec openbao bao status -address="$BAO_ADDR" -format=json >/dev/null 2>&1; do
+# bao status exits 0 (active) or 2 (sealed) when the server is up; exit 1 means not yet ready.
+bao_status_json() {
+    docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null
+    local rc=$?
+    [ $rc -eq 0 ] || [ $rc -eq 2 ]
+}
+while ! bao_status_json; do
     sleep 2
     elapsed=$((elapsed + 2))
     if [ "$elapsed" -ge "$max_wait" ]; then
@@ -50,9 +56,11 @@ done
 mkdir -p "$INIT_DIR"
 chmod 700 "$INIT_DIR"
 
-initialized=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('initialized','false'))" 2>/dev/null || echo false)
+# Reuse the JSON already fetched by the readiness loop.
+status_json=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null || true)
+initialized=$(printf '%s' "$status_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('initialized') else 'no')" 2>/dev/null || echo no)
 
-if [ "$initialized" = "True" ] || [ "$initialized" = "true" ]; then
+if [ "$initialized" = "yes" ]; then
     yellow "    OpenBao already initialized."
     if [ ! -f "$INIT_FILE" ]; then
         echo "ERROR: OpenBao is initialized but $INIT_FILE is missing. Recreate the openbao_data volume to start fresh." >&2
@@ -71,9 +79,9 @@ unseal_key1=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d[
 unseal_key2=$(python3 -c "import json; d=json.load(open('$INIT_FILE')); print(d['unseal_keys_b64'][2])")
 
 # ── 4. Unseal ────────────────────────────────────────────────────────────────
-sealed=$(docker compose exec openbao bao status -address="$BAO_ADDR" -format=json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('sealed','true'))" 2>/dev/null || echo true)
+sealed=$(printf '%s' "$status_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('sealed') else 'no')" 2>/dev/null || echo yes)
 
-if [ "$sealed" = "False" ] || [ "$sealed" = "false" ]; then
+if [ "$sealed" = "no" ]; then
     yellow "    OpenBao already unsealed."
 else
     echo; cyan "==> Unsealing OpenBao..."


### PR DESCRIPTION
## Summary

- Adds `setup.ps1` (Windows/PowerShell 7+) and `setup.sh` (Linux/macOS) to automate the full OpenBao bootstrap flow
- Replaces the need to manually run steps from `deploy/openbao/Makefile`
- Updates `.env` with the generated app token and prompts for Azure AD values interactively

## What changed

Both scripts perform the same steps:

1. Build all Docker containers
2. Start only the OpenBao container and wait for readiness
3. Initialize OpenBao — idempotent, skips if already done (errors if init file is missing)
4. Unseal using the first three keys from init output
5. Enable KV v2 at the `patchhound` mount
6. Write the PatchHound policy and create a scoped application token
7. Stop the OpenBao container and print both root and app tokens
8. Create `.env` from `.env.example` if absent, write `OPENBAO_TOKEN`
9. Interactively prompt for `AZURE_AD_CLIENT_ID`, `AZURE_AD_TENANT_ID`, `AZURE_AD_AUDIENCE` — pressing Enter keeps the existing value

## Notes for reviewer

- `setup.sh` uses `python3` for JSON parsing (available everywhere) to avoid a `jq` dependency
- Init output is saved to `.openbao-init/` with `chmod 600` — this directory should not be committed (already in `.gitignore` if secrets are excluded)
- The scripts are intentionally idempotent on a second run as long as `.openbao-init/init.json` is present