### PR TITLE
[codex] Extract device rule services

### DIFF
--- a/src/PatchHound.Api/Controllers/DeviceRulesController.cs
+++ b/src/PatchHound.Api/Controllers/DeviceRulesController.cs
@@ -5,13 +5,11 @@ using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Auth;
 using PatchHound.Api.Models;
 using PatchHound.Api.Models.DeviceRules;
+using PatchHound.Api.Services;
 using PatchHound.Core.Entities;
-using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
-using PatchHound.Core.Models;
 using PatchHound.Infrastructure.Data;
 using PatchHound.Infrastructure.Services;
-using PatchHound.Infrastructure.Services.Inventory;
 
 namespace PatchHound.Api.Controllers;
 
@@ -27,37 +25,29 @@ namespace PatchHound.Api.Controllers;
 [Authorize(Policy = Policies.ConfigureTenant)]
 public class DeviceRulesController : ControllerBase
 {
-    private const string DeviceAssetType = "Device";
-    private const string SoftwareAssetType = "Software";
-    private const string ApplicationAssetType = "Application";
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
-
     private readonly PatchHoundDbContext _dbContext;
     private readonly ITenantContext _tenantContext;
     private readonly IDeviceRuleEvaluationService _evaluationService;
-    private readonly DeviceRuleFilterBuilder _filterBuilder;
-    private readonly SoftwareRuleFilterBuilder _softwareFilterBuilder;
-    private readonly CloudApplicationRuleFilterBuilder _cloudApplicationFilterBuilder;
+    private readonly DeviceRuleDefinitionService _definitionService;
+    private readonly DeviceRulePreviewService _previewService;
+    private readonly DeviceRuleCleanupService _cleanupService;
     private readonly RiskRefreshService _riskRefreshService;
 
     public DeviceRulesController(
         PatchHoundDbContext dbContext,
         ITenantContext tenantContext,
         IDeviceRuleEvaluationService evaluationService,
-        DeviceRuleFilterBuilder filterBuilder,
-        SoftwareRuleFilterBuilder softwareFilterBuilder,
+        DeviceRuleDefinitionService definitionService,
+        DeviceRulePreviewService previewService,
+        DeviceRuleCleanupService cleanupService,
         RiskRefreshService riskRefreshService)
     {
         _dbContext = dbContext;
         _tenantContext = tenantContext;
         _evaluationService = evaluationService;
-        _filterBuilder = filterBuilder;
-        _softwareFilterBuilder = softwareFilterBuilder;
-        _cloudApplicationFilterBuilder = new CloudApplicationRuleFilterBuilder();
+        _definitionService = definitionService;
+        _previewService = previewService;
+        _cleanupService = cleanupService;
         _riskRefreshService = riskRefreshService;
     }
 
@@ -108,28 +98,27 @@ public class DeviceRulesController : ControllerBase
         if (_tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var filter = DeserializeFilter(request.FilterDefinition);
-        var operations = DeserializeOperations(request.Operations);
-
-        if (!IsSupportedAssetType(request.AssetType))
-            return BadRequest(new ProblemDetails { Title = "Unsupported asset type." });
-
-        if (filter is null || operations is null)
-            return BadRequest(new ProblemDetails { Title = "Invalid filter or operations JSON." });
-
-        var validationError = ValidateOperations(request.AssetType, operations);
-        if (validationError is not null)
-            return BadRequest(new ProblemDetails { Title = validationError });
-
-        var referenceValidationError = await ValidateOperationReferencesAsync(tenantId, operations, ct);
-        if (referenceValidationError is not null)
-            return BadRequest(new ProblemDetails { Title = referenceValidationError });
+        var definition = await _definitionService.ParseAndValidateAsync(
+            tenantId,
+            request.AssetType,
+            request.FilterDefinition,
+            request.Operations,
+            ct);
+        if (!definition.IsSuccess)
+            return BadRequest(new ProblemDetails { Title = definition.Error });
 
         var maxPriority = await _dbContext.DeviceRules
             .Where(r => r.TenantId == tenantId)
             .MaxAsync(r => (int?)r.Priority, ct) ?? 0;
 
-        var rule = DeviceRule.Create(tenantId, request.Name, request.Description, maxPriority + 1, request.AssetType, filter, operations);
+        var rule = DeviceRule.Create(
+            tenantId,
+            request.Name,
+            request.Description,
+            maxPriority + 1,
+            request.AssetType,
+            definition.Filter!,
+            definition.Operations);
         _dbContext.DeviceRules.Add(rule);
         await _dbContext.SaveChangesAsync(ct);
 
@@ -151,24 +140,16 @@ public class DeviceRulesController : ControllerBase
         if (rule is null)
             return NotFound();
 
-        var filter = DeserializeFilter(request.FilterDefinition);
-        var operations = DeserializeOperations(request.Operations);
+        var definition = await _definitionService.ParseAndValidateAsync(
+            tenantId,
+            request.AssetType,
+            request.FilterDefinition,
+            request.Operations,
+            ct);
+        if (!definition.IsSuccess)
+            return BadRequest(new ProblemDetails { Title = definition.Error });
 
-        if (!IsSupportedAssetType(request.AssetType))
-            return BadRequest(new ProblemDetails { Title = "Unsupported asset type." });
-
-        if (filter is null || operations is null)
-            return BadRequest(new ProblemDetails { Title = "Invalid filter or operations JSON." });
-
-        var validationError = ValidateOperations(request.AssetType, operations);
-        if (validationError is not null)
-            return BadRequest(new ProblemDetails { Title = validationError });
-
-        var referenceValidationError = await ValidateOperationReferencesAsync(tenantId, operations, ct);
-        if (referenceValidationError is not null)
-            return BadRequest(new ProblemDetails { Title = referenceValidationError });
-
-        rule.Update(request.Name, request.Description, request.Enabled, request.AssetType, filter, operations);
+        rule.Update(request.Name, request.Description, request.Enabled, request.AssetType, definition.Filter!, definition.Operations);
         await _dbContext.SaveChangesAsync(ct);
 
         return Ok(ToDto(rule));
@@ -201,7 +182,15 @@ public class DeviceRulesController : ControllerBase
             remaining[i].SetPriority(i + 1);
 
         await _dbContext.SaveChangesAsync(ct);
-        await ResetDeletedRuleEffectsAsync(tenantId, rule, operations, ct);
+        try
+        {
+            await _cleanupService.ResetDeletedRuleEffectsAsync(tenantId, rule, operations, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new ProblemDetails { Title = ex.Message });
+        }
+
         await _evaluationService.EvaluateRulesAsync(tenantId, ct);
         await _riskRefreshService.RefreshForTenantAsync(
             tenantId,
@@ -219,51 +208,24 @@ public class DeviceRulesController : ControllerBase
         if (_tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        if (!IsSupportedAssetType(request.AssetType))
+        if (!DeviceRuleAssetTypes.IsSupported(request.AssetType))
             return BadRequest(new ProblemDetails { Title = "Unsupported asset type." });
 
-        var filter = DeserializeFilter(request.FilterDefinition);
-        if (filter is null)
-            return BadRequest(new ProblemDetails { Title = "Invalid filter JSON." });
+        var filterResult = _definitionService.ParseFilter(request.FilterDefinition);
+        if (!filterResult.IsSuccess)
+            return BadRequest(new ProblemDetails { Title = filterResult.Error });
 
-        if (string.Equals(request.AssetType, DeviceAssetType, StringComparison.OrdinalIgnoreCase))
+        try
         {
-            var result = await _evaluationService.PreviewFilterAsync(tenantId, filter, ct);
+            var result = await _previewService.PreviewAsync(tenantId, request.AssetType, filterResult.Filter!, ct);
             return Ok(new DeviceRulePreviewDto(
                 result.Count,
                 result.Samples.Select(s => new DevicePreviewItemDto(s.Id, s.Name)).ToList()));
-        }
-
-        if (string.Equals(request.AssetType, ApplicationAssetType, StringComparison.OrdinalIgnoreCase))
-        {
-            (int Count, List<(Guid Id, string Name)> Samples) applicationPreview;
-            try
-            {
-                applicationPreview = await PreviewApplicationFilterAsync(tenantId, filter, ct);
-            }
-            catch (InvalidOperationException ex)
-            {
-                return BadRequest(new ProblemDetails { Title = ex.Message });
-            }
-
-            return Ok(new DeviceRulePreviewDto(
-                applicationPreview.Count,
-                applicationPreview.Samples.Select(s => new DevicePreviewItemDto(s.Id, s.Name)).ToList()));
-        }
-
-        (int Count, List<(Guid Id, string Name)> Samples) softwarePreview;
-        try
-        {
-            softwarePreview = await PreviewSoftwareFilterAsync(tenantId, filter, ct);
         }
         catch (InvalidOperationException ex)
         {
             return BadRequest(new ProblemDetails { Title = ex.Message });
         }
-
-        return Ok(new DeviceRulePreviewDto(
-            softwarePreview.Count,
-            softwarePreview.Samples.Select(s => new DevicePreviewItemDto(s.Id, s.Name)).ToList()));
     }
 
     [HttpPost("run")]
@@ -320,438 +282,4 @@ public class DeviceRulesController : ControllerBase
         rule.LastMatchCount
     );
 
-    private static bool IsSupportedAssetType(string assetType) =>
-        string.Equals(assetType, DeviceAssetType, StringComparison.OrdinalIgnoreCase)
-        || string.Equals(assetType, SoftwareAssetType, StringComparison.OrdinalIgnoreCase)
-        || string.Equals(assetType, ApplicationAssetType, StringComparison.OrdinalIgnoreCase);
-
-    private static FilterNode? DeserializeFilter(JsonElement element)
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<FilterNode>(element.GetRawText(), JsonOptions);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static List<AssetRuleOperation>? DeserializeOperations(JsonElement element)
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<List<AssetRuleOperation>>(element.GetRawText(), JsonOptions);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string? ValidateOperations(string assetType, IReadOnlyList<AssetRuleOperation> operations)
-    {
-        if (string.Equals(assetType, SoftwareAssetType, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(assetType, ApplicationAssetType, StringComparison.OrdinalIgnoreCase))
-        {
-            foreach (var operation in operations)
-            {
-                switch (operation.Type)
-                {
-                    case "AssignOwnerTeam":
-                        if (!operation.Parameters.TryGetValue("teamId", out var softwareTeamId)
-                            || !Guid.TryParse(softwareTeamId, out _))
-                        {
-                            return "AssignOwnerTeam requires a valid teamId.";
-                        }
-                        break;
-                    default:
-                        return string.Equals(assetType, SoftwareAssetType, StringComparison.OrdinalIgnoreCase)
-                            ? $"Unknown software rule operation type: {operation.Type}."
-                            : $"Unknown application rule operation type: {operation.Type}.";
-                }
-            }
-
-            return null;
-        }
-
-        foreach (var operation in operations)
-        {
-            switch (operation.Type)
-            {
-                case "AssignSecurityProfile":
-                    if (!operation.Parameters.TryGetValue("securityProfileId", out var securityProfileId)
-                        || !Guid.TryParse(securityProfileId, out _))
-                    {
-                        return "AssignSecurityProfile requires a valid securityProfileId.";
-                    }
-                    break;
-
-                case "AssignTeam":
-                    if (!operation.Parameters.TryGetValue("teamId", out var teamId)
-                        || !Guid.TryParse(teamId, out _))
-                    {
-                        return "AssignTeam requires a valid teamId.";
-                    }
-                    break;
-
-                case "AssignOwnerTeam":
-                    if (!operation.Parameters.TryGetValue("teamId", out var ownerTeamId)
-                        || !Guid.TryParse(ownerTeamId, out _))
-                    {
-                        return "AssignOwnerTeam requires a valid teamId.";
-                    }
-                    break;
-
-                case "AssignBusinessLabel":
-                    if (!operation.Parameters.TryGetValue("businessLabelId", out var businessLabelId)
-                        || !Guid.TryParse(businessLabelId, out _))
-                    {
-                        return "AssignBusinessLabel requires a valid businessLabelId.";
-                    }
-                    break;
-
-                case "SetCriticality":
-                    if (!operation.Parameters.TryGetValue("criticality", out var criticality)
-                        || !Enum.TryParse<Criticality>(criticality, true, out _))
-                    {
-                        return "SetCriticality requires a valid criticality value.";
-                    }
-                    break;
-
-                default:
-                    return $"Unknown device rule operation type: {operation.Type}.";
-            }
-        }
-
-        return null;
-    }
-
-    private async Task<(int Count, List<(Guid Id, string Name)> Samples)> PreviewSoftwareFilterAsync(
-        Guid tenantId,
-        FilterNode filter,
-        CancellationToken ct)
-    {
-        var predicate = _softwareFilterBuilder.Build(filter);
-        var query = _dbContext.SoftwareTenantRecords
-            .AsNoTracking()
-            .Where(item => item.TenantId == tenantId)
-            .Where(predicate);
-
-        var count = await query.CountAsync(ct);
-        var samples = await query
-            .OrderBy(item => item.SoftwareProduct.Name)
-            .ThenBy(item => item.SoftwareProduct.Vendor)
-            .Take(5)
-            .Select(item => new ValueTuple<Guid, string>(
-                item.Id,
-                string.IsNullOrWhiteSpace(item.SoftwareProduct.Vendor)
-                    ? item.SoftwareProduct.Name
-                    : $"{item.SoftwareProduct.Vendor} {item.SoftwareProduct.Name}"))
-            .ToListAsync(ct);
-
-        return (count, samples);
-    }
-
-    private async Task<(int Count, List<(Guid Id, string Name)> Samples)> PreviewApplicationFilterAsync(
-        Guid tenantId,
-        FilterNode filter,
-        CancellationToken ct)
-    {
-        var predicate = _cloudApplicationFilterBuilder.Build(filter);
-        var query = _dbContext.CloudApplications
-            .AsNoTracking()
-            .IgnoreQueryFilters()
-            .Where(item => item.TenantId == tenantId && item.ActiveInTenant)
-            .Where(predicate);
-
-        var count = await query.CountAsync(ct);
-        var samples = await query
-            .OrderBy(item => item.Name)
-            .Take(5)
-            .Select(item => new ValueTuple<Guid, string>(item.Id, item.Name))
-            .ToListAsync(ct);
-
-        return (count, samples);
-    }
-
-    private async Task<string?> ValidateOperationReferencesAsync(
-        Guid tenantId,
-        IReadOnlyList<AssetRuleOperation> operations,
-        CancellationToken ct)
-    {
-        foreach (var operation in operations)
-        {
-            switch (operation.Type)
-            {
-                case "AssignSecurityProfile":
-                    if (operation.Parameters.TryGetValue("securityProfileId", out var securityProfileId)
-                        && Guid.TryParse(securityProfileId, out var parsedSecurityProfileId))
-                    {
-                        var exists = await _dbContext.SecurityProfiles
-                            .AnyAsync(profile => profile.TenantId == tenantId && profile.Id == parsedSecurityProfileId, ct);
-                        if (!exists)
-                            return "AssignSecurityProfile references a security profile that does not belong to the active tenant.";
-                    }
-                    break;
-
-                case "AssignTeam":
-                case "AssignOwnerTeam":
-                    if (operation.Parameters.TryGetValue("teamId", out var teamId)
-                        && Guid.TryParse(teamId, out var parsedTeamId))
-                    {
-                        var exists = await _dbContext.Teams
-                            .AnyAsync(team => team.TenantId == tenantId && team.Id == parsedTeamId, ct);
-                        if (!exists)
-                            return $"{operation.Type} references a team that does not belong to the active tenant.";
-                    }
-                    break;
-
-                case "AssignBusinessLabel":
-                    if (operation.Parameters.TryGetValue("businessLabelId", out var businessLabelId)
-                        && Guid.TryParse(businessLabelId, out var parsedBusinessLabelId))
-                    {
-                        var exists = await _dbContext.BusinessLabels
-                            .AnyAsync(label => label.TenantId == tenantId && label.IsActive && label.Id == parsedBusinessLabelId, ct);
-                        if (!exists)
-                            return "AssignBusinessLabel references an active business label that does not belong to the active tenant.";
-                    }
-                    break;
-            }
-        }
-
-        return null;
-    }
-
-    private async Task<List<Guid>> GetMatchingDeviceIdsAsync(
-        DeviceRule rule,
-        Guid tenantId,
-        CancellationToken ct)
-    {
-        try
-        {
-            var predicate = _filterBuilder.Build(rule.ParseFilter());
-            return await _dbContext.Devices
-                .AsNoTracking()
-                .Where(device => device.TenantId == tenantId)
-                .Where(predicate)
-                .Select(device => device.Id)
-                .ToListAsync(ct);
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    private async Task<List<Guid>> GetMatchingSoftwareIdsAsync(
-        DeviceRule rule,
-        Guid tenantId,
-        CancellationToken ct)
-    {
-        try
-        {
-            if (string.Equals(rule.AssetType, ApplicationAssetType, StringComparison.OrdinalIgnoreCase))
-            {
-                var applicationPredicate = _cloudApplicationFilterBuilder.Build(rule.ParseFilter());
-                return await _dbContext.CloudApplications
-                    .AsNoTracking()
-                    .IgnoreQueryFilters()
-                    .Where(item => item.TenantId == tenantId && item.ActiveInTenant)
-                    .Where(applicationPredicate)
-                    .Select(item => item.Id)
-                    .ToListAsync(ct);
-            }
-
-            var predicate = _softwareFilterBuilder.Build(rule.ParseFilter());
-            return await _dbContext.SoftwareTenantRecords
-                .AsNoTracking()
-                .Where(item => item.TenantId == tenantId)
-                .Where(predicate)
-                .Select(item => item.Id)
-                .ToListAsync(ct);
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    private async Task ResetDeletedRuleEffectsAsync(
-        Guid tenantId,
-        DeviceRule deletedRule,
-        IReadOnlyCollection<AssetRuleOperation> operations,
-        CancellationToken ct)
-    {
-        if (operations.Count == 0)
-            return;
-
-        if (string.Equals(deletedRule.AssetType, ApplicationAssetType, StringComparison.OrdinalIgnoreCase))
-        {
-            var applicationIds = await GetMatchingSoftwareIdsAsync(deletedRule, tenantId, ct);
-            foreach (var operation in operations)
-            {
-                if (operation.Type != "AssignOwnerTeam" || applicationIds.Count == 0)
-                {
-                    continue;
-                }
-
-                var applications = await _dbContext.CloudApplications
-                    .IgnoreQueryFilters()
-                    .Where(item =>
-                        item.TenantId == tenantId
-                        && applicationIds.Contains(item.Id)
-                        && item.OwnerTeamRuleId == deletedRule.Id)
-                    .ToListAsync(ct);
-
-                foreach (var application in applications)
-                {
-                    application.ClearRuleAssignedOwnerTeam(deletedRule.Id);
-                }
-
-                if (applications.Count > 0)
-                {
-                    await _dbContext.SaveChangesAsync(ct);
-                }
-            }
-
-            return;
-        }
-
-        if (string.Equals(deletedRule.AssetType, SoftwareAssetType, StringComparison.OrdinalIgnoreCase))
-        {
-            var softwareIds = await GetMatchingSoftwareIdsAsync(deletedRule, tenantId, ct);
-            foreach (var operation in operations)
-            {
-                if (operation.Type != "AssignOwnerTeam" || softwareIds.Count == 0)
-                {
-                    continue;
-                }
-
-                var records = await _dbContext.SoftwareTenantRecords
-                    .Where(item =>
-                        item.TenantId == tenantId
-                        && softwareIds.Contains(item.Id)
-                        && item.OwnerTeamRuleId == deletedRule.Id)
-                    .ToListAsync(ct);
-
-                foreach (var record in records)
-                {
-                    record.ClearRuleAssignedOwnerTeam(deletedRule.Id);
-                }
-
-                if (records.Count > 0)
-                {
-                    await _dbContext.SaveChangesAsync(ct);
-                }
-            }
-
-            return;
-        }
-
-        var deviceIds = await GetMatchingDeviceIdsAsync(deletedRule, tenantId, ct);
-
-        foreach (var operation in operations)
-        {
-            switch (operation.Type)
-            {
-                case "AssignSecurityProfile":
-                    if (operation.Parameters.TryGetValue("securityProfileId", out _) && deviceIds.Count > 0)
-                    {
-                        var devices = await _dbContext.Devices
-                            .Where(device =>
-                                device.TenantId == tenantId
-                                && deviceIds.Contains(device.Id)
-                                && device.SecurityProfileRuleId == deletedRule.Id)
-                            .ToListAsync(ct);
-
-                        foreach (var device in devices)
-                            device.ClearRuleAssignedSecurityProfile(deletedRule.Id);
-
-                        if (devices.Count > 0)
-                            await _dbContext.SaveChangesAsync(ct);
-                    }
-                    break;
-
-                case "AssignTeam":
-                    if (operation.Parameters.TryGetValue("teamId", out _) && deviceIds.Count > 0)
-                    {
-                        var devices = await _dbContext.Devices
-                            .Where(device =>
-                                device.TenantId == tenantId
-                                && deviceIds.Contains(device.Id)
-                                && device.FallbackTeamRuleId == deletedRule.Id)
-                            .ToListAsync(ct);
-
-                        foreach (var device in devices)
-                            device.ClearRuleAssignedFallbackTeam(deletedRule.Id);
-
-                        if (devices.Count > 0)
-                            await _dbContext.SaveChangesAsync(ct);
-                    }
-                    break;
-
-                case "AssignOwnerTeam":
-                    if (operation.Parameters.TryGetValue("teamId", out _) && deviceIds.Count > 0)
-                    {
-                        var devices = await _dbContext.Devices
-                            .Where(device =>
-                                device.TenantId == tenantId
-                                && deviceIds.Contains(device.Id)
-                                && device.OwnerTeamRuleId == deletedRule.Id)
-                            .ToListAsync(ct);
-
-                        foreach (var device in devices)
-                            device.ClearRuleAssignedOwnerTeam(deletedRule.Id);
-
-                        if (devices.Count > 0)
-                            await _dbContext.SaveChangesAsync(ct);
-                    }
-                    break;
-
-                case "SetCriticality":
-                {
-                    if (deviceIds.Count == 0)
-                        break;
-
-                    var devices = await _dbContext.Devices
-                        .Where(device =>
-                            device.TenantId == tenantId
-                            && deviceIds.Contains(device.Id)
-                            && device.CriticalitySource == "Rule"
-                            && device.CriticalityRuleId == deletedRule.Id)
-                        .ToListAsync(ct);
-
-                    foreach (var device in devices)
-                        device.ResetCriticalityToBaseline();
-
-                    if (devices.Count > 0)
-                        await _dbContext.SaveChangesAsync(ct);
-
-                    break;
-                }
-
-                case "AssignBusinessLabel":
-                    if (operation.Parameters.TryGetValue("businessLabelId", out _))
-                    {
-                        // Rule-assigned DeviceBusinessLabel links are identified by
-                        // AssignedByRuleId — independent of the current device set so
-                        // we catch any stragglers from earlier evaluations.
-                        var existingAssignments = await _dbContext.DeviceBusinessLabels
-                            .Where(link =>
-                                link.TenantId == tenantId
-                                && link.AssignedByRuleId == deletedRule.Id
-                                && link.SourceType == DeviceBusinessLabel.RuleSourceType)
-                            .ToListAsync(ct);
-
-                        if (existingAssignments.Count > 0)
-                        {
-                            _dbContext.DeviceBusinessLabels.RemoveRange(existingAssignments);
-                            await _dbContext.SaveChangesAsync(ct);
-                        }
-                    }
-                    break;
-            }
-        }
-    }
 }

--- a/src/PatchHound.Api/Services/DeviceRuleCleanupService.cs
+++ b/src/PatchHound.Api/Services/DeviceRuleCleanupService.cs
@@ -1,0 +1,315 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+
+namespace PatchHound.Api.Services;
+
+public sealed class DeviceRuleCleanupService
+{
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DeviceRuleFilterBuilder _filterBuilder;
+    private readonly SoftwareRuleFilterBuilder _softwareFilterBuilder;
+    private readonly CloudApplicationRuleFilterBuilder _cloudApplicationFilterBuilder;
+
+    public DeviceRuleCleanupService(
+        PatchHoundDbContext dbContext,
+        DeviceRuleFilterBuilder filterBuilder,
+        SoftwareRuleFilterBuilder softwareFilterBuilder,
+        CloudApplicationRuleFilterBuilder cloudApplicationFilterBuilder)
+    {
+        _dbContext = dbContext;
+        _filterBuilder = filterBuilder;
+        _softwareFilterBuilder = softwareFilterBuilder;
+        _cloudApplicationFilterBuilder = cloudApplicationFilterBuilder;
+    }
+
+    public async Task ResetDeletedRuleEffectsAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<AssetRuleOperation> operations,
+        CancellationToken ct)
+    {
+        if (operations.Count == 0)
+            return;
+
+        if (DeviceRuleAssetTypes.IsApplication(deletedRule.AssetType))
+        {
+            await ResetApplicationRuleEffectsAsync(tenantId, deletedRule, operations, ct);
+            return;
+        }
+
+        if (DeviceRuleAssetTypes.IsSoftware(deletedRule.AssetType))
+        {
+            await ResetSoftwareRuleEffectsAsync(tenantId, deletedRule, operations, ct);
+            return;
+        }
+
+        await ResetDeviceRuleEffectsAsync(tenantId, deletedRule, operations, ct);
+    }
+
+    private async Task ResetApplicationRuleEffectsAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<AssetRuleOperation> operations,
+        CancellationToken ct)
+    {
+        var applicationIds = await GetMatchingSoftwareIdsAsync(deletedRule, tenantId, ct);
+        foreach (var operation in operations)
+        {
+            if (operation.Type != DeviceRuleOperationTypes.AssignOwnerTeam || applicationIds.Count == 0)
+                continue;
+
+            var applications = await _dbContext.CloudApplications
+                .IgnoreQueryFilters()
+                .Where(item =>
+                    item.TenantId == tenantId
+                    && applicationIds.Contains(item.Id)
+                    && item.OwnerTeamRuleId == deletedRule.Id)
+                .ToListAsync(ct);
+
+            foreach (var application in applications)
+            {
+                application.ClearRuleAssignedOwnerTeam(deletedRule.Id);
+            }
+
+            if (applications.Count > 0)
+                await _dbContext.SaveChangesAsync(ct);
+        }
+    }
+
+    private async Task ResetSoftwareRuleEffectsAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<AssetRuleOperation> operations,
+        CancellationToken ct)
+    {
+        var softwareIds = await GetMatchingSoftwareIdsAsync(deletedRule, tenantId, ct);
+        foreach (var operation in operations)
+        {
+            if (operation.Type != DeviceRuleOperationTypes.AssignOwnerTeam || softwareIds.Count == 0)
+                continue;
+
+            var records = await _dbContext.SoftwareTenantRecords
+                .Where(item =>
+                    item.TenantId == tenantId
+                    && softwareIds.Contains(item.Id)
+                    && item.OwnerTeamRuleId == deletedRule.Id)
+                .ToListAsync(ct);
+
+            foreach (var record in records)
+            {
+                record.ClearRuleAssignedOwnerTeam(deletedRule.Id);
+            }
+
+            if (records.Count > 0)
+                await _dbContext.SaveChangesAsync(ct);
+        }
+    }
+
+    private async Task ResetDeviceRuleEffectsAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<AssetRuleOperation> operations,
+        CancellationToken ct)
+    {
+        var deviceIds = await GetMatchingDeviceIdsAsync(deletedRule, tenantId, ct);
+
+        foreach (var operation in operations)
+        {
+            switch (operation.Type)
+            {
+                case DeviceRuleOperationTypes.AssignSecurityProfile:
+                    await ClearRuleAssignedSecurityProfileAsync(tenantId, deletedRule, deviceIds, ct);
+                    break;
+
+                case DeviceRuleOperationTypes.AssignTeam:
+                    await ClearRuleAssignedFallbackTeamAsync(tenantId, deletedRule, deviceIds, ct);
+                    break;
+
+                case DeviceRuleOperationTypes.AssignOwnerTeam:
+                    await ClearRuleAssignedOwnerTeamAsync(tenantId, deletedRule, deviceIds, ct);
+                    break;
+
+                case DeviceRuleOperationTypes.SetCriticality:
+                    await ResetRuleAssignedCriticalityAsync(tenantId, deletedRule, deviceIds, ct);
+                    break;
+
+                case DeviceRuleOperationTypes.AssignBusinessLabel:
+                    await RemoveRuleAssignedBusinessLabelsAsync(tenantId, deletedRule, ct);
+                    break;
+            }
+        }
+    }
+
+    private async Task<List<Guid>> GetMatchingDeviceIdsAsync(
+        DeviceRule rule,
+        Guid tenantId,
+        CancellationToken ct)
+    {
+        try
+        {
+            var predicate = _filterBuilder.Build(rule.ParseFilter());
+            return await _dbContext.Devices
+                .AsNoTracking()
+                .Where(device => device.TenantId == tenantId)
+                .Where(predicate)
+                .Select(device => device.Id)
+                .ToListAsync(ct);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.Text.Json.JsonException)
+        {
+            throw new InvalidOperationException(
+                $"Unable to evaluate deleted device rule filter for cleanup: {ex.Message}",
+                ex);
+        }
+    }
+
+    private async Task<List<Guid>> GetMatchingSoftwareIdsAsync(
+        DeviceRule rule,
+        Guid tenantId,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (DeviceRuleAssetTypes.IsApplication(rule.AssetType))
+            {
+                var applicationPredicate = _cloudApplicationFilterBuilder.Build(rule.ParseFilter());
+                return await _dbContext.CloudApplications
+                    .AsNoTracking()
+                    .IgnoreQueryFilters()
+                    .Where(item => item.TenantId == tenantId && item.ActiveInTenant)
+                    .Where(applicationPredicate)
+                    .Select(item => item.Id)
+                    .ToListAsync(ct);
+            }
+
+            var predicate = _softwareFilterBuilder.Build(rule.ParseFilter());
+            return await _dbContext.SoftwareTenantRecords
+                .AsNoTracking()
+                .Where(item => item.TenantId == tenantId)
+                .Where(predicate)
+                .Select(item => item.Id)
+                .ToListAsync(ct);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.Text.Json.JsonException)
+        {
+            throw new InvalidOperationException(
+                $"Unable to evaluate deleted {rule.AssetType.ToLowerInvariant()} rule filter for cleanup: {ex.Message}",
+                ex);
+        }
+    }
+
+    private async Task ClearRuleAssignedSecurityProfileAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken ct)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
+        var devices = await _dbContext.Devices
+            .Where(device =>
+                device.TenantId == tenantId
+                && deviceIds.Contains(device.Id)
+                && device.SecurityProfileRuleId == deletedRule.Id)
+            .ToListAsync(ct);
+
+        foreach (var device in devices)
+            device.ClearRuleAssignedSecurityProfile(deletedRule.Id);
+
+        if (devices.Count > 0)
+            await _dbContext.SaveChangesAsync(ct);
+    }
+
+    private async Task ClearRuleAssignedFallbackTeamAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken ct)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
+        var devices = await _dbContext.Devices
+            .Where(device =>
+                device.TenantId == tenantId
+                && deviceIds.Contains(device.Id)
+                && device.FallbackTeamRuleId == deletedRule.Id)
+            .ToListAsync(ct);
+
+        foreach (var device in devices)
+            device.ClearRuleAssignedFallbackTeam(deletedRule.Id);
+
+        if (devices.Count > 0)
+            await _dbContext.SaveChangesAsync(ct);
+    }
+
+    private async Task ClearRuleAssignedOwnerTeamAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken ct)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
+        var devices = await _dbContext.Devices
+            .Where(device =>
+                device.TenantId == tenantId
+                && deviceIds.Contains(device.Id)
+                && device.OwnerTeamRuleId == deletedRule.Id)
+            .ToListAsync(ct);
+
+        foreach (var device in devices)
+            device.ClearRuleAssignedOwnerTeam(deletedRule.Id);
+
+        if (devices.Count > 0)
+            await _dbContext.SaveChangesAsync(ct);
+    }
+
+    private async Task ResetRuleAssignedCriticalityAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken ct)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
+        var devices = await _dbContext.Devices
+            .Where(device =>
+                device.TenantId == tenantId
+                && deviceIds.Contains(device.Id)
+                && device.CriticalitySource == "Rule"
+                && device.CriticalityRuleId == deletedRule.Id)
+            .ToListAsync(ct);
+
+        foreach (var device in devices)
+            device.ResetCriticalityToBaseline();
+
+        if (devices.Count > 0)
+            await _dbContext.SaveChangesAsync(ct);
+    }
+
+    private async Task RemoveRuleAssignedBusinessLabelsAsync(
+        Guid tenantId,
+        DeviceRule deletedRule,
+        CancellationToken ct)
+    {
+        var existingAssignments = await _dbContext.DeviceBusinessLabels
+            .Where(link =>
+                link.TenantId == tenantId
+                && link.AssignedByRuleId == deletedRule.Id
+                && link.SourceType == DeviceBusinessLabel.RuleSourceType)
+            .ToListAsync(ct);
+
+        if (existingAssignments.Count > 0)
+        {
+            _dbContext.DeviceBusinessLabels.RemoveRange(existingAssignments);
+            await _dbContext.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/src/PatchHound.Api/Services/DeviceRuleConstants.cs
+++ b/src/PatchHound.Api/Services/DeviceRuleConstants.cs
@@ -1,0 +1,31 @@
+namespace PatchHound.Api.Services;
+
+public static class DeviceRuleAssetTypes
+{
+    public const string Device = "Device";
+    public const string Software = "Software";
+    public const string Application = "Application";
+
+    public static bool IsSupported(string assetType) =>
+        string.Equals(assetType, Device, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(assetType, Software, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(assetType, Application, StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsDevice(string assetType) =>
+        string.Equals(assetType, Device, StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsSoftware(string assetType) =>
+        string.Equals(assetType, Software, StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsApplication(string assetType) =>
+        string.Equals(assetType, Application, StringComparison.OrdinalIgnoreCase);
+}
+
+public static class DeviceRuleOperationTypes
+{
+    public const string AssignSecurityProfile = "AssignSecurityProfile";
+    public const string AssignTeam = "AssignTeam";
+    public const string AssignOwnerTeam = "AssignOwnerTeam";
+    public const string AssignBusinessLabel = "AssignBusinessLabel";
+    public const string SetCriticality = "SetCriticality";
+}

--- a/src/PatchHound.Api/Services/DeviceRuleDefinitionService.cs
+++ b/src/PatchHound.Api/Services/DeviceRuleDefinitionService.cs
@@ -1,0 +1,247 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+
+namespace PatchHound.Api.Services;
+
+public sealed class DeviceRuleDefinitionService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly PatchHoundDbContext _dbContext;
+
+    public DeviceRuleDefinitionService(PatchHoundDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<DeviceRuleDefinitionResult> ParseAndValidateAsync(
+        Guid tenantId,
+        string assetType,
+        JsonElement filterDefinition,
+        JsonElement operationsElement,
+        CancellationToken ct)
+    {
+        if (!DeviceRuleAssetTypes.IsSupported(assetType))
+            return DeviceRuleDefinitionResult.Failure("Unsupported asset type.");
+
+        var filterResult = ParseFilter(filterDefinition);
+        if (!filterResult.IsSuccess)
+            return DeviceRuleDefinitionResult.Failure(filterResult.Error!);
+
+        var operationsResult = ParseOperations(operationsElement);
+        if (!operationsResult.IsSuccess)
+            return DeviceRuleDefinitionResult.Failure(operationsResult.Error!);
+
+        var operations = operationsResult.Operations;
+        var validationError = ValidateOperations(assetType, operations);
+        if (validationError is not null)
+            return DeviceRuleDefinitionResult.Failure(validationError);
+
+        var referenceValidationError = await ValidateOperationReferencesAsync(tenantId, operations, ct);
+        if (referenceValidationError is not null)
+            return DeviceRuleDefinitionResult.Failure(referenceValidationError);
+
+        return DeviceRuleDefinitionResult.Success(filterResult.Filter!, operations);
+    }
+
+    public DeviceRuleFilterParseResult ParseFilter(JsonElement element)
+    {
+        try
+        {
+            var filter = JsonSerializer.Deserialize<FilterNode>(element.GetRawText(), JsonOptions);
+            return filter is null
+                ? DeviceRuleFilterParseResult.Failure("Invalid filter JSON.")
+                : DeviceRuleFilterParseResult.Success(filter);
+        }
+        catch (JsonException ex)
+        {
+            return DeviceRuleFilterParseResult.Failure($"Invalid filter JSON: {ex.Message}");
+        }
+        catch (NotSupportedException ex)
+        {
+            return DeviceRuleFilterParseResult.Failure($"Invalid filter JSON: {ex.Message}");
+        }
+    }
+
+    private static DeviceRuleOperationsParseResult ParseOperations(JsonElement element)
+    {
+        try
+        {
+            var operations = JsonSerializer.Deserialize<List<AssetRuleOperation>>(element.GetRawText(), JsonOptions);
+            return operations is null
+                ? DeviceRuleOperationsParseResult.Failure("Invalid operations JSON.")
+                : DeviceRuleOperationsParseResult.Success(operations);
+        }
+        catch (JsonException ex)
+        {
+            return DeviceRuleOperationsParseResult.Failure($"Invalid operations JSON: {ex.Message}");
+        }
+        catch (NotSupportedException ex)
+        {
+            return DeviceRuleOperationsParseResult.Failure($"Invalid operations JSON: {ex.Message}");
+        }
+    }
+
+    private static string? ValidateOperations(string assetType, IReadOnlyList<AssetRuleOperation> operations)
+    {
+        if (DeviceRuleAssetTypes.IsSoftware(assetType) || DeviceRuleAssetTypes.IsApplication(assetType))
+        {
+            foreach (var operation in operations)
+            {
+                switch (operation.Type)
+                {
+                    case DeviceRuleOperationTypes.AssignOwnerTeam:
+                        if (!operation.Parameters.TryGetValue("teamId", out var softwareTeamId)
+                            || !Guid.TryParse(softwareTeamId, out _))
+                        {
+                            return "AssignOwnerTeam requires a valid teamId.";
+                        }
+                        break;
+                    default:
+                        return DeviceRuleAssetTypes.IsSoftware(assetType)
+                            ? $"Unknown software rule operation type: {operation.Type}."
+                            : $"Unknown application rule operation type: {operation.Type}.";
+                }
+            }
+
+            return null;
+        }
+
+        foreach (var operation in operations)
+        {
+            switch (operation.Type)
+            {
+                case DeviceRuleOperationTypes.AssignSecurityProfile:
+                    if (!operation.Parameters.TryGetValue("securityProfileId", out var securityProfileId)
+                        || !Guid.TryParse(securityProfileId, out _))
+                    {
+                        return "AssignSecurityProfile requires a valid securityProfileId.";
+                    }
+                    break;
+
+                case DeviceRuleOperationTypes.AssignTeam:
+                    if (!operation.Parameters.TryGetValue("teamId", out var teamId)
+                        || !Guid.TryParse(teamId, out _))
+                    {
+                        return "AssignTeam requires a valid teamId.";
+                    }
+                    break;
+
+                case DeviceRuleOperationTypes.AssignOwnerTeam:
+                    if (!operation.Parameters.TryGetValue("teamId", out var ownerTeamId)
+                        || !Guid.TryParse(ownerTeamId, out _))
+                    {
+                        return "AssignOwnerTeam requires a valid teamId.";
+                    }
+                    break;
+
+                case DeviceRuleOperationTypes.AssignBusinessLabel:
+                    if (!operation.Parameters.TryGetValue("businessLabelId", out var businessLabelId)
+                        || !Guid.TryParse(businessLabelId, out _))
+                    {
+                        return "AssignBusinessLabel requires a valid businessLabelId.";
+                    }
+                    break;
+
+                case DeviceRuleOperationTypes.SetCriticality:
+                    if (!operation.Parameters.TryGetValue("criticality", out var criticality)
+                        || !Enum.TryParse<Criticality>(criticality, true, out _))
+                    {
+                        return "SetCriticality requires a valid criticality value.";
+                    }
+                    break;
+
+                default:
+                    return $"Unknown device rule operation type: {operation.Type}.";
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<string?> ValidateOperationReferencesAsync(
+        Guid tenantId,
+        IReadOnlyList<AssetRuleOperation> operations,
+        CancellationToken ct)
+    {
+        foreach (var operation in operations)
+        {
+            switch (operation.Type)
+            {
+                case DeviceRuleOperationTypes.AssignSecurityProfile:
+                    if (operation.Parameters.TryGetValue("securityProfileId", out var securityProfileId)
+                        && Guid.TryParse(securityProfileId, out var parsedSecurityProfileId))
+                    {
+                        var exists = await _dbContext.SecurityProfiles
+                            .AnyAsync(profile => profile.TenantId == tenantId && profile.Id == parsedSecurityProfileId, ct);
+                        if (!exists)
+                            return "AssignSecurityProfile references a security profile that does not belong to the active tenant.";
+                    }
+                    break;
+
+                case DeviceRuleOperationTypes.AssignTeam:
+                case DeviceRuleOperationTypes.AssignOwnerTeam:
+                    if (operation.Parameters.TryGetValue("teamId", out var teamId)
+                        && Guid.TryParse(teamId, out var parsedTeamId))
+                    {
+                        var exists = await _dbContext.Teams
+                            .AnyAsync(team => team.TenantId == tenantId && team.Id == parsedTeamId, ct);
+                        if (!exists)
+                            return $"{operation.Type} references a team that does not belong to the active tenant.";
+                    }
+                    break;
+
+                case DeviceRuleOperationTypes.AssignBusinessLabel:
+                    if (operation.Parameters.TryGetValue("businessLabelId", out var businessLabelId)
+                        && Guid.TryParse(businessLabelId, out var parsedBusinessLabelId))
+                    {
+                        var exists = await _dbContext.BusinessLabels
+                            .AnyAsync(label => label.TenantId == tenantId && label.IsActive && label.Id == parsedBusinessLabelId, ct);
+                        if (!exists)
+                            return "AssignBusinessLabel references an active business label that does not belong to the active tenant.";
+                    }
+                    break;
+            }
+        }
+
+        return null;
+    }
+}
+
+public sealed record DeviceRuleDefinitionResult(
+    bool IsSuccess,
+    FilterNode? Filter,
+    List<AssetRuleOperation> Operations,
+    string? Error)
+{
+    public static DeviceRuleDefinitionResult Success(FilterNode filter, List<AssetRuleOperation> operations) =>
+        new(true, filter, operations, null);
+
+    public static DeviceRuleDefinitionResult Failure(string error) =>
+        new(false, null, [], error);
+}
+
+public sealed record DeviceRuleFilterParseResult(bool IsSuccess, FilterNode? Filter, string? Error)
+{
+    public static DeviceRuleFilterParseResult Success(FilterNode filter) => new(true, filter, null);
+
+    public static DeviceRuleFilterParseResult Failure(string error) => new(false, null, error);
+}
+
+internal sealed record DeviceRuleOperationsParseResult(
+    bool IsSuccess,
+    List<AssetRuleOperation> Operations,
+    string? Error)
+{
+    public static DeviceRuleOperationsParseResult Success(List<AssetRuleOperation> operations) =>
+        new(true, operations, null);
+
+    public static DeviceRuleOperationsParseResult Failure(string error) =>
+        new(false, [], error);
+}

--- a/src/PatchHound.Api/Services/DeviceRulePreviewService.cs
+++ b/src/PatchHound.Api/Services/DeviceRulePreviewService.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+
+namespace PatchHound.Api.Services;
+
+public sealed class DeviceRulePreviewService
+{
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly IDeviceRuleEvaluationService _evaluationService;
+    private readonly SoftwareRuleFilterBuilder _softwareFilterBuilder;
+    private readonly CloudApplicationRuleFilterBuilder _cloudApplicationFilterBuilder;
+
+    public DeviceRulePreviewService(
+        PatchHoundDbContext dbContext,
+        IDeviceRuleEvaluationService evaluationService,
+        SoftwareRuleFilterBuilder softwareFilterBuilder,
+        CloudApplicationRuleFilterBuilder cloudApplicationFilterBuilder)
+    {
+        _dbContext = dbContext;
+        _evaluationService = evaluationService;
+        _softwareFilterBuilder = softwareFilterBuilder;
+        _cloudApplicationFilterBuilder = cloudApplicationFilterBuilder;
+    }
+
+    public async Task<DeviceRulePreviewResult> PreviewAsync(
+        Guid tenantId,
+        string assetType,
+        FilterNode filter,
+        CancellationToken ct)
+    {
+        if (DeviceRuleAssetTypes.IsDevice(assetType))
+            return await _evaluationService.PreviewFilterAsync(tenantId, filter, ct);
+
+        if (DeviceRuleAssetTypes.IsApplication(assetType))
+            return await PreviewApplicationFilterAsync(tenantId, filter, ct);
+
+        if (DeviceRuleAssetTypes.IsSoftware(assetType))
+            return await PreviewSoftwareFilterAsync(tenantId, filter, ct);
+
+        throw new InvalidOperationException("Unsupported asset type.");
+    }
+
+    private async Task<DeviceRulePreviewResult> PreviewSoftwareFilterAsync(
+        Guid tenantId,
+        FilterNode filter,
+        CancellationToken ct)
+    {
+        var predicate = _softwareFilterBuilder.Build(filter);
+        var query = _dbContext.SoftwareTenantRecords
+            .AsNoTracking()
+            .Where(item => item.TenantId == tenantId)
+            .Where(predicate);
+
+        var count = await query.CountAsync(ct);
+        var samples = await query
+            .OrderBy(item => item.SoftwareProduct.Name)
+            .ThenBy(item => item.SoftwareProduct.Vendor)
+            .Take(5)
+            .Select(item => new DevicePreviewItem(
+                item.Id,
+                string.IsNullOrWhiteSpace(item.SoftwareProduct.Vendor)
+                    ? item.SoftwareProduct.Name
+                    : $"{item.SoftwareProduct.Vendor} {item.SoftwareProduct.Name}"))
+            .ToListAsync(ct);
+
+        return new DeviceRulePreviewResult(count, samples);
+    }
+
+    private async Task<DeviceRulePreviewResult> PreviewApplicationFilterAsync(
+        Guid tenantId,
+        FilterNode filter,
+        CancellationToken ct)
+    {
+        var predicate = _cloudApplicationFilterBuilder.Build(filter);
+        var query = _dbContext.CloudApplications
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(item => item.TenantId == tenantId && item.ActiveInTenant)
+            .Where(predicate);
+
+        var count = await query.CountAsync(ct);
+        var samples = await query
+            .OrderBy(item => item.Name)
+            .Take(5)
+            .Select(item => new DevicePreviewItem(item.Id, item.Name))
+            .ToListAsync(ct);
+
+        return new DeviceRulePreviewResult(count, samples);
+    }
+}

--- a/src/PatchHound.Api/Startup/PatchHoundApiServiceExtensions.cs
+++ b/src/PatchHound.Api/Startup/PatchHoundApiServiceExtensions.cs
@@ -23,6 +23,9 @@ public static class PatchHoundApiServiceExtensions
         services.AddScoped<DashboardQueryService>();
         services.AddScoped<VulnerabilityDetailQueryService>();
         services.AddScoped<DeviceDetailQueryService>();
+        services.AddScoped<DeviceRuleDefinitionService>();
+        services.AddScoped<DeviceRulePreviewService>();
+        services.AddScoped<DeviceRuleCleanupService>();
         services.AddScoped<RemediationDecisionQueryService>();
         services.AddScoped<ThreatIntelGenerationService>();
         services.AddScoped<AiRecommendationDraftService>();

--- a/src/PatchHound.Infrastructure/DependencyInjection.cs
+++ b/src/PatchHound.Infrastructure/DependencyInjection.cs
@@ -232,6 +232,7 @@ public static class DependencyInjection
         // Device Rules
         services.AddScoped<DeviceRuleFilterBuilder>();
         services.AddScoped<SoftwareRuleFilterBuilder>();
+        services.AddScoped<CloudApplicationRuleFilterBuilder>();
         services.AddScoped<IDeviceRuleEvaluationService, DeviceRuleEvaluationService>();
 
         // Inventory resolvers & staged-device merge (needed by IngestionService + AuthenticatedScanIngestionService)

--- a/tests/PatchHound.Tests/Api/DeviceRuleCleanupServiceTests.cs
+++ b/tests/PatchHound.Tests/Api/DeviceRuleCleanupServiceTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class DeviceRuleCleanupServiceTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _sourceSystemId = Guid.NewGuid();
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DeviceRuleCleanupService _service;
+
+    public DeviceRuleCleanupServiceTests()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns(_tenantId);
+        tenantContext.AccessibleTenantIds.Returns(new List<Guid> { _tenantId });
+        tenantContext.HasAccessToTenant(_tenantId).Returns(true);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(options, TestServiceProviderFactory.Create(tenantContext));
+        _service = new DeviceRuleCleanupService(
+            _dbContext,
+            new DeviceRuleFilterBuilder(_dbContext),
+            new SoftwareRuleFilterBuilder(),
+            new CloudApplicationRuleFilterBuilder());
+    }
+
+    [Fact]
+    public async Task ResetDeletedRuleEffectsAsync_ClearsOnlyRuleAssignedDeviceBusinessLabels()
+    {
+        var label = BusinessLabel.Create(_tenantId, "Critical Infra", null, null);
+        var device = Device.Create(_tenantId, _sourceSystemId, "device-1", "Device-A", Criticality.Low);
+        var rule = DeviceRule.Create(
+            _tenantId,
+            "Tag Device-A",
+            null,
+            1,
+            DeviceRuleAssetTypes.Device,
+            BuildFilter("Name", "Device-A"),
+            new List<AssetRuleOperation>
+            {
+                new(DeviceRuleOperationTypes.AssignBusinessLabel, new Dictionary<string, string> { ["businessLabelId"] = label.Id.ToString() }),
+            });
+        await _dbContext.AddRangeAsync(
+            label,
+            device,
+            DeviceBusinessLabel.CreateManual(_tenantId, device.Id, label.Id, assignedBy: null),
+            DeviceBusinessLabel.CreateRule(_tenantId, device.Id, label.Id, rule.Id));
+        await _dbContext.SaveChangesAsync();
+
+        await _service.ResetDeletedRuleEffectsAsync(_tenantId, rule, rule.ParseOperations(), CancellationToken.None);
+
+        var links = await _dbContext.DeviceBusinessLabels
+            .Where(link => link.DeviceId == device.Id)
+            .ToListAsync();
+        links.Should().ContainSingle()
+            .Which.SourceType.Should().Be(DeviceBusinessLabel.ManualSourceType);
+    }
+
+    private static FilterNode BuildFilter(string field, string value) =>
+        new FilterGroup(
+            "AND",
+            new List<FilterNode>
+            {
+                new FilterCondition(field, "Equals", value),
+            });
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/tests/PatchHound.Tests/Api/DeviceRuleDefinitionServiceTests.cs
+++ b/tests/PatchHound.Tests/Api/DeviceRuleDefinitionServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class DeviceRuleDefinitionServiceTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DeviceRuleDefinitionService _service;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public DeviceRuleDefinitionServiceTests()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns(_tenantId);
+        tenantContext.AccessibleTenantIds.Returns(new List<Guid> { _tenantId });
+        tenantContext.HasAccessToTenant(_tenantId).Returns(true);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(options, TestServiceProviderFactory.Create(tenantContext));
+        _service = new DeviceRuleDefinitionService(_dbContext);
+    }
+
+    [Fact]
+    public async Task ParseAndValidateAsync_ReturnsTypedDefinitionForValidDeviceRule()
+    {
+        var filter = BuildFilter("Name", "Device-A");
+        var operations = new List<AssetRuleOperation>
+        {
+            new(DeviceRuleOperationTypes.SetCriticality, new Dictionary<string, string> { ["criticality"] = "High" }),
+        };
+
+        var result = await _service.ParseAndValidateAsync(
+            _tenantId,
+            DeviceRuleAssetTypes.Device,
+            SerializeJson(filter),
+            SerializeJson(operations),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Filter.Should().BeOfType<FilterGroup>();
+        result.Operations.Should().ContainSingle()
+            .Which.Type.Should().Be(DeviceRuleOperationTypes.SetCriticality);
+    }
+
+    [Fact]
+    public async Task ParseAndValidateAsync_ReturnsActionableErrorForUnknownOperation()
+    {
+        var result = await _service.ParseAndValidateAsync(
+            _tenantId,
+            DeviceRuleAssetTypes.Device,
+            SerializeJson(BuildFilter("Name", "Device-A")),
+            SerializeJson(new List<AssetRuleOperation>
+            {
+                new("Noop", new Dictionary<string, string>()),
+            }),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Unknown device rule operation type: Noop.");
+    }
+
+    [Fact]
+    public async Task ParseAndValidateAsync_ReturnsActionableErrorForForeignTeamReference()
+    {
+        var otherTenantTeam = Team.Create(Guid.NewGuid(), "Other tenant");
+        await _dbContext.Teams.AddAsync(otherTenantTeam);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ParseAndValidateAsync(
+            _tenantId,
+            DeviceRuleAssetTypes.Software,
+            SerializeJson(BuildFilter("Vendor", "Contoso")),
+            SerializeJson(new List<AssetRuleOperation>
+            {
+                new(DeviceRuleOperationTypes.AssignOwnerTeam, new Dictionary<string, string> { ["teamId"] = otherTenantTeam.Id.ToString() }),
+            }),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("AssignOwnerTeam references a team that does not belong to the active tenant.");
+    }
+
+    private static FilterNode BuildFilter(string field, string value) =>
+        new FilterGroup(
+            "AND",
+            new List<FilterNode>
+            {
+                new FilterCondition(field, "Equals", value),
+            });
+
+    private static JsonElement SerializeJson(object value)
+    {
+        var json = JsonSerializer.Serialize(value, JsonOptions);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/tests/PatchHound.Tests/Api/DeviceRulePreviewServiceTests.cs
+++ b/tests/PatchHound.Tests/Api/DeviceRulePreviewServiceTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PatchHound.Api.Services;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Core.Models;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services.Inventory;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Api;
+
+public class DeviceRulePreviewServiceTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _sourceSystemId = Guid.NewGuid();
+    private readonly PatchHoundDbContext _dbContext;
+    private readonly DeviceRulePreviewService _service;
+
+    public DeviceRulePreviewServiceTests()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns(_tenantId);
+        tenantContext.AccessibleTenantIds.Returns(new List<Guid> { _tenantId });
+        tenantContext.HasAccessToTenant(_tenantId).Returns(true);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(options, TestServiceProviderFactory.Create(tenantContext));
+        var deviceFilterBuilder = new DeviceRuleFilterBuilder(_dbContext);
+        _service = new DeviceRulePreviewService(
+            _dbContext,
+            new DeviceRuleEvaluationService(
+                _dbContext,
+                deviceFilterBuilder,
+                new SoftwareRuleFilterBuilder(),
+                Substitute.For<ILogger<DeviceRuleEvaluationService>>()),
+            new SoftwareRuleFilterBuilder(),
+            new CloudApplicationRuleFilterBuilder());
+    }
+
+    [Fact]
+    public async Task PreviewAsync_ReturnsSoftwareMatches()
+    {
+        var device = Device.Create(_tenantId, _sourceSystemId, "device-1", "Device-A", Criticality.Medium);
+        var matchingProduct = SoftwareProduct.Create("Contoso", "Browser", null);
+        var otherProduct = SoftwareProduct.Create("Fabrikam", "Agent", null);
+        var matchingTenantSoftware = SoftwareTenantRecord.Create(_tenantId, null, matchingProduct.Id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        var otherTenantSoftware = SoftwareTenantRecord.Create(_tenantId, null, otherProduct.Id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        await _dbContext.AddRangeAsync(
+            device,
+            matchingProduct,
+            otherProduct,
+            matchingTenantSoftware,
+            otherTenantSoftware,
+            InstalledSoftware.Observe(_tenantId, device.Id, matchingProduct.Id, _sourceSystemId, "1.0.0", DateTimeOffset.UtcNow),
+            InstalledSoftware.Observe(_tenantId, device.Id, otherProduct.Id, _sourceSystemId, "2.0.0", DateTimeOffset.UtcNow));
+        await _dbContext.SaveChangesAsync();
+
+        var preview = await _service.PreviewAsync(
+            _tenantId,
+            DeviceRuleAssetTypes.Software,
+            BuildFilter("Vendor", "Contoso"),
+            CancellationToken.None);
+
+        preview.Count.Should().Be(1);
+        preview.Samples.Should().ContainSingle().Which.Id.Should().Be(matchingTenantSoftware.Id);
+    }
+
+    [Fact]
+    public async Task PreviewAsync_ReturnsActionableErrorForInvalidSoftwareFilter()
+    {
+        var act = () => _service.PreviewAsync(
+            _tenantId,
+            DeviceRuleAssetTypes.Software,
+            BuildFilter("BadField", "Contoso"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Unknown software filter field: BadField");
+    }
+
+    private static FilterNode BuildFilter(string field, string value) =>
+        new FilterGroup(
+            "AND",
+            new List<FilterNode>
+            {
+                new FilterCondition(field, "Equals", value),
+            });
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/tests/PatchHound.Tests/Api/DeviceRulesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/DeviceRulesControllerTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using PatchHound.Api.Controllers;
 using PatchHound.Api.Models;
 using PatchHound.Api.Models.DeviceRules;
+using PatchHound.Api.Services;
 using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
@@ -63,19 +64,33 @@ public class DeviceRulesControllerTests : IDisposable
             Substitute.For<MaterializedViewRefreshService>(_dbContext)
         );
         var filterBuilder = new DeviceRuleFilterBuilder(_dbContext);
+        var softwareFilterBuilder = new SoftwareRuleFilterBuilder();
+        var cloudApplicationFilterBuilder = new CloudApplicationRuleFilterBuilder();
         var evaluationService = new DeviceRuleEvaluationService(
             _dbContext,
             filterBuilder,
-            new SoftwareRuleFilterBuilder(),
+            softwareFilterBuilder,
             Substitute.For<Microsoft.Extensions.Logging.ILogger<DeviceRuleEvaluationService>>()
         );
+        var definitionService = new DeviceRuleDefinitionService(_dbContext);
+        var previewService = new DeviceRulePreviewService(
+            _dbContext,
+            evaluationService,
+            softwareFilterBuilder,
+            cloudApplicationFilterBuilder);
+        var cleanupService = new DeviceRuleCleanupService(
+            _dbContext,
+            filterBuilder,
+            softwareFilterBuilder,
+            cloudApplicationFilterBuilder);
 
         _controller = new DeviceRulesController(
             _dbContext,
             _tenantContext,
             evaluationService,
-            filterBuilder,
-            new SoftwareRuleFilterBuilder(),
+            definitionService,
+            previewService,
+            cleanupService,
             riskRefreshService
         );
     }


### PR DESCRIPTION
## Summary

Closes #112.

This PR extracts the current device rule controller internals into focused services:

- `DeviceRuleDefinitionService` for rule filter parsing, operation validation, and tenant-scoped reference validation.
- `DeviceRulePreviewService` for device, software, and application preview queries.
- `DeviceRuleCleanupService` for deleted-rule effect cleanup.
- Shared `DeviceRuleAssetTypes` and `DeviceRuleOperationTypes` constants for asset and operation names.

The public controller routes and DTOs stay stable. Invalid filter/operation paths now return more actionable validation errors instead of broad catch-and-empty behavior where practical.

## Validation

- `dotnet build PatchHound.slnx`
- `dotnet test PatchHound.slnx -v minimal`
