### PR TITLE
[codex] Centralize API tenant and time helpers

### DIFF
--- a/src/PatchHound.Api/Controllers/DeviceRulesController.cs
+++ b/src/PatchHound.Api/Controllers/DeviceRulesController.cs
@@ -26,7 +26,7 @@ namespace PatchHound.Api.Controllers;
 public class DeviceRulesController : ControllerBase
 {
     private readonly PatchHoundDbContext _dbContext;
-    private readonly ITenantContext _tenantContext;
+    private readonly ApiRequestContext _requestContext;
     private readonly IDeviceRuleEvaluationService _evaluationService;
     private readonly DeviceRuleDefinitionService _definitionService;
     private readonly DeviceRulePreviewService _previewService;
@@ -35,7 +35,7 @@ public class DeviceRulesController : ControllerBase
 
     public DeviceRulesController(
         PatchHoundDbContext dbContext,
-        ITenantContext tenantContext,
+        ApiRequestContext requestContext,
         IDeviceRuleEvaluationService evaluationService,
         DeviceRuleDefinitionService definitionService,
         DeviceRulePreviewService previewService,
@@ -43,7 +43,7 @@ public class DeviceRulesController : ControllerBase
         RiskRefreshService riskRefreshService)
     {
         _dbContext = dbContext;
-        _tenantContext = tenantContext;
+        _requestContext = requestContext;
         _evaluationService = evaluationService;
         _definitionService = definitionService;
         _previewService = previewService;
@@ -56,8 +56,8 @@ public class DeviceRulesController : ControllerBase
         [FromQuery] PaginationQuery pagination,
         CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         var query = _dbContext.DeviceRules
             .AsNoTracking()
@@ -77,8 +77,8 @@ public class DeviceRulesController : ControllerBase
     [HttpGet("{id:guid}")]
     public async Task<ActionResult<DeviceRuleDto>> Get(Guid id, CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         var rule = await _dbContext.DeviceRules
             .AsNoTracking()
@@ -95,8 +95,8 @@ public class DeviceRulesController : ControllerBase
         [FromBody] CreateDeviceRuleRequest request,
         CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         var definition = await _definitionService.ParseAndValidateAsync(
             tenantId,
@@ -131,8 +131,8 @@ public class DeviceRulesController : ControllerBase
         [FromBody] UpdateDeviceRuleRequest request,
         CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         var rule = await _dbContext.DeviceRules
             .FirstOrDefaultAsync(r => r.Id == id && r.TenantId == tenantId, ct);
@@ -158,8 +158,8 @@ public class DeviceRulesController : ControllerBase
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         var rule = await _dbContext.DeviceRules
             .FirstOrDefaultAsync(r => r.Id == id && r.TenantId == tenantId, ct);
@@ -205,8 +205,8 @@ public class DeviceRulesController : ControllerBase
         [FromBody] PreviewDeviceRuleFilterRequest request,
         CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         if (!DeviceRuleAssetTypes.IsSupported(request.AssetType))
             return BadRequest(new ProblemDetails { Title = "Unsupported asset type." });
@@ -231,8 +231,8 @@ public class DeviceRulesController : ControllerBase
     [HttpPost("run")]
     public async Task<IActionResult> Run(CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         await _evaluationService.EvaluateRulesAsync(tenantId, ct);
         await _riskRefreshService.RefreshForTenantAsync(
@@ -248,8 +248,8 @@ public class DeviceRulesController : ControllerBase
         [FromBody] ReorderDeviceRulesRequest request,
         CancellationToken ct)
     {
-        if (_tenantContext.CurrentTenantId is not Guid tenantId)
-            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+        if (_requestContext.RequireCurrentTenant(out var tenantId) is { } tenantError)
+            return tenantError;
 
         var rules = await _dbContext.DeviceRules
             .Where(r => r.TenantId == tenantId)

--- a/src/PatchHound.Api/Services/ApiClock.cs
+++ b/src/PatchHound.Api/Services/ApiClock.cs
@@ -1,0 +1,13 @@
+namespace PatchHound.Api.Services;
+
+public interface IApiClock
+{
+    DateTimeOffset UtcNow { get; }
+}
+
+public sealed class SystemApiClock : IApiClock
+{
+    public static SystemApiClock Instance { get; } = new();
+
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/src/PatchHound.Api/Services/ApiProblemDetails.cs
+++ b/src/PatchHound.Api/Services/ApiProblemDetails.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace PatchHound.Api.Services;
+
+public static class ApiProblemDetails
+{
+    public const string NoActiveTenantTitle = "No active tenant is selected.";
+    public const string ForbiddenTenantTitle = "The active user cannot access the requested tenant.";
+
+    public static ProblemDetails NoActiveTenant() => new()
+    {
+        Title = NoActiveTenantTitle,
+        Status = StatusCodes.Status400BadRequest,
+    };
+
+    public static ProblemDetails ForbiddenTenant() => new()
+    {
+        Title = ForbiddenTenantTitle,
+        Status = StatusCodes.Status403Forbidden,
+    };
+}

--- a/src/PatchHound.Api/Services/ApiRequestContext.cs
+++ b/src/PatchHound.Api/Services/ApiRequestContext.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using PatchHound.Core.Interfaces;
+
+namespace PatchHound.Api.Services;
+
+public sealed class ApiRequestContext
+{
+    private readonly ITenantContext _tenantContext;
+
+    public ApiRequestContext(ITenantContext tenantContext)
+    {
+        _tenantContext = tenantContext;
+    }
+
+    public ActionResult? RequireCurrentTenant(out Guid tenantId)
+    {
+        if (_tenantContext.CurrentTenantId is Guid currentTenantId)
+        {
+            tenantId = currentTenantId;
+            return null;
+        }
+
+        tenantId = Guid.Empty;
+        return new BadRequestObjectResult(ApiProblemDetails.NoActiveTenant());
+    }
+
+    public ActionResult? RequireTenantAccess(Guid tenantId)
+    {
+        if (_tenantContext.HasAccessToTenant(tenantId))
+            return null;
+
+        return new ObjectResult(ApiProblemDetails.ForbiddenTenant())
+        {
+            StatusCode = StatusCodes.Status403Forbidden,
+        };
+    }
+}

--- a/src/PatchHound.Api/Services/DashboardQueryService.cs
+++ b/src/PatchHound.Api/Services/DashboardQueryService.cs
@@ -11,7 +11,8 @@ namespace PatchHound.Api.Services;
 public class DashboardQueryService(
     PatchHoundDbContext dbContext,
     IRiskChangeBriefAiSummaryService riskChangeBriefAiSummaryService,
-    ExecutiveDashboardBriefingService? executiveDashboardBriefingService = null
+    ExecutiveDashboardBriefingService? executiveDashboardBriefingService = null,
+    IApiClock? clock = null
 )
 {
     public record RecurrenceData(
@@ -100,7 +101,7 @@ public class DashboardQueryService(
         int cutoffHours = 24
     )
     {
-        var cutoff = DateTimeOffset.UtcNow.AddHours(-Math.Abs(cutoffHours));
+        var cutoff = (clock ?? SystemApiClock.Instance).UtcNow.AddHours(-Math.Abs(cutoffHours));
 
         var appeared = await dbContext.DeviceVulnerabilityExposures.AsNoTracking()
             .Where(e => e.TenantId == tenantId && e.FirstObservedAt >= cutoff)

--- a/src/PatchHound.Api/Startup/PatchHoundApiServiceExtensions.cs
+++ b/src/PatchHound.Api/Startup/PatchHoundApiServiceExtensions.cs
@@ -19,6 +19,8 @@ public static class PatchHoundApiServiceExtensions
         services.AddPatchHoundInfrastructure(configuration);
 
         services.AddScoped<ITenantContext, Auth.TenantContext>();
+        services.AddSingleton<IApiClock, SystemApiClock>();
+        services.AddScoped<ApiRequestContext>();
         services.AddScoped<TenantSoftwareAliasResolver>();
         services.AddScoped<DashboardQueryService>();
         services.AddScoped<VulnerabilityDetailQueryService>();

--- a/tests/PatchHound.Tests/Api/ApiRequestContextTests.cs
+++ b/tests/PatchHound.Tests/Api/ApiRequestContextTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using PatchHound.Api.Services;
+using PatchHound.Core.Interfaces;
+
+namespace PatchHound.Tests.Api;
+
+public class ApiRequestContextTests
+{
+    [Fact]
+    public void RequireCurrentTenant_ReturnsSharedProblemDetailsWhenTenantIsMissing()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns((Guid?)null);
+        var requestContext = new ApiRequestContext(tenantContext);
+
+        var action = requestContext.RequireCurrentTenant(out var tenantId);
+
+        tenantId.Should().BeEmpty();
+        var badRequest = action.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().BeOfType<ProblemDetails>()
+            .Subject.Title.Should().Be(ApiProblemDetails.NoActiveTenantTitle);
+    }
+
+    [Fact]
+    public void RequireTenantAccess_ReturnsSharedProblemDetailsWhenTenantIsForbidden()
+    {
+        var tenantId = Guid.NewGuid();
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.HasAccessToTenant(tenantId).Returns(false);
+        var requestContext = new ApiRequestContext(tenantContext);
+
+        var action = requestContext.RequireTenantAccess(tenantId);
+
+        var forbidden = action.Should().BeOfType<ObjectResult>().Subject;
+        forbidden.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        forbidden.Value.Should().BeOfType<ProblemDetails>()
+            .Subject.Title.Should().Be(ApiProblemDetails.ForbiddenTenantTitle);
+    }
+}

--- a/tests/PatchHound.Tests/Api/DashboardQueryServiceCanonicalTests.cs
+++ b/tests/PatchHound.Tests/Api/DashboardQueryServiceCanonicalTests.cs
@@ -28,6 +28,12 @@ public class DashboardQueryServiceCanonicalTests : IAsyncDisposable
     private DashboardQueryService CreateSut() =>
         new(_db, Substitute.For<IRiskChangeBriefAiSummaryService>());
 
+    private DashboardQueryService CreateSut(DateTimeOffset utcNow) =>
+        new(
+            _db,
+            Substitute.For<IRiskChangeBriefAiSummaryService>(),
+            clock: new FixedApiClock(utcNow));
+
     // ── Test 1 ──────────────────────────────────────────────────────────────
     [Fact]
     public async Task GetRecurrenceDataAsync_SingleEpisode_NotCountedAsRecurring()
@@ -252,6 +258,64 @@ public class DashboardQueryServiceCanonicalTests : IAsyncDisposable
         result.Appeared.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task BuildRiskChangeBriefAsync_UsesInjectedClockForCutoff()
+    {
+        var seed = await CanonicalSeed.PlantAsync(_db, _tenantId);
+        var fixedNow = new DateTimeOffset(2030, 1, 10, 12, 0, 0, TimeSpan.Zero);
+        var insideWindow = Vulnerability.Create(
+            "nvd",
+            "CVE-2030-1100",
+            "Inside deterministic window",
+            "desc",
+            Severity.High,
+            8.0m,
+            null,
+            fixedNow);
+        var outsideWindow = Vulnerability.Create(
+            "nvd",
+            "CVE-2030-1101",
+            "Outside deterministic window",
+            "desc",
+            Severity.High,
+            8.0m,
+            null,
+            fixedNow);
+        _db.Vulnerabilities.AddRange(insideWindow, outsideWindow);
+        await _db.SaveChangesAsync();
+
+        _db.DeviceVulnerabilityExposures.AddRange(
+            DeviceVulnerabilityExposure.Observe(
+                _tenantId,
+                seed.DeviceA.Id,
+                insideWindow.Id,
+                seed.ProductA.Id,
+                seed.InstallA.Id,
+                seed.InstallA.Version,
+                ExposureMatchSource.Product,
+                fixedNow.AddHours(-23),
+                runId: Guid.NewGuid()),
+            DeviceVulnerabilityExposure.Observe(
+                _tenantId,
+                seed.DeviceA.Id,
+                outsideWindow.Id,
+                seed.ProductA.Id,
+                seed.InstallA.Id,
+                seed.InstallA.Version,
+                ExposureMatchSource.Product,
+                fixedNow.AddHours(-25),
+                runId: Guid.NewGuid()));
+        await _db.SaveChangesAsync();
+
+        var svc = CreateSut(fixedNow);
+        var result = await svc.BuildRiskChangeBriefAsync(
+            _tenantId, _tenantId, limit: null, highCriticalOnly: false,
+            CancellationToken.None, cutoffHours: 24);
+
+        result.Appeared.Should().ContainSingle(item => item.VulnerabilityId == insideWindow.Id);
+        result.Appeared.Should().NotContain(item => item.VulnerabilityId == outsideWindow.Id);
+    }
+
     // ── Test 6 ──────────────────────────────────────────────────────────────
     [Fact]
     public async Task BuildRiskChangeBriefAsync_AppearedItem_CarriesRemediationCaseId()
@@ -316,5 +380,10 @@ public class DashboardQueryServiceCanonicalTests : IAsyncDisposable
             decision.Outcome,
             decision.ApprovedAt!.Value));
         await _db.SaveChangesAsync();
+    }
+
+    private sealed class FixedApiClock(DateTimeOffset utcNow) : IApiClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
     }
 }

--- a/tests/PatchHound.Tests/Api/DeviceRulesControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/DeviceRulesControllerTests.cs
@@ -86,7 +86,7 @@ public class DeviceRulesControllerTests : IDisposable
 
         _controller = new DeviceRulesController(
             _dbContext,
-            _tenantContext,
+            new ApiRequestContext(_tenantContext),
             evaluationService,
             definitionService,
             previewService,


### PR DESCRIPTION
## Summary

Closes #110.

This PR adds the first centralized API request helpers for tenant and request-time handling:

- `ApiRequestContext` resolves the current tenant and centralizes tenant-access checks.
- `ApiProblemDetails` centralizes the common missing-tenant and forbidden-tenant `ProblemDetails` payloads.
- `IApiClock` / `SystemApiClock` provide an injectable API clock.
- `DeviceRulesController` now uses `ApiRequestContext` instead of repeating missing-tenant boilerplate.
- `DashboardQueryService` uses the injected clock for risk-change cutoff calculations.

This keeps the migration incremental while giving future controller/service refactors a shared API surface to use.

## Validation

- `dotnet build PatchHound.slnx`
- `dotnet test PatchHound.slnx -v minimal`
