### PR TITLE
feat(ai-context): audit persistence of grounded recommendations (Phase 6)

### DIFF
--- a/frontend/src/api/remediation.functions.ts
+++ b/frontend/src/api/remediation.functions.ts
@@ -100,6 +100,7 @@ export const addRecommendation = createServerFn({ method: 'POST' })
       rationale: z.string(),
       priorityOverride: z.string().optional(),
       vulnerabilityId: z.string().uuid().optional(),
+      contextSnapshotId: z.string().uuid().optional(),
     })
   )
   .handler(async ({ context, data: { caseId, ...body } }) => {

--- a/frontend/src/api/remediation.schemas.ts
+++ b/frontend/src/api/remediation.schemas.ts
@@ -150,6 +150,7 @@ export const aiRecommendationDraftSchema = z.object({
   rationale: z.string(),
   operationalContextUsed: z.boolean().optional(),
   uncited: z.boolean().optional(),
+  contextSnapshotId: z.string().uuid().nullish(),
   citations: z
     .array(
       z.object({

--- a/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
+++ b/frontend/src/components/features/remediation/SecurityAnalystWorkbench.tsx
@@ -67,6 +67,7 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
     operationalContextUsed: boolean
     uncited: boolean
     citations: { key: string; label: string; fact: string; entityType: string; entityId: string }[]
+    contextSnapshotId: string | null
   } | null>(null)
   const [citedFactsOpen, setCitedFactsOpen] = useState(false)
   const [requestingAssessment, setRequestingAssessment] = useState(false)
@@ -128,6 +129,7 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
           recommendedOutcome,
           rationale: rationale.trim(),
           priorityOverride: priorityOverride || undefined,
+          contextSnapshotId: aiDraftMeta?.contextSnapshotId ?? undefined,
         },
       })
       await Promise.all([
@@ -180,6 +182,7 @@ export function SecurityAnalystWorkbench({ data, caseId, queryKey }: SecurityAna
         operationalContextUsed: draft.operationalContextUsed ?? false,
         uncited: draft.uncited ?? false,
         citations: draft.citations ?? [],
+        contextSnapshotId: draft.contextSnapshotId ?? null,
       })
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to apply the AI recommendation draft.'))

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -142,6 +142,7 @@ public class RemediationDecisionsController(
             userId,
             request.VulnerabilityId,
             request.PriorityOverride,
+            request.ContextSnapshotId,
             ct
         );
 

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -428,7 +428,7 @@ public class RemediationDecisionsController(
         if (tenantContext.CurrentTenantId is not Guid tenantId)
             return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
 
-        var result = await aiRecommendationDraftService.GenerateAsync(tenantId, caseId, ct);
+        var result = await aiRecommendationDraftService.GenerateAsync(tenantId, caseId, tenantContext.CurrentUserId, ct);
         if (!result.IsSuccess)
         {
             if (result.Error == "Remediation case not found.")

--- a/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
+++ b/src/PatchHound.Api/Controllers/RemediationDecisionsController.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PatchHound.Api.Auth;
+using PatchHound.Core.Models.OperationalContext;
 using PatchHound.Api.Models;
 using PatchHound.Api.Models.ApprovalTasks;
 using PatchHound.Api.Models.Decisions;
@@ -115,6 +117,35 @@ public class RemediationDecisionsController(
         return Ok(context.Recommendations);
     }
 
+    [HttpGet("recommendations/context/{snapshotId:guid}")]
+    [Authorize(Policy = Policies.ViewVulnerabilities)]
+    public async Task<ActionResult<RecommendationContextSnapshotDto>> GetRecommendationContext(
+        Guid caseId,
+        Guid snapshotId,
+        CancellationToken ct
+    )
+    {
+        if (tenantContext.CurrentTenantId is not Guid tenantId)
+            return BadRequest(new ProblemDetails { Title = "No active tenant is selected." });
+
+        var snapshot = await dbContext.RecommendationContextSnapshots.AsNoTracking()
+            .FirstOrDefaultAsync(item =>
+                item.Id == snapshotId
+                && item.TenantId == tenantId
+                && item.RemediationCaseId == caseId,
+                ct);
+        if (snapshot is null)
+            return NotFound(new ProblemDetails { Title = "Context snapshot not found." });
+
+        var pack = JsonSerializer.Deserialize<OperationalContextPack>(
+            snapshot.ContextJson, OperationalContextPack.SerializerOptions)!;
+        var citations = JsonSerializer.Deserialize<List<OperationalContextCitation>>(
+            snapshot.CitationsJson, OperationalContextPack.SerializerOptions) ?? [];
+
+        return Ok(new RecommendationContextSnapshotDto(
+            snapshot.Id, snapshot.RemediationCaseId, snapshot.GeneratedAt, pack, citations));
+    }
+
     [HttpPost("analysis")]
     [Authorize(Policy = Policies.AddComments)]
     public async Task<ActionResult<AnalystRecommendationDto>> AddRecommendation(
@@ -157,7 +188,8 @@ public class RemediationDecisionsController(
         var r = result.Value;
         return Created("", new AnalystRecommendationDto(
             r.Id, r.VulnerabilityId, r.RecommendedOutcome.ToString(),
-            r.Rationale, r.PriorityOverride, r.AnalystId, analystDisplayName, r.CreatedAt
+            r.Rationale, r.PriorityOverride, r.AnalystId, analystDisplayName, r.CreatedAt,
+            r.ContextSnapshotId
         ));
     }
 

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -203,7 +203,8 @@ public record CreateRecommendationRequest(
     string RecommendedOutcome,
     string Rationale,
     string? PriorityOverride,
-    Guid? VulnerabilityId
+    Guid? VulnerabilityId,
+    Guid? ContextSnapshotId = null
 );
 
 public record VerifyRemediationRequest(

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -144,7 +144,16 @@ public record AnalystRecommendationDto(
     string? PriorityOverride,
     Guid AnalystId,
     string? AnalystDisplayName,
-    DateTimeOffset CreatedAt
+    DateTimeOffset CreatedAt,
+    Guid? ContextSnapshotId = null
+);
+
+public record RecommendationContextSnapshotDto(
+    Guid Id,
+    Guid RemediationCaseId,
+    DateTimeOffset GeneratedAt,
+    PatchHound.Core.Models.OperationalContext.OperationalContextPack Context,
+    IReadOnlyList<PatchHound.Core.Models.OperationalContext.OperationalContextCitation> Citations
 );
 
 public record DecisionVulnDto(

--- a/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
+++ b/src/PatchHound.Api/Models/Decisions/RemediationDecisionDto.cs
@@ -61,7 +61,8 @@ public record AiRecommendationDraftDto(
     string Rationale,
     bool OperationalContextUsed = false,
     bool Uncited = false,
-    IReadOnlyList<AiCitationDto>? Citations = null
+    IReadOnlyList<AiCitationDto>? Citations = null,
+    Guid? ContextSnapshotId = null
 );
 
 public record DecisionSummaryDto(

--- a/src/PatchHound.Api/Services/AiRecommendationDraftService.cs
+++ b/src/PatchHound.Api/Services/AiRecommendationDraftService.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using PatchHound.Api.Models.Decisions;
 using PatchHound.Core.Common;
 using PatchHound.Core.Constants;
+using PatchHound.Core.Entities;
 using PatchHound.Core.Enums;
 using PatchHound.Core.Interfaces;
 using PatchHound.Core.Models;
@@ -51,6 +52,7 @@ public class AiRecommendationDraftService(
     public async Task<Result<AiRecommendationDraftDto>> GenerateAsync(
         Guid tenantId,
         Guid caseId,
+        Guid userId,
         CancellationToken ct)
     {
         var case_ = await dbContext.RemediationCases.AsNoTracking()
@@ -185,6 +187,22 @@ public class AiRecommendationDraftService(
             ? new CitationValidationResult([], false)
             : OperationalContextCitationValidator.Validate(parsed.Citations ?? [], context.Citations);
 
+        Guid? contextSnapshotId = null;
+        if (context is not null)
+        {
+            var hash = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(
+                    Encoding.UTF8.GetBytes(context.PackJson))).ToLowerInvariant();
+            var citationsJson = JsonSerializer.Serialize(
+                validation.Citations,
+                OperationalContextPack.SerializerOptions);
+            var snapshot = RecommendationContextSnapshot.Create(
+                tenantId, caseId, context.PackJson, hash, citationsJson, userId);
+            await dbContext.RecommendationContextSnapshots.AddAsync(snapshot, ct);
+            await dbContext.SaveChangesAsync(ct);
+            contextSnapshotId = snapshot.Id;
+        }
+
         return Result<AiRecommendationDraftDto>.Success(new AiRecommendationDraftDto(
             NormalizeMatch(parsed.RecommendedOutcome, SupportedOutcomes),
             NormalizeMatch(parsed.PriorityOverride, SupportedPriorities),
@@ -193,7 +211,8 @@ public class AiRecommendationDraftService(
             Uncited: context is not null && validation.Uncited,
             Citations: validation.Citations
                 .Select(c => new AiCitationDto(c.Key, c.EntityType, c.EntityId, c.Label, c.Fact))
-                .ToList()
+                .ToList(),
+            ContextSnapshotId: contextSnapshotId
         ));
     }
 

--- a/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
+++ b/src/PatchHound.Api/Services/RemediationDecisionQueryService.cs
@@ -786,7 +786,8 @@ public class RemediationDecisionQueryService(
             r.PriorityOverride,
             r.AnalystId,
             recommendationAnalystNames.GetValueOrDefault(r.AnalystId),
-            r.CreatedAt
+            r.CreatedAt,
+            r.ContextSnapshotId
         )).ToList();
 
         if (activeWorkflow?.RecurrenceSourceWorkflowId is Guid recurrenceSourceWorkflowId)

--- a/src/PatchHound.Core/Entities/AnalystRecommendation.cs
+++ b/src/PatchHound.Core/Entities/AnalystRecommendation.cs
@@ -13,6 +13,7 @@ public class AnalystRecommendation
     public string Rationale { get; private set; } = null!;
     public string? PriorityOverride { get; private set; }
     public Guid AnalystId { get; private set; }
+    public Guid? ContextSnapshotId { get; private set; }
     public DateTimeOffset CreatedAt { get; private set; }
 
     public RemediationCase RemediationCase { get; private set; } = null!;
@@ -27,7 +28,8 @@ public class AnalystRecommendation
         string rationale,
         Guid analystId,
         Guid? vulnerabilityId = null,
-        string? priorityOverride = null)
+        string? priorityOverride = null,
+        Guid? contextSnapshotId = null)
     {
         if (string.IsNullOrWhiteSpace(rationale))
             throw new ArgumentException("Rationale is required.");
@@ -42,6 +44,7 @@ public class AnalystRecommendation
             Rationale = rationale,
             PriorityOverride = priorityOverride,
             AnalystId = analystId,
+            ContextSnapshotId = contextSnapshotId,
             CreatedAt = DateTimeOffset.UtcNow,
         };
     }
@@ -56,7 +59,8 @@ public class AnalystRecommendation
         string rationale,
         Guid analystId,
         Guid? vulnerabilityId = null,
-        string? priorityOverride = null)
+        string? priorityOverride = null,
+        Guid? contextSnapshotId = null)
     {
         if (string.IsNullOrWhiteSpace(rationale))
             throw new ArgumentException("Rationale is required.");
@@ -66,6 +70,7 @@ public class AnalystRecommendation
         AnalystId = analystId;
         VulnerabilityId = vulnerabilityId;
         PriorityOverride = priorityOverride;
+        ContextSnapshotId = contextSnapshotId;
         CreatedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/src/PatchHound.Core/Entities/RecommendationContextSnapshot.cs
+++ b/src/PatchHound.Core/Entities/RecommendationContextSnapshot.cs
@@ -1,0 +1,47 @@
+namespace PatchHound.Core.Entities;
+
+public class RecommendationContextSnapshot
+{
+    public Guid Id { get; private set; }
+    public Guid TenantId { get; private set; }
+    public Guid RemediationCaseId { get; private set; }
+    public string ContextJson { get; private set; } = null!;
+    public string ContextHash { get; private set; } = null!;
+    public string CitationsJson { get; private set; } = "[]";
+    public Guid GeneratedBy { get; private set; }
+    public DateTimeOffset GeneratedAt { get; private set; }
+
+    private RecommendationContextSnapshot() { }
+
+    public static RecommendationContextSnapshot Create(
+        Guid tenantId,
+        Guid remediationCaseId,
+        string contextJson,
+        string contextHash,
+        string citationsJson,
+        Guid generatedBy)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId is required.", nameof(tenantId));
+        if (remediationCaseId == Guid.Empty)
+            throw new ArgumentException("RemediationCaseId is required.", nameof(remediationCaseId));
+        if (generatedBy == Guid.Empty)
+            throw new ArgumentException("GeneratedBy is required.", nameof(generatedBy));
+        if (string.IsNullOrWhiteSpace(contextJson))
+            throw new ArgumentException("ContextJson is required.", nameof(contextJson));
+        if (contextHash is { Length: > 64 })
+            throw new ArgumentException("ContextHash must be at most 64 characters.", nameof(contextHash));
+
+        return new RecommendationContextSnapshot
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            RemediationCaseId = remediationCaseId,
+            ContextJson = contextJson,
+            ContextHash = contextHash ?? string.Empty,
+            CitationsJson = string.IsNullOrWhiteSpace(citationsJson) ? "[]" : citationsJson,
+            GeneratedBy = generatedBy,
+            GeneratedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/Configurations/RecommendationContextSnapshotConfiguration.cs
+++ b/src/PatchHound.Infrastructure/Data/Configurations/RecommendationContextSnapshotConfiguration.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PatchHound.Core.Entities;
+
+namespace PatchHound.Infrastructure.Data.Configurations;
+
+public class RecommendationContextSnapshotConfiguration
+    : IEntityTypeConfiguration<RecommendationContextSnapshot>
+{
+    public void Configure(EntityTypeBuilder<RecommendationContextSnapshot> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.HasIndex(x => new { x.TenantId, x.RemediationCaseId });
+        builder.Property(x => x.ContextJson).HasColumnType("text").IsRequired();
+        builder.Property(x => x.ContextHash).HasMaxLength(64).IsRequired();
+        builder.Property(x => x.CitationsJson).HasColumnType("text").IsRequired();
+    }
+}

--- a/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
+++ b/src/PatchHound.Infrastructure/Data/PatchHoundDbContext.cs
@@ -122,6 +122,8 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
     public DbSet<ApprovedVulnerabilityRemediation> ApprovedVulnerabilityRemediations =>
         Set<ApprovedVulnerabilityRemediation>();
     public DbSet<AnalystRecommendation> AnalystRecommendations => Set<AnalystRecommendation>();
+    public DbSet<RecommendationContextSnapshot> RecommendationContextSnapshots =>
+        Set<RecommendationContextSnapshot>();
     public DbSet<PatchingTask> PatchingTasks => Set<PatchingTask>();
     public DbSet<ApprovalTask> ApprovalTasks => Set<ApprovalTask>();
     public DbSet<ApprovalTaskVisibleRole> ApprovalTaskVisibleRoles => Set<ApprovalTaskVisibleRole>();
@@ -381,6 +383,9 @@ public class PatchHoundDbContext : DbContext, IUnitOfWork
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<AnalystRecommendation>()
+            .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
+        modelBuilder
+            .Entity<RecommendationContextSnapshot>()
             .HasQueryFilter(e => IsSystemContext || AccessibleTenantIds.Contains(e.TenantId));
         modelBuilder
             .Entity<PatchingTask>()

--- a/src/PatchHound.Infrastructure/Migrations/20260604111215_AddRecommendationContextSnapshot.Designer.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260604111215_AddRecommendationContextSnapshot.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatchHound.Infrastructure.Data;
@@ -11,9 +12,11 @@ using PatchHound.Infrastructure.Data;
 namespace PatchHound.Infrastructure.Migrations
 {
     [DbContext(typeof(PatchHoundDbContext))]
-    partial class PatchHoundDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604111215_AddRecommendationContextSnapshot")]
+    partial class AddRecommendationContextSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PatchHound.Infrastructure/Migrations/20260604111215_AddRecommendationContextSnapshot.cs
+++ b/src/PatchHound.Infrastructure/Migrations/20260604111215_AddRecommendationContextSnapshot.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatchHound.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecommendationContextSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ContextSnapshotId",
+                table: "AnalystRecommendations",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "RecommendationContextSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RemediationCaseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContextJson = table.Column<string>(type: "text", nullable: false),
+                    ContextHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CitationsJson = table.Column<string>(type: "text", nullable: false),
+                    GeneratedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    GeneratedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RecommendationContextSnapshots", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecommendationContextSnapshots_TenantId_RemediationCaseId",
+                table: "RecommendationContextSnapshots",
+                columns: new[] { "TenantId", "RemediationCaseId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RecommendationContextSnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "ContextSnapshotId",
+                table: "AnalystRecommendations");
+        }
+    }
+}

--- a/src/PatchHound.Infrastructure/Services/AnalystRecommendationService.cs
+++ b/src/PatchHound.Infrastructure/Services/AnalystRecommendationService.cs
@@ -19,6 +19,7 @@ public class AnalystRecommendationService(
         Guid analystId,
         Guid? vulnerabilityId = null,
         string? priorityOverride = null,
+        Guid? contextSnapshotId = null,
         CancellationToken ct = default
     )
     {
@@ -27,6 +28,21 @@ public class AnalystRecommendationService(
             remediationCaseId,
             ct
         );
+
+        // Only link a snapshot that belongs to this same tenant + case. A forged or foreign id
+        // is ignored (the recommendation still saves, just without an audit link).
+        Guid? verifiedSnapshotId = null;
+        if (contextSnapshotId is Guid snapshotId)
+        {
+            var snapshotMatches = await dbContext.RecommendationContextSnapshots
+                .AnyAsync(snapshot =>
+                    snapshot.Id == snapshotId
+                    && snapshot.TenantId == tenantId
+                    && snapshot.RemediationCaseId == remediationCaseId,
+                    ct);
+            if (snapshotMatches)
+                verifiedSnapshotId = snapshotId;
+        }
 
         var recommendation = await dbContext.AnalystRecommendations
             .FirstOrDefaultAsync(item =>
@@ -44,7 +60,8 @@ public class AnalystRecommendationService(
                 rationale,
                 analystId,
                 vulnerabilityId,
-                priorityOverride
+                priorityOverride,
+                verifiedSnapshotId
             );
 
             await dbContext.AnalystRecommendations.AddAsync(recommendation, ct);
@@ -56,7 +73,8 @@ public class AnalystRecommendationService(
                 rationale,
                 analystId,
                 vulnerabilityId,
-                priorityOverride
+                priorityOverride,
+                verifiedSnapshotId
             );
         }
 

--- a/tests/PatchHound.Tests/Api/AiRecommendationDraftServiceTests.cs
+++ b/tests/PatchHound.Tests/Api/AiRecommendationDraftServiceTests.cs
@@ -18,6 +18,7 @@ namespace PatchHound.Tests.Api;
 public class AiRecommendationDraftServiceTests : IDisposable
 {
     private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
     private readonly ITenantContext _tenantContext;
     private readonly PatchHoundDbContext _dbContext;
 
@@ -97,7 +98,7 @@ public class AiRecommendationDraftServiceTests : IDisposable
             contextService
         );
 
-        var result = await service.GenerateAsync(_tenantId, remediationCase.Id, CancellationToken.None);
+        var result = await service.GenerateAsync(_tenantId, remediationCase.Id, _userId, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue(result.Error);
         capturedRequest.Should().NotBeNull();
@@ -138,7 +139,7 @@ public class AiRecommendationDraftServiceTests : IDisposable
             aiResolver,
             contextService);
 
-        var result = await service.GenerateAsync(_tenantId, caseId, CancellationToken.None);
+        var result = await service.GenerateAsync(_tenantId, caseId, _userId, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue(result.Error);
         await contextService.Received(1).BuildForRemediationCaseAsync(
@@ -176,7 +177,7 @@ public class AiRecommendationDraftServiceTests : IDisposable
             aiResolver,
             contextService);
 
-        var result = await service.GenerateAsync(_tenantId, caseId, CancellationToken.None);
+        var result = await service.GenerateAsync(_tenantId, caseId, _userId, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue(result.Error);
         await contextService.DidNotReceiveWithAnyArgs().BuildForRemediationCaseAsync(
@@ -214,7 +215,7 @@ public class AiRecommendationDraftServiceTests : IDisposable
             aiResolver,
             contextService);
 
-        var result = await service.GenerateAsync(_tenantId, caseId, CancellationToken.None);
+        var result = await service.GenerateAsync(_tenantId, caseId, _userId, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue(result.Error);
         result.Value.OperationalContextUsed.Should().BeTrue();
@@ -223,6 +224,84 @@ public class AiRecommendationDraftServiceTests : IDisposable
         result.Value.RecommendedOutcome.Should().Be("ApprovedForPatching");
         result.Value.PriorityOverride.Should().Be("Critical");
         result.Value.Rationale.Should().Be("Patch now.");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_persists_context_snapshot_when_grounded()
+    {
+        var caseId = await SeedSingleAssessmentCaseAsync();
+        const string packJson = "{\"contextKind\":\"RemediationCase\"}";
+
+        var provider = StubProvider(
+            _ => { },
+            """
+            {
+              "recommendedOutcome": "ApprovedForPatching",
+              "priorityOverride": "Critical",
+              "rationale": "Patch now.",
+              "citations": ["device-risk-top-1"]
+            }
+            """);
+
+        var profile = TenantAiProfileFactory.Create(_tenantId, allowOperationalContext: true);
+        var aiResolver = ResolverFor(profile);
+
+        var contextService = Substitute.For<IAiOperationalContextService>();
+        contextService
+            .BuildForRemediationCaseAsync(_tenantId, caseId, Arg.Any<AiOperationalContextOptions>(), Arg.Any<CancellationToken>())
+            .Returns(PackWithJson(packJson, "device-risk-top-1"));
+
+        var service = new AiRecommendationDraftService(
+            _dbContext,
+            new TenantAiTextGenerationService([provider], aiResolver),
+            aiResolver,
+            contextService);
+
+        var result = await service.GenerateAsync(_tenantId, caseId, _userId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Value.ContextSnapshotId.Should().NotBeNull();
+
+        var snapshot = await _dbContext.RecommendationContextSnapshots
+            .FirstOrDefaultAsync(s => s.Id == result.Value.ContextSnapshotId);
+        snapshot.Should().NotBeNull();
+        snapshot!.TenantId.Should().Be(_tenantId);
+        snapshot.RemediationCaseId.Should().Be(caseId);
+        snapshot.GeneratedBy.Should().Be(_userId);
+        snapshot.ContextJson.Should().Be(packJson);
+        snapshot.ContextHash.Should().HaveLength(64);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_does_not_persist_snapshot_when_context_disallowed()
+    {
+        var caseId = await SeedSingleAssessmentCaseAsync();
+
+        var provider = StubProvider(
+            _ => { },
+            """
+            {
+              "recommendedOutcome": "ApprovedForPatching",
+              "priorityOverride": "Critical",
+              "rationale": "Patch now."
+            }
+            """);
+
+        var profile = TenantAiProfileFactory.Create(_tenantId, allowOperationalContext: false);
+        var aiResolver = ResolverFor(profile);
+        var contextService = Substitute.For<IAiOperationalContextService>();
+
+        var service = new AiRecommendationDraftService(
+            _dbContext,
+            new TenantAiTextGenerationService([provider], aiResolver),
+            aiResolver,
+            contextService);
+
+        var result = await service.GenerateAsync(_tenantId, caseId, _userId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Value.ContextSnapshotId.Should().BeNull();
+        (await _dbContext.RecommendationContextSnapshots.AnyAsync()).Should().BeFalse();
     }
 
     private static IAiReportProvider StubProvider(Action<AiTextGenerationRequest> capture, string response)
@@ -247,10 +326,13 @@ public class AiRecommendationDraftServiceTests : IDisposable
     }
 
     private static AiOperationalContextResult PackWith(params string[] keys) =>
+        PackWithJson("{}", keys);
+
+    private static AiOperationalContextResult PackWithJson(string packJson, params string[] keys) =>
         new()
         {
             Pack = new OperationalContextPack(),
-            PackJson = "{}",
+            PackJson = packJson,
             Citations = keys
                 .Select((key, index) => new OperationalContextCitation
                 {

--- a/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
+++ b/tests/PatchHound.Tests/Api/RemediationDecisionsControllerTests.cs
@@ -90,6 +90,36 @@ public class RemediationDecisionsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task GetRecommendationContext_ReturnsSnapshotForTenant()
+    {
+        var caseId = Guid.NewGuid();
+        var snapshot = RecommendationContextSnapshot.Create(
+            _tenantId, caseId, "{\"contextKind\":\"RemediationCase\"}", "hash", "[]", _userId);
+        _dbContext.RecommendationContextSnapshots.Add(snapshot);
+        await _dbContext.SaveChangesAsync();
+
+        var controller = CreateController();
+
+        var result = await controller.GetRecommendationContext(caseId, snapshot.Id, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<RecommendationContextSnapshotDto>().Subject;
+        dto.Id.Should().Be(snapshot.Id);
+        dto.Context.ContextKind.Should().Be("RemediationCase");
+    }
+
+    [Fact]
+    public async Task GetRecommendationContext_ReturnsNotFoundForUnknownId()
+    {
+        var controller = CreateController();
+
+        var result = await controller.GetRecommendationContext(
+            Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
     public async Task CreateDecision_RejectsNumericDeadlineMode()
     {
         var caseId = await SeedActiveDecisionWorkflowAsync();

--- a/tests/PatchHound.Tests/Core/OperationalContext/RecommendationContextSnapshotTests.cs
+++ b/tests/PatchHound.Tests/Core/OperationalContext/RecommendationContextSnapshotTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using PatchHound.Core.Entities;
+using Xunit;
+
+namespace PatchHound.Tests.Core.OperationalContext;
+
+public class RecommendationContextSnapshotTests
+{
+    private static RecommendationContextSnapshot New(string hash = "abc") =>
+        RecommendationContextSnapshot.Create(
+            tenantId: Guid.NewGuid(), remediationCaseId: Guid.NewGuid(),
+            contextJson: "{\"contextKind\":\"RemediationCase\"}", contextHash: hash,
+            citationsJson: "[]", generatedBy: Guid.NewGuid());
+
+    [Fact]
+    public void Create_sets_fields_and_timestamp()
+    {
+        var s = New();
+        s.Id.Should().NotBeEmpty();
+        s.ContextJson.Should().Contain("RemediationCase");
+        s.GeneratedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Create_rejects_hash_over_64_chars()
+    {
+        var act = () => New(hash: new string('a', 65));
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void Create_rejects_empty_tenant(string tenant)
+    {
+        var act = () => RecommendationContextSnapshot.Create(
+            Guid.Parse(tenant), Guid.NewGuid(), "{}", "h", "[]", Guid.NewGuid());
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/PatchHound.Tests/Infrastructure/Services/AnalystRecommendationSnapshotLinkTests.cs
+++ b/tests/PatchHound.Tests/Infrastructure/Services/AnalystRecommendationSnapshotLinkTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using PatchHound.Core.Entities;
+using PatchHound.Core.Enums;
+using PatchHound.Core.Interfaces;
+using PatchHound.Infrastructure.Data;
+using PatchHound.Infrastructure.Services;
+using PatchHound.Tests.TestData;
+
+namespace PatchHound.Tests.Infrastructure.Services;
+
+public class AnalystRecommendationSnapshotLinkTests : IDisposable
+{
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _analystId = Guid.NewGuid();
+    private readonly PatchHoundDbContext _dbContext;
+
+    public AnalystRecommendationSnapshotLinkTests()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.CurrentTenantId.Returns(_tenantId);
+        tenantContext.AccessibleTenantIds.Returns([_tenantId]);
+        tenantContext.HasAccessToTenant(_tenantId).Returns(true);
+
+        var options = new DbContextOptionsBuilder<PatchHoundDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new PatchHoundDbContext(
+            options,
+            TestServiceProviderFactory.Create(tenantContext)
+        );
+    }
+
+    private async Task<Guid> SeedCaseAsync()
+    {
+        var product = SoftwareProduct.Create("Contoso", "Agent", null);
+        var remediationCase = RemediationCase.Create(_tenantId, product.Id);
+        await _dbContext.AddRangeAsync(product, remediationCase);
+        await _dbContext.SaveChangesAsync();
+        return remediationCase.Id;
+    }
+
+    private async Task<Guid> SeedSnapshotAsync(Guid tenantId, Guid caseId)
+    {
+        var snapshot = RecommendationContextSnapshot.Create(
+            tenantId, caseId, "{\"contextKind\":\"RemediationCase\"}", "hash", "[]", _analystId);
+        await _dbContext.RecommendationContextSnapshots.AddAsync(snapshot);
+        await _dbContext.SaveChangesAsync();
+        return snapshot.Id;
+    }
+
+    private AnalystRecommendationService Sut() =>
+        new(_dbContext, new RemediationWorkflowService(_dbContext));
+
+    [Fact]
+    public async Task Links_snapshot_belonging_to_same_tenant_and_case()
+    {
+        var caseId = await SeedCaseAsync();
+        var snapshotId = await SeedSnapshotAsync(_tenantId, caseId);
+
+        var result = await Sut().AddRecommendationForCaseAsync(
+            _tenantId, caseId, RemediationOutcome.ApprovedForPatching, "Patch now.",
+            _analystId, vulnerabilityId: null, priorityOverride: null,
+            contextSnapshotId: snapshotId, ct: CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Value.ContextSnapshotId.Should().Be(snapshotId);
+    }
+
+    [Fact]
+    public async Task Does_not_link_snapshot_from_a_different_case()
+    {
+        var caseId = await SeedCaseAsync();
+        var otherProduct = SoftwareProduct.Create("Other", "Thing", null);
+        var otherCase = RemediationCase.Create(_tenantId, otherProduct.Id);
+        await _dbContext.AddRangeAsync(otherProduct, otherCase);
+        await _dbContext.SaveChangesAsync();
+        var foreignSnapshotId = await SeedSnapshotAsync(_tenantId, otherCase.Id);
+
+        var result = await Sut().AddRecommendationForCaseAsync(
+            _tenantId, caseId, RemediationOutcome.ApprovedForPatching, "Patch now.",
+            _analystId, vulnerabilityId: null, priorityOverride: null,
+            contextSnapshotId: foreignSnapshotId, ct: CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Value.ContextSnapshotId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Does_not_link_snapshot_from_a_different_tenant()
+    {
+        var caseId = await SeedCaseAsync();
+        var foreignSnapshotId = await SeedSnapshotAsync(Guid.NewGuid(), caseId);
+
+        var result = await Sut().AddRecommendationForCaseAsync(
+            _tenantId, caseId, RemediationOutcome.ApprovedForPatching, "Patch now.",
+            _analystId, vulnerabilityId: null, priorityOverride: null,
+            contextSnapshotId: foreignSnapshotId, ct: CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Error);
+        result.Value.ContextSnapshotId.Should().BeNull();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}


### PR DESCRIPTION
## Summary

Makes AI-assisted recommendations auditable after the fact — closes the spec's acceptance criterion that "the exact context snapshot used for a generation is available to an auditor later." **Capture-at-generation, link-on-save, server-authoritative.**

- **`RecommendationContextSnapshot`** — a new tenant-scoped entity (carries `TenantId` + `RemediationCaseId`) storing the exact post-redaction context pack, its SHA-256 hash, and the model's validated citations. Written server-side when a grounded draft is generated, so it can't be tampered with by the client.
- **Link on save** — the save endpoint accepts a `contextSnapshotId` and links it to the saved `AnalystRecommendation`, but only after verifying the snapshot belongs to the **same tenant + case** (a forged/foreign id is ignored; the save still succeeds, just unlinked).
- **Audit retrieval** — `GET /api/remediation/cases/{caseId}/recommendations/context/{snapshotId}` returns the stored pack + citations, tenant-scoped, for later review. `ContextSnapshotId` is also exposed on the recommendation read DTO.
- **Frontend** — the analyst workbench carries the draft's snapshot id through to the save call.

Tenant-safe by construction: the snapshot rows carry `TenantId`, the link-verification and retrieval both filter by tenant + case, and only the already-redacted pack is persisted (no un-redacted PII). No change to the global `VulnerabilityPatchAssessment`.

## Notable fixes during build
- Found and fixed an overload-resolution bug in a test helper that was silently masking citations (a single-string `PackWith("key")` was binding to the new 2-arg `(json, keys)` overload, producing an empty pack).
- Rebuilt the branch cleanly on top of the current `main` (which had advanced ~11 PRs with API refactors) and confirmed it builds, the migration chain is consistent, and the full suite passes.

## Known follow-up (out of scope)
- Periodic cleanup of orphan snapshots from discarded drafts (unlinked rows older than the 90-day window).
- A frontend "view recorded context" panel on saved recommendations (the GET endpoint already exposes the data).

## Test Plan
- [x] Backend full suite: **993 passed, 0 failed**
- [x] `dotnet ef migrations has-pending-model-changes` clean; migration additive + reversible
- [x] Frontend: typecheck + lint clean, **92 tests passing**
- [x] Verified-link tests reject cross-tenant and cross-case snapshots
- [x] Retrieval endpoint tenant-scoped (200 for own tenant, 404 for unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)